### PR TITLE
Make daemon config optional in gui

### DIFF
--- a/gui/README.md
+++ b/gui/README.md
@@ -13,7 +13,7 @@ In addition, if you want to build the project from source, you will need:
 - [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) (On Debian/Ubuntu `apt install pkg-config`)
 
 
-## Usage
+## Common usage
 
 *For a quick guide to try out the software see [../doc/TRY.md](../doc/TRY.md).*
 
@@ -27,8 +27,12 @@ Bitcoin mainnet, but testnet signet and regtest are supported.
 If the software is started with no parameter and no data directory is detected, a Liana installer
 will be spawned that will guide you in the processing of configuring Liana.
 
-If the software is started and a reachable `lianad` is running, it will plug to it via `lianad`'s
-JSONRPC interface.
+## Connecting to an external Liana daemon
+
+By setting in the `liana-gui` configuration file the `daemon_rpc_path`
+field. The GUI will connect to the distant daemon via `lianad`'s
+JSONRPC interface. In case of failure, the GUI will display an error
+message.
 
 ### Troubleshooting
 

--- a/gui/src/app/config.rs
+++ b/gui/src/app/config.rs
@@ -5,7 +5,9 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
     /// Path to lianad configuration file.
-    pub daemon_config_path: PathBuf,
+    pub daemon_config_path: Option<PathBuf>,
+    /// Path to the lianad rpc socket.
+    pub daemon_rpc_path: Option<PathBuf>,
     /// log level, can be "info", "debug", "trace".
     pub log_level: Option<String>,
     /// Use iced debug feature if true.
