### PR TITLE
fix: spend minimal amount in btc

### DIFF
--- a/gui/src/app/view/spend/step.rs
+++ b/gui/src/app/view/spend/step.rs
@@ -100,7 +100,7 @@ pub fn recipient_view<'a>(
                 form::Form::new("Amount", amount, move |msg| {
                     CreateSpendMessage::RecipientEdited(index, "amount", msg)
                 })
-                .warning("Please enter correct amount (> 5000 sats)")
+                .warning("Please enter correct amount (> 0.00005000 btc)")
                 .size(20)
                 .padding(10),
             )


### PR DESCRIPTION
"> 5000 sats" message was confusing with the actual amount in btc requirement