### PR TITLE
ci: re-enable the macOS CI for unit tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,7 @@ jobs:
           - nightly
         os:
           - ubuntu-latest
-          # See issue https://github.com/revault/liana/issues/69
-          #- macOS-latest
+          - macOS-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Fixes #69 