### PR TITLE
gui: reorganize imports and mod

### DIFF
--- a/gui/src/app/error.rs
+++ b/gui/src/app/error.rs
@@ -1,7 +1,6 @@
 use crate::daemon::DaemonError;
 use liana::config::ConfigError;
-use std::convert::From;
-use std::io::ErrorKind;
+use std::{convert::From, io::ErrorKind};
 
 #[derive(Debug)]
 pub enum Error {

--- a/gui/src/app/message.rs
+++ b/gui/src/app/message.rs
@@ -1,15 +1,14 @@
+use crate::{
+    app::{error::Error, view},
+    daemon::model::*,
+    hw::HardwareWallet,
+};
 use liana::{
     config::Config as DaemonConfig,
     miniscript::bitcoin::{
         util::{bip32::Fingerprint, psbt::Psbt},
         Address,
     },
-};
-
-use crate::{
-    app::{error::Error, view},
-    daemon::model::*,
-    hw::HardwareWallet,
 };
 
 #[derive(Debug)]

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -9,24 +9,17 @@ pub mod wallet;
 
 mod error;
 
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::sync::Arc;
-use std::time::Duration;
-
-use iced::{clipboard, time, Command, Element, Subscription};
-
-pub use liana::config::Config as DaemonConfig;
-
 pub use config::Config;
+pub use liana::config::Config as DaemonConfig;
 pub use message::Message;
-
-use state::{CoinsPanel, CreateSpendPanel, Home, ReceivePanel, RecoveryPanel, SpendPanel, State};
 
 use crate::{
     app::{cache::Cache, error::Error, menu::Menu, wallet::Wallet},
     daemon::Daemon,
 };
+use iced::{clipboard, time, Command, Element, Subscription};
+use state::{CoinsPanel, CreateSpendPanel, Home, ReceivePanel, RecoveryPanel, SpendPanel, State};
+use std::{fs::OpenOptions, io::Write, sync::Arc, time::Duration};
 
 pub struct App {
     state: Box<dyn State>,

--- a/gui/src/app/settings.rs
+++ b/gui/src/app/settings.rs
@@ -1,10 +1,7 @@
-use std::collections::HashMap;
-use std::path::Path;
-
+use crate::hw::HardwareWalletConfig;
 use liana::miniscript::bitcoin::util::bip32::Fingerprint;
 use serde::{Deserialize, Serialize};
-
-use crate::hw::HardwareWalletConfig;
+use std::{collections::HashMap, path::Path};
 
 ///! Settings is the module to handle the GUI settings file.
 ///! The settings file is used by the GUI to store useful information.

--- a/gui/src/app/state/coins.rs
+++ b/gui/src/app/state/coins.rs
@@ -1,12 +1,10 @@
-use std::cmp::Ordering;
-use std::sync::Arc;
-
-use iced::{Command, Element};
-
 use crate::{
     app::{cache::Cache, error::Error, menu::Menu, message::Message, state::State, view},
     daemon::{model::Coin, Daemon},
 };
+use iced::{Command, Element};
+use std::cmp::Ordering;
+use std::sync::Arc;
 
 pub struct CoinsPanel {
     coins: Vec<Coin>,

--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -3,24 +3,22 @@ mod recovery;
 mod settings;
 mod spend;
 
-use std::convert::TryInto;
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use iced::{widget::qr_code, Command, Subscription};
-use iced::{widget::Column, Element};
-use liana::miniscript::bitcoin::{Address, Amount};
-
-use super::{cache::Cache, error::Error, menu::Menu, message::Message, view, wallet::Wallet};
-
-use crate::daemon::{
-    model::{remaining_sequence, Coin, HistoryTransaction},
-    Daemon,
-};
 pub use coins::CoinsPanel;
 pub use recovery::RecoveryPanel;
 pub use settings::SettingsState;
 pub use spend::{CreateSpendPanel, SpendPanel};
+
+use super::{cache::Cache, error::Error, menu::Menu, message::Message, view, wallet::Wallet};
+use crate::daemon::{
+    model::{remaining_sequence, Coin, HistoryTransaction},
+    Daemon,
+};
+use iced::{widget::qr_code, Command, Subscription};
+use iced::{widget::Column, Element};
+use liana::miniscript::bitcoin::{Address, Amount};
+use std::convert::TryInto;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub trait State {
     fn view<'a>(&'a self, cache: &'a Cache) -> Element<'a, view::Message>;

--- a/gui/src/app/state/recovery.rs
+++ b/gui/src/app/state/recovery.rs
@@ -1,8 +1,3 @@
-use std::str::FromStr;
-use std::sync::Arc;
-
-use iced::{Command, Element};
-
 use crate::{
     app::{
         cache::Cache,
@@ -20,8 +15,9 @@ use crate::{
     },
     ui::component::form,
 };
-
+use iced::{Command, Element};
 use liana::miniscript::bitcoin::{Address, Amount, Network};
+use std::{str::FromStr, sync::Arc};
 
 pub struct RecoveryPanel {
     wallet: Arc<Wallet>,

--- a/gui/src/app/state/settings.rs
+++ b/gui/src/app/state/settings.rs
@@ -1,19 +1,12 @@
-use std::convert::From;
-use std::net::SocketAddr;
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::sync::Arc;
-
-use chrono::prelude::*;
-use iced::{Command, Element};
-
-use liana::config::{BitcoinConfig, BitcoindConfig, Config};
-
 use crate::{
     app::{cache::Cache, error::Error, message::Message, state::State, view},
     daemon::Daemon,
     ui::component::form,
 };
+use chrono::prelude::*;
+use iced::{Command, Element};
+use liana::config::{BitcoinConfig, BitcoindConfig, Config};
+use std::{convert::From, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
 
 trait Setting: std::fmt::Debug {
     fn edited(&mut self, success: bool);

--- a/gui/src/app/state/spend/detail.rs
+++ b/gui/src/app/state/spend/detail.rs
@@ -1,14 +1,3 @@
-use std::sync::Arc;
-
-use iced::{Command, Element};
-use liana::{
-    descriptors::LianaDescInfo,
-    miniscript::bitcoin::{
-        consensus,
-        util::{bip32::Fingerprint, psbt::Psbt},
-    },
-};
-
 use crate::{
     app::{
         cache::Cache, error::Error, message::Message, view, view::spend::detail, wallet::Wallet,
@@ -20,6 +9,15 @@ use crate::{
     hw::{list_hardware_wallets, HardwareWallet},
     ui::component::{form, modal},
 };
+use iced::{Command, Element};
+use liana::{
+    descriptors::LianaDescInfo,
+    miniscript::bitcoin::{
+        consensus,
+        util::{bip32::Fingerprint, psbt::Psbt},
+    },
+};
+use std::sync::Arc;
 
 trait Action {
     fn warning(&self) -> Option<&Error> {

--- a/gui/src/app/state/spend/mod.rs
+++ b/gui/src/app/state/spend/mod.rs
@@ -1,10 +1,5 @@
 pub mod detail;
 mod step;
-use std::sync::Arc;
-
-use iced::{Command, Element};
-
-use liana::miniscript::bitcoin::{consensus, util::psbt::Psbt};
 
 use super::{redirect, State};
 use crate::{
@@ -15,6 +10,9 @@ use crate::{
     },
     ui::component::{form, modal},
 };
+use iced::{Command, Element};
+use liana::miniscript::bitcoin::{consensus, util::psbt::Psbt};
+use std::sync::Arc;
 
 pub struct SpendPanel {
     wallet: Arc<Wallet>,

--- a/gui/src/app/state/spend/step.rs
+++ b/gui/src/app/state/spend/step.rs
@@ -1,15 +1,3 @@
-use std::collections::HashMap;
-use std::str::FromStr;
-use std::sync::Arc;
-
-use iced::{Command, Element};
-use liana::{
-    descriptors::MultipathDescriptor,
-    miniscript::bitcoin::{
-        self, util::psbt::Psbt, Address, Amount, Denomination, Network, OutPoint,
-    },
-};
-
 use crate::{
     app::{
         cache::Cache, error::Error, message::Message, state::spend::detail, view, wallet::Wallet,
@@ -20,6 +8,14 @@ use crate::{
     },
     ui::component::form,
 };
+use iced::{Command, Element};
+use liana::{
+    descriptors::MultipathDescriptor,
+    miniscript::bitcoin::{
+        self, util::psbt::Psbt, Address, Amount, Denomination, Network, OutPoint,
+    },
+};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 /// See: https://github.com/wizardsardine/liana/blob/master/src/commands/mod.rs#L32
 const DUST_OUTPUT_SATS: u64 = 5_000;

--- a/gui/src/app/view/coins.rs
+++ b/gui/src/app/view/coins.rs
@@ -1,8 +1,3 @@
-use iced::{
-    widget::{Button, Column, Container, Row},
-    Alignment, Element, Length,
-};
-
 use crate::{
     app::{
         cache::Cache,
@@ -15,6 +10,10 @@ use crate::{
         icon,
         util::Collection,
     },
+};
+use iced::{
+    widget::{Button, Column, Container, Row},
+    Alignment, Element, Length,
 };
 
 pub fn coins_view<'a>(

--- a/gui/src/app/view/home.rs
+++ b/gui/src/app/view/home.rs
@@ -1,19 +1,9 @@
-use chrono::NaiveDateTime;
-
-use iced::{
-    alignment,
-    widget::{Button, Column, Container, Row},
-    Alignment, Element, Length,
-};
-
 use crate::ui::{
     color,
     component::{badge, button::Style, card, text::*},
     icon,
     util::Collection,
 };
-use liana::miniscript::bitcoin;
-
 use crate::{
     app::{
         cache::Cache,
@@ -21,6 +11,13 @@ use crate::{
     },
     daemon::model::HistoryTransaction,
 };
+use chrono::NaiveDateTime;
+use iced::{
+    alignment,
+    widget::{Button, Column, Container, Row},
+    Alignment, Element, Length,
+};
+use liana::miniscript::bitcoin;
 
 pub const HISTORY_EVENT_PAGE_SIZE: u64 = 20;
 

--- a/gui/src/app/view/hw.rs
+++ b/gui/src/app/view/hw.rs
@@ -1,8 +1,3 @@
-use iced::{
-    widget::{Button, Column, Container, Row},
-    Alignment, Element, Length,
-};
-
 use crate::{
     app::view::message::*,
     hw::HardwareWallet,
@@ -15,6 +10,10 @@ use crate::{
         icon,
         util::Collection,
     },
+};
+use iced::{
+    widget::{Button, Column, Container, Row},
+    Alignment, Element, Length,
 };
 
 pub fn hw_list_view<'a>(

--- a/gui/src/app/view/mod.rs
+++ b/gui/src/app/view/mod.rs
@@ -1,7 +1,3 @@
-mod message;
-mod util;
-mod warning;
-
 pub mod coins;
 pub mod home;
 pub mod hw;
@@ -10,21 +6,25 @@ pub mod recovery;
 pub mod settings;
 pub mod spend;
 
-pub use message::*;
-use warning::warn;
+mod message;
+mod util;
+mod warning;
 
+pub use message::*;
+
+use crate::{
+    app::{cache::Cache, error::Error, menu::Menu},
+    ui::{
+        component::{badge, button, container, separation, text::*},
+        icon::{coin_icon, cross_icon, home_icon, receive_icon, send_icon, settings_icon},
+        util::Collection,
+    },
+};
 use iced::{
     widget::{self, scrollable, Button, Column, Container, Row},
     Element, Length,
 };
-
-use crate::ui::{
-    component::{badge, button, container, separation, text::*},
-    icon::{coin_icon, cross_icon, home_icon, receive_icon, send_icon, settings_icon},
-    util::Collection,
-};
-
-use crate::app::{cache::Cache, error::Error, menu::Menu};
+use warning::warn;
 
 pub fn sidebar<'a>(menu: &Menu, cache: &'a Cache) -> widget::Container<'a, Message> {
     let home_button = if *menu == Menu::Home {

--- a/gui/src/app/view/receive.rs
+++ b/gui/src/app/view/receive.rs
@@ -1,3 +1,8 @@
+use super::message::Message;
+use crate::ui::{
+    component::{button, card, text::*},
+    icon,
+};
 use iced::{
     widget::{
         qr_code::{self, QRCode},
@@ -5,15 +10,7 @@ use iced::{
     },
     Alignment, Element,
 };
-
 use liana::miniscript::bitcoin;
-
-use crate::ui::{
-    component::{button, card, text::*},
-    icon,
-};
-
-use super::message::Message;
 
 pub fn receive<'a>(address: &'a bitcoin::Address, qr: &'a qr_code::State) -> Element<'a, Message> {
     card::simple(

--- a/gui/src/app/view/recovery.rs
+++ b/gui/src/app/view/recovery.rs
@@ -1,10 +1,3 @@
-use iced::{
-    widget::{Column, Container, Row, Space},
-    Alignment, Element, Length,
-};
-
-use liana::miniscript::bitcoin::Amount;
-
 use crate::{
     app::view::message::{CreateSpendMessage, Message},
     ui::{
@@ -13,6 +6,11 @@ use crate::{
         util::Collection,
     },
 };
+use iced::{
+    widget::{Column, Container, Row, Space},
+    Alignment, Element, Length,
+};
+use liana::miniscript::bitcoin::Amount;
 
 #[allow(clippy::too_many_arguments)]
 pub fn recovery<'a>(

--- a/gui/src/app/view/settings.rs
+++ b/gui/src/app/view/settings.rs
@@ -1,18 +1,7 @@
-use std::str::FromStr;
-
-use iced::{
-    alignment,
-    widget::{self, Column, Container, ProgressBar, Row, Space},
-    Alignment, Element, Length,
-};
-
-use liana::miniscript::bitcoin;
-
 use super::{
     dashboard,
     message::{Message, SettingsMessage},
 };
-
 use crate::{
     app::{cache::Cache, error::Error, menu::Menu},
     ui::{
@@ -22,6 +11,13 @@ use crate::{
         util::Collection,
     },
 };
+use iced::{
+    alignment,
+    widget::{self, Column, Container, ProgressBar, Row, Space},
+    Alignment, Element, Length,
+};
+use liana::miniscript::bitcoin;
+use std::str::FromStr;
 
 pub fn list<'a>(
     cache: &'a Cache,

--- a/gui/src/app/view/spend/detail.rs
+++ b/gui/src/app/view/spend/detail.rs
@@ -1,15 +1,3 @@
-use std::collections::HashMap;
-
-use iced::{
-    widget::{scrollable, tooltip, Button, Column, Container, Row, Scrollable, Space},
-    Alignment, Element, Length,
-};
-
-use liana::{
-    descriptors::{LianaDescInfo, PathInfo, PathSpendInfo},
-    miniscript::bitcoin::{util::bip32::Fingerprint, Address, Amount, Network, Transaction},
-};
-
 use crate::{
     app::{
         error::Error,
@@ -29,6 +17,15 @@ use crate::{
         util::Collection,
     },
 };
+use iced::{
+    widget::{scrollable, tooltip, Button, Column, Container, Row, Scrollable, Space},
+    Alignment, Element, Length,
+};
+use liana::{
+    descriptors::{LianaDescInfo, PathInfo, PathSpendInfo},
+    miniscript::bitcoin::{util::bip32::Fingerprint, Address, Amount, Network, Transaction},
+};
+use std::collections::HashMap;
 
 pub fn spend_view<'a>(
     tx: &'a SpendTx,

--- a/gui/src/app/view/spend/mod.rs
+++ b/gui/src/app/view/spend/mod.rs
@@ -1,11 +1,6 @@
 pub mod detail;
 pub mod step;
 
-use iced::{
-    widget::{Button, Column, Container, Row, Space},
-    Alignment, Element, Length,
-};
-
 use crate::{
     app::{error::Error, menu::Menu, view::util::*},
     daemon::model::{SpendStatus, SpendTx},
@@ -15,6 +10,10 @@ use crate::{
         icon,
         util::Collection,
     },
+};
+use iced::{
+    widget::{Button, Column, Container, Row, Space},
+    Alignment, Element, Length,
 };
 
 use super::{message::*, warning::warn};

--- a/gui/src/app/view/spend/step.rs
+++ b/gui/src/app/view/spend/step.rs
@@ -1,10 +1,3 @@
-use iced::{
-    widget::{self, Button, Column, Container, Row},
-    Alignment, Element, Length,
-};
-
-use liana::miniscript::bitcoin::Amount;
-
 use crate::{
     app::{
         cache::Cache,
@@ -22,6 +15,11 @@ use crate::{
         util::Collection,
     },
 };
+use iced::{
+    widget::{self, Button, Column, Container, Row},
+    Alignment, Element, Length,
+};
+use liana::miniscript::bitcoin::Amount;
 
 pub fn choose_recipients_view<'a>(
     balance_available: &'a Amount,

--- a/gui/src/app/view/util.rs
+++ b/gui/src/app/view/util.rs
@@ -1,7 +1,6 @@
+use crate::ui::{color, component::text::*, util::Collection};
 use iced::{widget::Row, Element};
 use liana::miniscript::bitcoin::Amount;
-
-use crate::ui::{color, component::text::*, util::Collection};
 
 pub fn amount<'a, T: 'a>(a: &Amount) -> impl Into<Element<'a, T>> {
     amount_with_size(a, TEXT_REGULAR_SIZE)

--- a/gui/src/app/view/warning.rs
+++ b/gui/src/app/view/warning.rs
@@ -1,15 +1,13 @@
-use std::convert::From;
-
-use iced::{
-    widget::{self, Column, Container},
-    Length,
-};
-
 use crate::{
     app::error::Error,
     daemon::{client::error::RpcErrorCode, DaemonError},
     ui::component::notification,
 };
+use iced::{
+    widget::{self, Column, Container},
+    Length,
+};
+use std::convert::From;
 
 /// Simple warning message displayed to non technical user.
 pub struct WarningMessage(String);

--- a/gui/src/app/wallet.rs
+++ b/gui/src/app/wallet.rs
@@ -1,9 +1,6 @@
-use std::collections::HashMap;
-
 use crate::hw::HardwareWalletConfig;
-
-use liana::descriptors::MultipathDescriptor;
-use liana::miniscript::bitcoin::util::bip32::Fingerprint;
+use liana::{descriptors::MultipathDescriptor, miniscript::bitcoin::util::bip32::Fingerprint};
+use std::collections::HashMap;
 
 pub const DEFAULT_WALLET_NAME: &str = "Liana";
 

--- a/gui/src/daemon/client/error.rs
+++ b/gui/src/daemon/client/error.rs
@@ -17,10 +17,8 @@
 //! Some useful methods for creating Error objects
 //!
 
-use std::io;
-use std::{error, fmt};
-
 use serde::{Deserialize, Serialize};
+use std::{error, fmt, io};
 
 #[allow(dead_code)]
 #[derive(Debug)]

--- a/gui/src/daemon/client/jsonrpc.rs
+++ b/gui/src/daemon/client/jsonrpc.rs
@@ -21,17 +21,16 @@
 #[cfg(not(windows))]
 use std::os::unix::net::UnixStream;
 
-use std::fmt::Debug;
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::time::Duration;
-use std::{error, fmt, io};
-
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
-use serde_json::Deserializer;
-
 use log::debug;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Deserializer;
+use std::{
+    error,
+    fmt::{self, Debug},
+    io::{self, Write},
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 /// A handle to a remote JSONRPC server
 #[derive(Debug, Clone)]

--- a/gui/src/daemon/client/mod.rs
+++ b/gui/src/daemon/client/mod.rs
@@ -1,20 +1,15 @@
-use std::collections::HashMap;
-use std::fmt::Debug;
-
-use log::{error, info};
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-
 pub mod error;
 pub mod jsonrpc;
 
+use super::{model::*, Daemon, DaemonError};
 use liana::{
     config::Config,
     miniscript::bitcoin::{consensus, util::psbt::Psbt, Address, OutPoint, Txid},
 };
-
-use super::{model::*, Daemon, DaemonError};
+use log::{error, info};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::json;
+use std::{collections::HashMap, fmt::Debug};
 
 pub trait Client {
     type Error: Into<DaemonError> + Debug;

--- a/gui/src/daemon/embedded.rs
+++ b/gui/src/daemon/embedded.rs
@@ -1,12 +1,10 @@
-use std::collections::HashMap;
-use std::sync::RwLock;
-
 use super::{model::*, Daemon, DaemonError};
 use liana::{
     config::Config,
     miniscript::bitcoin::{util::psbt::Psbt, Address, OutPoint, Txid},
     DaemonHandle,
 };
+use std::{collections::HashMap, sync::RwLock};
 
 pub struct EmbeddedDaemon {
     config: Config,

--- a/gui/src/daemon/mod.rs
+++ b/gui/src/daemon/mod.rs
@@ -2,15 +2,12 @@ pub mod client;
 pub mod embedded;
 pub mod model;
 
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::io::ErrorKind;
-
 use liana::{
     config::Config,
     miniscript::bitcoin::{util::psbt::Psbt, Address, OutPoint, Txid},
     StartupError,
 };
+use std::{collections::HashMap, fmt::Debug, io::ErrorKind};
 
 #[derive(Debug)]
 pub enum DaemonError {

--- a/gui/src/hw.rs
+++ b/gui/src/hw.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use async_hwi::{ledger, specter, DeviceKind, Error as HWIError, HWI};
 use liana::miniscript::bitcoin::{
     hashes::hex::{FromHex, ToHex},
@@ -7,6 +5,7 @@ use liana::miniscript::bitcoin::{
 };
 use log::debug;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct HardwareWallet {

--- a/gui/src/installer/config.rs
+++ b/gui/src/installer/config.rs
@@ -1,8 +1,6 @@
-use std::convert::TryFrom;
-
-use liana::config::Config as LianaConfig;
-
 use super::Context;
+use liana::config::Config as LianaConfig;
+use std::convert::TryFrom;
 
 pub const DEFAULT_FILE_NAME: &str = "daemon.toml";
 

--- a/gui/src/installer/context.rs
+++ b/gui/src/installer/context.rs
@@ -1,6 +1,3 @@
-use std::path::PathBuf;
-use std::time::Duration;
-
 use crate::{
     app::{
         settings::{KeySetting, Settings, WalletSetting},
@@ -15,6 +12,7 @@ use liana::{
     descriptors::MultipathDescriptor,
     miniscript::bitcoin,
 };
+use std::{path::PathBuf, time::Duration};
 
 #[derive(Clone)]
 pub struct Context {

--- a/gui/src/installer/message.rs
+++ b/gui/src/installer/message.rs
@@ -1,11 +1,10 @@
+use super::Error;
+use crate::hw::HardwareWallet;
 use liana::miniscript::{
     bitcoin::{util::bip32::Fingerprint, Network},
     DescriptorPublicKey,
 };
 use std::path::PathBuf;
-
-use super::Error;
-use crate::hw::HardwareWallet;
 
 #[derive(Debug, Clone)]
 pub enum Message {

--- a/gui/src/installer/mod.rs
+++ b/gui/src/installer/mod.rs
@@ -4,16 +4,13 @@ mod prompt;
 mod step;
 mod view;
 
-use iced::{clipboard, Command, Element, Subscription};
-use liana::miniscript::bitcoin;
-
-use context::Context;
-use std::io::Write;
-use std::path::PathBuf;
+pub use message::Message;
 
 use crate::app::{config as gui_config, settings as gui_settings};
-
-pub use message::Message;
+use context::Context;
+use iced::{clipboard, Command, Element, Subscription};
+use liana::miniscript::bitcoin;
+use std::{io::Write, path::PathBuf};
 use step::{
     BackupDescriptor, DefineBitcoind, DefineDescriptor, Final, ImportDescriptor, ParticipateXpub,
     RegisterDescriptor, Step, Welcome,

--- a/gui/src/installer/step/descriptor.rs
+++ b/gui/src/installer/step/descriptor.rs
@@ -1,7 +1,13 @@
-use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
-use std::str::FromStr;
-
+use crate::{
+    app::settings::KeySetting,
+    hw::{list_hardware_wallets, HardwareWallet},
+    installer::{
+        message::{self, Message},
+        step::{Context, Step},
+        view, Error,
+    },
+    ui::component::{form, modal::Modal},
+};
 use iced::{Command, Element};
 use liana::{
     descriptors::{LianaDescKeys, MultipathDescriptor},
@@ -13,16 +19,10 @@ use liana::{
         descriptor::{DerivPaths, DescriptorMultiXKey, DescriptorPublicKey, Wildcard},
     },
 };
-
-use crate::{
-    app::settings::KeySetting,
-    hw::{list_hardware_wallets, HardwareWallet},
-    installer::{
-        message::{self, Message},
-        step::{Context, Step},
-        view, Error,
-    },
-    ui::component::{form, modal::Modal},
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    str::FromStr,
 };
 
 pub trait DescriptorKeyModal {

--- a/gui/src/installer/step/mod.rs
+++ b/gui/src/installer/step/mod.rs
@@ -1,21 +1,20 @@
 mod descriptor;
+
 pub use descriptor::{
     BackupDescriptor, DefineDescriptor, ImportDescriptor, ParticipateXpub, RegisterDescriptor,
 };
 
-use std::path::PathBuf;
-use std::str::FromStr;
-
+use crate::{
+    installer::{
+        context::Context,
+        message::{self, Message},
+        view,
+    },
+    ui::component::form,
+};
 use iced::{Command, Element};
 use liana::{config::BitcoindConfig, miniscript::bitcoin};
-
-use crate::ui::component::form;
-
-use crate::installer::{
-    context::Context,
-    message::{self, Message},
-    view,
-};
+use std::{path::PathBuf, str::FromStr};
 
 pub trait Step {
     fn update(&mut self, _message: Message) -> Command<Message> {

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -1,10 +1,3 @@
-use iced::widget::{
-    scrollable::Properties, Button, Checkbox, Column, Container, PickList, Row, Scrollable, Space,
-};
-use iced::{alignment, Alignment, Element, Length};
-
-use liana::miniscript::bitcoin;
-
 use crate::{
     hw::HardwareWallet,
     installer::{
@@ -23,6 +16,15 @@ use crate::{
         util::Collection,
     },
 };
+use iced::{
+    alignment,
+    widget::{
+        scrollable::Properties, Button, Checkbox, Column, Container, PickList, Row, Scrollable,
+        Space,
+    },
+    Alignment, Element, Length,
+};
+use liana::miniscript::bitcoin;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Network {

--- a/gui/src/launcher.rs
+++ b/gui/src/launcher.rs
@@ -1,16 +1,13 @@
-use std::path::PathBuf;
-
-use iced::{
-    widget::{Button, Column, Container, Row},
-    Alignment, Element, Length, Subscription,
-};
-
-use liana::miniscript::bitcoin::Network;
-
 use crate::ui::{
     component::{badge, button, text::*},
     icon,
 };
+use iced::{
+    widget::{Button, Column, Container, Row},
+    Alignment, Element, Length, Subscription,
+};
+use liana::miniscript::bitcoin::Network;
+use std::path::PathBuf;
 
 pub struct Launcher {
     choices: Vec<Network>,

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -1,21 +1,3 @@
-use std::convert::From;
-use std::io::ErrorKind;
-use std::path::PathBuf;
-use std::sync::Arc;
-
-use iced::{
-    widget::{Column, Container, ProgressBar, Row},
-    Element,
-};
-use iced::{Alignment, Command, Length, Subscription};
-use log::{debug, info};
-
-use liana::{
-    config::{Config, ConfigError},
-    miniscript::bitcoin,
-    StartupError,
-};
-
 use crate::{
     app::{
         cache::Cache,
@@ -30,6 +12,17 @@ use crate::{
         util::Collection,
     },
 };
+use iced::{
+    widget::{Column, Container, ProgressBar, Row},
+    Alignment, Command, Element, Length, Subscription,
+};
+use liana::{
+    config::{Config, ConfigError},
+    miniscript::bitcoin,
+    StartupError,
+};
+use log::{debug, info};
+use std::{convert::From, io::ErrorKind, path::PathBuf, sync::Arc};
 
 type Lianad = client::Lianad<client::jsonrpc::JsonRPCClient>;
 

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -1,13 +1,10 @@
 #![windows_subsystem = "windows"]
 
-use std::{error::Error, path::PathBuf, str::FromStr};
-
 use iced::{executor, Application, Command, Element, Settings, Subscription};
+use std::{error::Error, path::PathBuf, str::FromStr};
 extern crate serde;
 extern crate serde_json;
-
 use liana::{config::Config as DaemonConfig, miniscript::bitcoin};
-
 use liana_gui::{
     app::{
         self,

--- a/gui/src/ui/component/badge.rs
+++ b/gui/src/ui/component/badge.rs
@@ -1,9 +1,8 @@
+use crate::ui::{color, icon};
 use iced::{
     widget::{self, Container},
     Element, Length,
 };
-
-use crate::ui::{color, icon};
 
 pub enum Style {
     Standard,

--- a/gui/src/ui/component/button.rs
+++ b/gui/src/ui/component/button.rs
@@ -1,8 +1,9 @@
-use iced::widget::{button, container, Container, Row, Text};
-use iced::{Alignment, Color, Length, Vector};
-
 use super::text::text;
 use crate::ui::color;
+use iced::{
+    widget::{button, container, Container, Row, Text},
+    Alignment, Color, Length, Vector,
+};
 
 pub fn alert<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) -> button::Button<'a, T> {
     button::Button::new(content(icon, t)).style(Style::Destructive.into())

--- a/gui/src/ui/component/card.rs
+++ b/gui/src/ui/component/card.rs
@@ -1,9 +1,8 @@
+use crate::ui::{color, component::text::text, icon};
 use iced::{
     widget::{self, Container, Row, Tooltip},
     Element,
 };
-
-use crate::ui::{color, component::text::text, icon};
 
 pub fn simple<'a, T: 'a, C: Into<Element<'a, T>>>(content: C) -> widget::Container<'a, T> {
     Container::new(content).padding(15).style(SimpleCardStyle)

--- a/gui/src/ui/component/form.rs
+++ b/gui/src/ui/component/form.rs
@@ -1,3 +1,4 @@
+use crate::ui::{color, component::text::*, util::Collection};
 use iced::{
     widget::{
         text_input::{Appearance, StyleSheet, TextInput},
@@ -5,8 +6,6 @@ use iced::{
     },
     Element, Length,
 };
-
-use crate::ui::{color, component::text::*, util::Collection};
 
 #[derive(Debug, Clone)]
 pub struct Value<T> {

--- a/gui/src/ui/component/mod.rs
+++ b/gui/src/ui/component/mod.rs
@@ -11,10 +11,11 @@ pub mod tooltip;
 
 pub use tooltip::tooltip;
 
-use iced::widget::{Column, Container, Text};
-use iced::Length;
-
 use crate::ui::color;
+use iced::{
+    widget::{Column, Container, Text},
+    Length,
+};
 
 pub fn separation<'a, T: 'a>() -> Container<'a, T> {
     Container::new(Column::new().push(Text::new(" ")))

--- a/gui/src/ui/component/modal.rs
+++ b/gui/src/ui/component/modal.rs
@@ -1,9 +1,9 @@
 /// modal widget from https://github.com/iced-rs/iced/blob/master/examples/modal/
-use iced_native::alignment::Alignment;
-use iced_native::widget::{self, Tree};
 use iced_native::{
-    event, layout, mouse, overlay, renderer, Clipboard, Color, Element, Event, Layout, Length,
-    Point, Rectangle, Shell, Size, Widget,
+    alignment::Alignment,
+    event, layout, mouse, overlay, renderer,
+    widget::{self, Tree},
+    Clipboard, Color, Element, Event, Layout, Length, Point, Rectangle, Shell, Size, Widget,
 };
 
 /// A widget that centers a modal element over some base element

--- a/gui/src/utils/mock.rs
+++ b/gui/src/utils/mock.rs
@@ -1,13 +1,14 @@
 use crate::daemon::{client::Client, DaemonError};
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{json, Value};
-use std::fmt::Debug;
-use std::sync::{
-    mpsc::{channel, Receiver, Sender},
-    Mutex,
+use std::{
+    fmt::Debug,
+    sync::{
+        mpsc::{channel, Receiver, Sender},
+        Mutex,
+    },
+    thread,
 };
-use std::thread;
-
 type TransportReceiver = Receiver<Result<Value, DaemonError>>;
 
 #[derive(Debug)]

--- a/gui/src/utils/sandbox.rs
+++ b/gui/src/utils/sandbox.rs
@@ -1,11 +1,9 @@
-use std::sync::Arc;
-
-use iced_native::command::Action;
-
 use crate::{
     app::{cache::Cache, message::Message, state::State},
     daemon::Daemon,
 };
+use iced_native::command::Action;
+use std::sync::Arc;
 
 pub struct Sandbox<S: State> {
     state: S,


### PR DESCRIPTION
To make it easy to read, and to code, I followed theses rules :
 - Start with modules, then import crates
 - Start with public then go with private
 - No empty lines, except between the previous groups
 - Group imports when possible
 
Rustfmt will order each group of code alphabetically, prioritizing rust specific keywords in imports (ex: use super::, use crate::)

Example:

```
pub mod home;
pub mod settings;

mod message;
mod util;

pub use message::*;

use crate::{
    app::{cache::Cache, error::Error, menu::Menu, wallet::Wallet},
    daemon::Daemon,
};
use iced::{
    widget::{self, scrollable, Button, Column, Container, Row},
    Element, Length,
};
```