### PR TITLE
Add dependencies for ubuntu

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -78,6 +78,8 @@ $ ls target/release/
 build  deps  examples  incremental  liana-cli  liana-cli.d  lianad  lianad.d  libliana.d  libliana.rlib
 ```
 
+Depencies needed for build GUI can be found [there](https://github.com/wizardsardine/liana/tree/master/gui#dependencies)
+
 To build the GUI, do the same but in the [`gui/`](../gui/) folder present at the root of the
 repository:
 ```
@@ -86,3 +88,4 @@ $ cargo build --release
 $ ls target/release/
 build  deps  examples  incremental  liana-gui  liana-gui.d  libliana_gui.d  libliana_gui.rlib
 ```
+


### PR DESCRIPTION
I got few errors while building liana-gui with Ubuntu Mate 22.10, then try on a  fresh install with ubuntu 22.04 server (minimal install):

```
 running: "cmake" "/home/pythcoiner/.cargo/registry/src/github.com-1ecc6299db9ec823/freetype-sys-0.13.1/freetype2" "-DWITH_BZip2=OFF" "-DWITH_HarfBuzz=OFF" "-DWITH_PNG=OFF" "-DWITH_ZLIB=OFF" "-DCMAKE_INSTALL_PREFIX=/home/pythcoiner/liana/gui/target/release/build/freetype-sys-952a2cbdb10ff868/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_CXX_COMPILER=c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_ASM_COMPILER=/usr/bin/cc" "-DCMAKE_BUILD_TYPE=Release"

  --- stderr
  thread 'main' panicked at '
  failed to execute command: No such file or directory (os error 2)
  is `cmake` not installed?

  build script failed, must exit now', /home/pythcoiner/.cargo/registry/src/github.com-1ecc6299db9ec823/cmake-0.1.49/src/lib.rs:1104:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

fixed by 

```
sudo apt install cmake.
```

then:

```
--- stderr
  CMake Deprecation Warning at CMakeLists.txt:78 (cmake_minimum_required):
    Compatibility with CMake < 2.8.12 will be removed from a future version of
    CMake.

    Update the VERSION argument <min> value or use a ...<max> suffix to tell
    CMake that the project does not need compatibility with older versions.


  CMake Error at CMakeLists.txt:119 (project):
    The CMAKE_CXX_COMPILER:

      c++

    is not a full path and was not found in the PATH.

    Tell CMake where to find the compiler by setting either the environment
    variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
    to the compiler, or to the compiler name if it is in the PATH.


  thread 'main' panicked at '
  command did not execute successfully, got: exit status: 1

  build script failed, must exit now', /home/pythcoiner/.cargo/registry/src/github.com-1ecc6299db9ec823/cmake-0.1.49/src/lib.rs:1104:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

fix by:

```
sudo apt install build-essential
```

then:

```
--- stderr
  thread 'main' panicked at 'Could not run `"pkg-config" "--libs" "--cflags" "fontconfig" "fontconfig >= 2.11.1"`
  The pkg-config command could not be found.

  Most likely, you need to install a pkg-config package for your OS.
  Try `apt install pkg-config`, or `yum install pkg-config`,
  or `pkg install pkg-config` depending on your distribution.

  If you've already installed it, ensure the pkg-config command is one of the
  directories in the PATH environment variable.

  If you did not expect this build to link to a pre-installed system library,
  then check documentation of the servo-fontconfig-sys crate for an option to
  build the library from source, or disable features or dependencies
  that require pkg-config.', /home/pythcoiner/.cargo/registry/src/github.com-1ecc6299db9ec823/servo-fontconfig-sys-5.1.0/build.rs:34:17
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

fix by:

```
sudo apt install libfontconfig1-dev

```

then:

```
--- stderr
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "`\"pkg-config\" \"--libs\" \"--cflags\" \"libudev\"` did not exit successfully: exit status: 1\nerror: could not find system library 'libudev' required by the 'libudev-sys' crate\n\n--- stderr\nPackage libudev was not found in the pkg-config search path.\nPerhaps you should add the directory containing `libudev.pc'\nto the PKG_CONFIG_PATH environment variable\nNo package 'libudev' found\n"', /home/pythcoiner/.cargo/registry/src/github.com-1ecc6299db9ec823/libudev-sys-0.1.4/build.rs:38:41
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

fix by:

```
sudo apt install librust-libudev-dev
```

