### PR TITLE
fix: drop connections to hws in share xpub panel

### DIFF
--- a/gui/src/installer/step/descriptor.rs
+++ b/gui/src/installer/step/descriptor.rs
@@ -910,6 +910,8 @@ impl Step for ParticipateXpub {
 
     fn apply(&mut self, ctx: &mut Context) -> bool {
         ctx.bitcoin_config.network = self.network;
+        // Drop connections to hardware wallets.
+        self.xpubs_hw = Vec::new();
         true
     }
 


### PR DESCRIPTION
Use needs to be able to start new connections
in the register descriptor step.