### PR TITLE
gui: store descriptor in wallet module

### DIFF
--- a/gui/src/app/wallet.rs
+++ b/gui/src/app/wallet.rs
@@ -1,0 +1,16 @@
+use liana::descriptors::MultipathDescriptor;
+
+#[derive(Clone)]
+pub struct Wallet {
+    pub name: String,
+    pub main_descriptor: MultipathDescriptor,
+}
+
+impl Wallet {
+    pub fn new(main_descriptor: MultipathDescriptor) -> Self {
+        Self {
+            name: "Liana".to_string(),
+            main_descriptor,
+        }
+    }
+}

--- a/gui/src/daemon/client/mod.rs
+++ b/gui/src/daemon/client/mod.rs
@@ -27,13 +27,12 @@ pub trait Client {
 
 #[derive(Debug, Clone)]
 pub struct Lianad<C: Client> {
-    config: Config,
     client: C,
 }
 
 impl<C: Client> Lianad<C> {
-    pub fn new(client: C, config: Config) -> Lianad<C> {
-        Lianad { client, config }
+    pub fn new(client: C) -> Lianad<C> {
+        Lianad { client }
     }
 
     /// Generic call function for RPC calls.
@@ -55,8 +54,8 @@ impl<C: Client + Debug> Daemon for Lianad<C> {
         true
     }
 
-    fn config(&self) -> &Config {
-        &self.config
+    fn config(&self) -> Option<&Config> {
+        None
     }
 
     fn stop(&mut self) -> Result<(), DaemonError> {

--- a/gui/src/daemon/embedded.rs
+++ b/gui/src/daemon/embedded.rs
@@ -51,8 +51,8 @@ impl Daemon for EmbeddedDaemon {
         Ok(())
     }
 
-    fn config(&self) -> &Config {
-        &self.config
+    fn config(&self) -> Option<&Config> {
+        Some(&self.config)
     }
 
     fn stop(&mut self) -> Result<(), DaemonError> {

--- a/gui/src/daemon/mod.rs
+++ b/gui/src/daemon/mod.rs
@@ -46,7 +46,7 @@ pub trait Daemon: Debug {
     fn load_config(&mut self, _cfg: Config) -> Result<(), DaemonError> {
         Ok(())
     }
-    fn config(&self) -> &Config;
+    fn config(&self) -> Option<&Config>;
     fn stop(&mut self) -> Result<(), DaemonError>;
     fn get_info(&self) -> Result<model::GetInfoResult, DaemonError>;
     fn get_new_address(&self) -> Result<model::GetAddressResult, DaemonError>;

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -296,10 +296,10 @@ pub fn cover<'a, T: 'a + Clone, C: Into<Element<'a, T>>>(
 
 async fn connect(
     socket_path: PathBuf,
-    config: Config,
+    _config: Config,
 ) -> Result<Arc<dyn Daemon + Sync + Send>, Error> {
     let client = client::jsonrpc::JsonRPCClient::new(socket_path);
-    let daemon = Lianad::new(client, config);
+    let daemon = Lianad::new(client);
 
     debug!("Searching for external daemon");
     daemon.get_info()?;

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -13,6 +13,7 @@ use liana_gui::{
         self,
         cache::Cache,
         config::{default_datadir, ConfigError},
+        wallet::Wallet,
         App,
     },
     installer::{self, Installer},
@@ -206,14 +207,16 @@ impl Application for GUI {
                 }
                 loader::Message::Synced(info, coins, spend_txs, daemon) => {
                     let cache = Cache {
-                        network: daemon.config().bitcoin_config.network,
+                        network: info.network,
                         blockheight: info.block_height,
                         coins,
                         spend_txs,
                         ..Default::default()
                     };
 
-                    let (app, command) = App::new(cache, loader.gui_config.clone(), daemon);
+                    let wallet = Wallet::new(info.descriptors.main);
+
+                    let (app, command) = App::new(cache, wallet, loader.gui_config.clone(), daemon);
                     self.state = State::App(app);
                     command.map(|msg| Message::Run(Box::new(msg)))
                 }

--- a/gui/src/utils/mock.rs
+++ b/gui/src/utils/mock.rs
@@ -1,5 +1,4 @@
 use crate::daemon::{client::Client, DaemonError};
-use liana::config::Config;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{json, Value};
 use std::fmt::Debug;
@@ -75,21 +74,4 @@ impl Daemon {
             transport: Mutex::new((client_sender, client_receiver)),
         }
     }
-}
-
-pub fn fake_daemon_config() -> Config {
-    toml::from_str(
-r#"
-data_dir = "/home/edouard/code/revault/demo/liana/datadir"
-main_descriptor = "wsh(or_d(pk(tpubDCbK3Ysvk8HjcF6mPyrgMu3KgLiaaP19RjKpNezd8GrbAbNg6v5BtWLaCt8FNm6QkLseopKLf5MNYQFtochDTKHdfgG6iqJ8cqnLNAwtXuP/<0;1>/*),and_v(v:pkh(tpubDDtb2WPYwEWw2WWDV7reLV348iJHw2HmhzvPysKKrJw3hYmvrd4jasyoioVPdKGQqjyaBMEvTn1HvHWDSVqQ6amyyxRZ5YjpPBBGjJ8yu8S/<0;1>/*),older(100))))#9sx3g3pv"
-
-[bitcoin_config]
-network = "regtest"
-poll_interval_secs = 30
-
-[bitcoind_config]
-addr = "127.0.0.1:9001"
-cookie_path = "/home/edouard/code/revault/demo/liana/regtest/bcdir1/regtest/.cookie"
-"#
-    ).unwrap()
 }


### PR DESCRIPTION
A new module wallet is introduced that contains the main_descriptor retrieved from `getinfo`.
It removes the requirement for the `Daemon` trait to provide the demon config in the  other components of the application.
Actually BitcoindSettings cannot be edited if the gui is connected to an external daemon, this PR just remove the display of the Bitcoind Settings section.