@@ -18,9 +20,14 @@ pub struct Config {
 pub const DEFAULT_FILE_NAME: &str = "gui.toml";
 
 impl Config {
-    pub fn new(daemon_config_path: PathBuf, hardware_wallets: Vec<HardwareWalletConfig>) -> Self {
+    pub fn new(
+        daemon_config_path: Option<PathBuf>,
+        daemon_rpc_path: Option<PathBuf>,
+        hardware_wallets: Vec<HardwareWalletConfig>,
+    ) -> Self {
         Self {
             daemon_config_path,
+            daemon_rpc_path,
             log_level: None,
             debug: None,
             hardware_wallets,

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -175,20 +175,22 @@ impl App {
             }
         }
 
-        let mut daemon_config_file = OpenOptions::new()
-            .write(true)
-            .open(&self.config.daemon_config_path)
-            .map_err(|e| Error::Config(e.to_string()))?;
+        if let Some(path) = &self.config.daemon_config_path {
+            let mut daemon_config_file = OpenOptions::new()
+                .write(true)
+                .open(path)
+                .map_err(|e| Error::Config(e.to_string()))?;
 
-        let content =
-            toml::to_string(&self.daemon.config()).map_err(|e| Error::Config(e.to_string()))?;
+            let content =
+                toml::to_string(&self.daemon.config()).map_err(|e| Error::Config(e.to_string()))?;
 
-        daemon_config_file
-            .write_all(content.as_bytes())
-            .map_err(|e| {
-                log::warn!("failed to write to file: {:?}", e);
-                Error::Config(e.to_string())
-            })?;
+            daemon_config_file
+                .write_all(content.as_bytes())
+                .map_err(|e| {
+                    log::warn!("failed to write to file: {:?}", e);
+                    Error::Config(e.to_string())
+                })?;
+        }
 
         Ok(())
     }

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -4,6 +4,7 @@ pub mod menu;
 pub mod message;
 pub mod state;
 pub mod view;
+pub mod wallet;
 
 mod error;
 
@@ -23,7 +24,7 @@ pub use message::Message;
 use state::{CoinsPanel, CreateSpendPanel, Home, ReceivePanel, RecoveryPanel, SpendPanel, State};
 
 use crate::{
-    app::{cache::Cache, error::Error, menu::Menu},
+    app::{cache::Cache, error::Error, menu::Menu, wallet::Wallet},
     daemon::Daemon,
 };
 
@@ -32,16 +33,18 @@ pub struct App {
     state: Box<dyn State>,
     cache: Cache,
     config: Config,
+    wallet: Wallet,
     daemon: Arc<dyn Daemon + Sync + Send>,
 }
 
 impl App {
     pub fn new(
         cache: Cache,
+        wallet: Wallet,
         config: Config,
         daemon: Arc<dyn Daemon + Sync + Send>,
     ) -> (App, Command<Message>) {
-        let state: Box<dyn State> = Home::new(&cache.coins).into();
+        let state: Box<dyn State> = Home::new(wallet.clone(), &cache.coins).into();
         let cmd = state.load(daemon.clone());
         (
             Self {
@@ -50,6 +53,7 @@ impl App {
                 cache,
                 config,
                 daemon,
+                wallet,
             },
             cmd,
         )
@@ -58,31 +62,36 @@ impl App {
     fn load_state(&mut self, menu: &Menu) -> Command<Message> {
         self.state = match menu {
             menu::Menu::Settings => state::SettingsState::new(
-                self.daemon.config().clone(),
+                self.daemon.config().cloned(),
                 &self.cache,
                 self.daemon.is_external(),
             )
             .into(),
-            menu::Menu::Home => Home::new(&self.cache.coins).into(),
+            menu::Menu::Home => Home::new(self.wallet.clone(), &self.cache.coins).into(),
             menu::Menu::Coins => CoinsPanel::new(
                 &self.cache.coins,
-                self.daemon.config().main_descriptor.timelock_value(),
+                self.wallet.main_descriptor.timelock_value(),
             )
             .into(),
             menu::Menu::Recovery => RecoveryPanel::new(
+                self.wallet.clone(),
                 self.config.clone(),
                 &self.cache.coins,
-                self.daemon.config().main_descriptor.timelock_value(),
+                self.wallet.main_descriptor.timelock_value(),
                 self.cache.blockheight as u32,
             )
             .into(),
             menu::Menu::Receive => ReceivePanel::default().into(),
-            menu::Menu::Spend => SpendPanel::new(self.config.clone(), &self.cache.spend_txs).into(),
-            menu::Menu::CreateSpendTx => CreateSpendPanel::new(
+            menu::Menu::Spend => SpendPanel::new(
+                self.wallet.clone(),
                 self.config.clone(),
-                self.daemon.config().main_descriptor.clone(),
+                &self.cache.spend_txs,
+            )
+            .into(),
+            menu::Menu::CreateSpendTx => CreateSpendPanel::new(
+                self.wallet.clone(),
+                self.config.clone(),
                 &self.cache.coins,
-                self.daemon.config().main_descriptor.timelock_value(),
                 self.cache.blockheight as u32,
             )
             .into(),

--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -329,10 +329,7 @@ mod tests {
             client::{Lianad, Request},
             model::*,
         },
-        utils::{
-            mock::{fake_daemon_config, Daemon},
-            sandbox::Sandbox,
-        },
+        utils::{mock::Daemon, sandbox::Sandbox},
     };
 
     use liana::miniscript::bitcoin::Address;
@@ -352,7 +349,7 @@ mod tests {
         )]);
 
         let sandbox: Sandbox<ReceivePanel> = Sandbox::new(ReceivePanel::default());
-        let client = Arc::new(Lianad::new(daemon.run(), fake_daemon_config()));
+        let client = Arc::new(Lianad::new(daemon.run()));
         let sandbox = sandbox.load(client, &Cache::default()).await;
 
         let panel = sandbox.state();

--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -11,7 +11,7 @@ use iced::{widget::qr_code, Command, Subscription};
 use iced::{widget::Column, Element};
 use liana::miniscript::bitcoin::{Address, Amount};
 
-use super::{cache::Cache, error::Error, menu::Menu, message::Message, view};
+use super::{cache::Cache, error::Error, menu::Menu, message::Message, view, wallet::Wallet};
 
 use crate::daemon::{
     model::{remaining_sequence, Coin, HistoryTransaction},
@@ -39,6 +39,7 @@ pub trait State {
 }
 
 pub struct Home {
+    wallet: Wallet,
     balance: Amount,
     recovery_warning: Option<(Amount, usize)>,
     recovery_alert: Option<(Amount, usize)>,
@@ -49,8 +50,9 @@ pub struct Home {
 }
 
 impl Home {
-    pub fn new(coins: &[Coin]) -> Self {
+    pub fn new(wallet: Wallet, coins: &[Coin]) -> Self {
         Self {
+            wallet,
             balance: Amount::from_sat(
                 coins
                     .iter()
@@ -120,7 +122,7 @@ impl State for Home {
                     for coin in coins {
                         if coin.spend_info.is_none() && coin.block_height.is_some() {
                             self.balance += coin.amount;
-                            let timelock = daemon.config().main_descriptor.timelock_value();
+                            let timelock = self.wallet.main_descriptor.timelock_value();
                             let seq = remaining_sequence(&coin, cache.blockheight as u32, timelock);
                             if seq == 0 {
                                 recovery_alert.0 += coin.amount;

--- a/gui/src/app/wallet.rs
+++ b/gui/src/app/wallet.rs
@@ -1,0 +1,16 @@
+use liana::descriptors::MultipathDescriptor;
+
+#[derive(Clone)]
+pub struct Wallet {
+    pub name: String,
+    pub main_descriptor: MultipathDescriptor,
+}
+
+impl Wallet {
+    pub fn new(main_descriptor: MultipathDescriptor) -> Self {
+        Self {
+            name: "Liana".to_string(),
+            main_descriptor,
+        }
+    }
+}

--- a/gui/src/daemon/client/mod.rs
+++ b/gui/src/daemon/client/mod.rs
@@ -27,13 +27,12 @@ pub trait Client {
 
 #[derive(Debug, Clone)]
 pub struct Lianad<C: Client> {
-    config: Config,
     client: C,
 }
 
 impl<C: Client> Lianad<C> {
-    pub fn new(client: C, config: Config) -> Lianad<C> {
-        Lianad { client, config }
+    pub fn new(client: C) -> Lianad<C> {
+        Lianad { client }
     }
 
     /// Generic call function for RPC calls.
@@ -55,8 +54,8 @@ impl<C: Client + Debug> Daemon for Lianad<C> {
         true
     }
 
-    fn config(&self) -> &Config {
-        &self.config
+    fn config(&self) -> Option<&Config> {
+        None
     }
 
     fn stop(&mut self) -> Result<(), DaemonError> {

--- a/gui/src/daemon/embedded.rs
+++ b/gui/src/daemon/embedded.rs
@@ -51,8 +51,8 @@ impl Daemon for EmbeddedDaemon {
         Ok(())
     }
 
-    fn config(&self) -> &Config {
-        &self.config
+    fn config(&self) -> Option<&Config> {
+        Some(&self.config)
     }
 
     fn stop(&mut self) -> Result<(), DaemonError> {

--- a/gui/src/daemon/mod.rs
+++ b/gui/src/daemon/mod.rs
@@ -46,7 +46,7 @@ pub trait Daemon: Debug {
     fn load_config(&mut self, _cfg: Config) -> Result<(), DaemonError> {
         Ok(())
     }
-    fn config(&self) -> &Config;
+    fn config(&self) -> Option<&Config>;
     fn stop(&mut self) -> Result<(), DaemonError>;
     fn get_info(&self) -> Result<model::GetInfoResult, DaemonError>;
     fn get_new_address(&self) -> Result<model::GetAddressResult, DaemonError>;

--- a/gui/src/installer/mod.rs
+++ b/gui/src/installer/mod.rs
@@ -215,9 +215,10 @@ pub async fn install(ctx: Context) -> Result<PathBuf, Error> {
     gui_config_file
         .write_all(
             toml::to_string(&gui_config::Config::new(
-                daemon_config_path.canonicalize().map_err(|e| {
+                Some(daemon_config_path.canonicalize().map_err(|e| {
                     Error::Unexpected(format!("Failed to canonicalize daemon config path: {}", e))
-                })?,
+                })?),
+                None,
                 hardware_wallets,
             ))
             .unwrap()

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -312,10 +312,10 @@ pub fn cover<'a, T: 'a + Clone, C: Into<Element<'a, T>>>(
 
 async fn connect(
     socket_path: PathBuf,
-    config: Config,
+    _config: Config,
 ) -> Result<Arc<dyn Daemon + Sync + Send>, Error> {
     let client = client::jsonrpc::JsonRPCClient::new(socket_path);
-    let daemon = Lianad::new(client, config);
+    let daemon = Lianad::new(client);
 
     debug!("Searching for external daemon");
     daemon.get_info()?;

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -13,6 +13,7 @@ use liana_gui::{
         self,
         cache::Cache,
         config::{default_datadir, ConfigError},
+        wallet::Wallet,
         App,
     },
     installer::{self, Installer},
@@ -206,14 +207,16 @@ impl Application for GUI {
                 }
                 loader::Message::Synced(info, coins, spend_txs, daemon) => {
                     let cache = Cache {
-                        network: daemon.config().bitcoin_config.network,
+                        network: info.network,
                         blockheight: info.block_height,
                         coins,
                         spend_txs,
                         ..Default::default()
                     };
 
-                    let (app, command) = App::new(cache, loader.gui_config.clone(), daemon);
+                    let wallet = Wallet::new(info.descriptors.main);
+
+                    let (app, command) = App::new(cache, wallet, loader.gui_config.clone(), daemon);
                     self.state = State::App(app);
                     command.map(|msg| Message::Run(Box::new(msg)))
                 }

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -6,7 +6,7 @@ use iced::{executor, Application, Command, Element, Settings, Subscription};
 extern crate serde;
 extern crate serde_json;
 
-use liana::{config::Config as DaemonConfig, miniscript::bitcoin};
+use liana::miniscript::bitcoin;
 
 use liana_gui::{
     app::{
@@ -132,9 +132,7 @@ impl Application for GUI {
                 )
             }
             Config::Run(datadir_path, cfg) => {
-                let daemon_cfg =
-                    DaemonConfig::from_file(Some(cfg.daemon_config_path.clone())).unwrap();
-                let (loader, command) = Loader::new(datadir_path, cfg, daemon_cfg);
+                let (loader, command) = Loader::new(datadir_path, cfg);
                 (
                     Self {
                         state: State::Loader(Box::new(loader)),
@@ -177,10 +175,7 @@ impl Application for GUI {
                     path.push(network.to_string());
                     path.push(app::config::DEFAULT_FILE_NAME);
                     let cfg = app::Config::from_file(&path).unwrap();
-                    let daemon_cfg =
-                        DaemonConfig::from_file(Some(cfg.daemon_config_path.clone())).unwrap();
-                    let (loader, command) =
-                        Loader::new(Some(l.datadir_path.clone()), cfg, daemon_cfg);
+                    let (loader, command) = Loader::new(Some(l.datadir_path.clone()), cfg);
                     self.state = State::Loader(Box::new(loader));
                     command.map(|msg| Message::Load(Box::new(msg)))
                 }
@@ -189,9 +184,7 @@ impl Application for GUI {
             (State::Installer(i), Message::Install(msg)) => {
                 if let installer::Message::Exit(path) = *msg {
                     let cfg = app::Config::from_file(&path).unwrap();
-                    let daemon_cfg =
-                        DaemonConfig::from_file(Some(cfg.daemon_config_path.clone())).unwrap();
-                    let (loader, command) = Loader::new(None, cfg, daemon_cfg);
+                    let (loader, command) = Loader::new(None, cfg);
                     self.state = State::Loader(Box::new(loader));
                     command.map(|msg| Message::Load(Box::new(msg)))
                 } else {

--- a/gui/src/utils/mock.rs
+++ b/gui/src/utils/mock.rs
@@ -1,5 +1,4 @@
 use crate::daemon::{client::Client, DaemonError};
-use liana::config::Config;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{json, Value};
 use std::fmt::Debug;
@@ -75,21 +74,4 @@ impl Daemon {
             transport: Mutex::new((client_sender, client_receiver)),
         }
     }
-}
-
-pub fn fake_daemon_config() -> Config {
-    toml::from_str(
-r#"
-data_dir = "/home/edouard/code/revault/demo/liana/datadir"
-main_descriptor = "wsh(or_d(pk(tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/<0;1>/*),and_v(v:pkh(tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S/<0;1>/*),older(100))))#9sx3g3pv"
-
-[bitcoin_config]
-network = "regtest"
-poll_interval_secs = 30
-
-[bitcoind_config]
-addr = "127.0.0.1:9001"
-cookie_path = "/home/edouard/code/revault/demo/liana/regtest/bcdir1/regtest/.cookie"
-"#
-    ).unwrap()
 }


### PR DESCRIPTION
Because by making the daemon config optional,
the GUI must store the main_descriptor from
the getinfo request.

A new module wallet is introduced that
contains the main_descriptor.

close #147 