### PR TITLE
Handle unconfirmed deposits that were replaced

### DIFF
--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -964,6 +964,22 @@ impl BitcoinD {
             |h| self.get_block_stats(h),
         )
     }
+
+    /// Whether this transaction is in the mempool.
+    pub fn is_in_mempool(&self, txid: &bitcoin::Txid) -> bool {
+        match self
+            .make_fallible_node_request("getmempoolentry", &params!(Json::String(txid.to_string())))
+        {
+            Ok(_) => true,
+            Err(BitcoindError::Server(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+                code: -5,
+                ..
+            }))) => false,
+            Err(e) => {
+                panic!("Unexpected error returned by bitcoind {}", e);
+            }
+        }
+    }
 }
 
 /// An entry in the 'listdescriptors' result.

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -89,6 +89,9 @@ pub trait DatabaseConnection {
     /// Store new UTxOs. Coins must not already be in database.
     fn new_unspent_coins(&mut self, coins: &[Coin]);
 
+    /// Remove some UTxOs from the database.
+    fn remove_coins(&mut self, coins: &[bitcoin::OutPoint]);
+
     /// Mark a set of coins as being confirmed at a specified height and block time.
     fn confirm_coins(&mut self, outpoints: &[(bitcoin::OutPoint, i32, u32)]);
 
@@ -194,6 +197,10 @@ impl DatabaseConnection for SqliteConn {
 
     fn new_unspent_coins<'a>(&mut self, coins: &[Coin]) {
         self.new_unspent_coins(coins)
+    }
+
+    fn remove_coins(&mut self, outpoints: &[bitcoin::OutPoint]) {
+        self.remove_coins(outpoints)
     }
 
     fn confirm_coins<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, i32, u32)]) {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -65,8 +65,11 @@ impl BitcoinInterface for DummyBitcoind {
         Vec::new()
     }
 
-    fn confirmed_coins(&self, _: &[bitcoin::OutPoint]) -> Vec<(bitcoin::OutPoint, i32, u32)> {
-        Vec::new()
+    fn confirmed_coins(
+        &self,
+        _: &[bitcoin::OutPoint],
+    ) -> (Vec<(bitcoin::OutPoint, i32, u32)>, Vec<bitcoin::OutPoint>) {
+        (Vec::new(), Vec::new())
     }
 
     fn spending_coins(&self, _: &[bitcoin::OutPoint]) -> Vec<(bitcoin::OutPoint, bitcoin::Txid)> {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -220,6 +220,12 @@ impl DatabaseConnection for DummyDatabase {
         }
     }
 
+    fn remove_coins(&mut self, outpoints: &[bitcoin::OutPoint]) {
+        for op in outpoints {
+            self.db.write().unwrap().coins.remove(op);
+        }
+    }
+
     fn confirm_coins<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, i32, u32)]) {
         for (op, height, time) in outpoints {
             let mut db = self.db.write().unwrap();

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -289,7 +289,11 @@ def test_deposit_replacement(lianad, bitcoind):
     # Make sure we registered the unconfirmed coin. Then RBF the deposit tx.
     wait_for(lambda: len(lianad.rpc.listcoins()["coins"]) == 1)
     txid = bitcoind.rpc.sendrawtransaction(conflicting_tx)
-    bitcoind.generate_block(1, wait_for_mempool=txid)
 
     # We must forget about the deposit.
+    wait_for(lambda: len(lianad.rpc.listcoins()["coins"]) == 0)
+
+    # Send a new one, it'll be detected.
+    addr = lianad.rpc.getnewaddress()["address"]
+    bitcoind.rpc.sendtoaddress(addr, 2)
     wait_for(lambda: len(lianad.rpc.listcoins()["coins"]) == 1)


### PR DESCRIPTION
Previously we would not detect whether the transaction for an unconfirmed deposit was still in our mempool. For instance a deposit that was RBF'd would result in us storing two coins, the replaced and the replacement. Keeping the unconfirmed replaced coin forever.

Fix this by dropping unconfirmed coins from our database if their transaction isn't in our mempool (anymore).

Fixes #72.