### PR TITLE
gui: fix hws list reloading

### DIFF
--- a/gui/src/app/state/spend/detail.rs
+++ b/gui/src/app/state/spend/detail.rs
@@ -345,6 +345,9 @@ impl Action for SignAction {
                 }
             }
             Message::View(view::Message::Reload) => {
+                self.hws = Vec::new();
+                self.chosen_hw = None;
+                self.error = None;
                 return self.load(wallet, daemon);
             }
             _ => {}

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -3,6 +3,8 @@ use iced::widget::{
 };
 use iced::{alignment, Alignment, Element, Length};
 
+use std::collections::HashSet;
+
 use liana::miniscript::bitcoin;
 
 use crate::{
@@ -606,7 +608,8 @@ pub fn participate_xpub(
 pub fn register_descriptor<'a>(
     progress: (usize, usize),
     descriptor: String,
-    hws: &'a [(HardwareWallet, Option<[u8; 32]>, bool)],
+    hws: &'a [HardwareWallet],
+    registered: &HashSet<bitcoin::util::bip32::Fingerprint>,
     error: Option<&Error>,
     processing: bool,
     chosen_hw: Option<usize>,
@@ -654,10 +657,12 @@ pub fn register_descriptor<'a>(
                             .fold(Column::new().spacing(10), |col, (i, hw)| {
                                 col.push(hw_list_view(
                                     i,
-                                    &hw.0,
+                                    hw,
                                     Some(i) == chosen_hw,
                                     processing,
-                                    hw.2,
+                                    hw.fingerprint()
+                                        .map(|fg| registered.contains(&fg))
+                                        .unwrap_or(false),
                                 ))
                             }),
                     )


### PR DESCRIPTION
I wanted the refresh button to add more harware wallet to the list without erasing the previous list
in order to not cut the existing communication channels.

But with the new display of "unsupported wallet" this behaviour can corrupt the list. An "unsupported wallet" can become "supported" because user switch app or unlock.

It is preferable to reset the full list and drop the objects after a refresh.