### PR TITLE
daemonize: switch the pid and log file arguments

### DIFF
--- a/src/daemonize.rs
+++ b/src/daemonize.rs
@@ -10,8 +10,8 @@ use std::path::Path;
 // MIT licensed according to https://github.com/jedisct1/rust-daemonize-simple/blob/master/Cargo.toml
 pub unsafe fn daemonize(
     chdir: &Path,
-    pid_file: &Path,
     log_file: &Path,
+    pid_file: &Path,
 ) -> Result<(), &'static str> {
     match libc::fork() {
         -1 => return Err("fork() failed"),


### PR DESCRIPTION
The caller and the definition had them swapped.. So it was logging to the PID file and writing the PID to the log file..