### PR TITLE
gui: log off ledger_transport_hid

### DIFF
--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -339,6 +339,14 @@ pub fn setup_logger(log_level: log::LevelFilter) -> Result<(), fern::InitError> 
         .level_for("iced_glow", log::LevelFilter::Off)
         .level_for("glow_glyph", log::LevelFilter::Off)
         .level_for("naga", log::LevelFilter::Off)
+        .level_for(
+            "ledger_transport_hid",
+            if log_level == log::LevelFilter::Info {
+                log::LevelFilter::Off
+            } else {
+                log_level
+            },
+        )
         .level_for("mio", log::LevelFilter::Off);
 
     dispatcher.chain(std::io::stdout()).apply()?;


### PR DESCRIPTION
ledger hid apdu exchanges were displayed in the log because of ledger_transport_hid crate.
This commit removes these log entries.