### PR TITLE
gui: filter unused events

### DIFF
--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -241,7 +241,17 @@ impl Application for GUI {
                 State::App(v) => v.subscription().map(|msg| Message::Run(Box::new(msg))),
                 State::Launcher(v) => v.subscription().map(|msg| Message::Launch(Box::new(msg))),
             },
-            iced_native::subscription::events().map(Self::Message::Event),
+            iced_native::subscription::events_with(|event, _status| {
+                if matches!(
+                    event,
+                    iced::Event::Window(iced_native::window::Event::CloseRequested)
+                ) {
+                    Some(event)
+                } else {
+                    None
+                }
+            })
+            .map(Self::Message::Event),
         ])
     }
 


### PR DESCRIPTION
It may removes the annoying logs that occurs after a while.
```
[1669885771][iced_futures::subscription::tracker][WARN] Error sending event to subscription: TrySendError { kind: Full }
[1669885771][iced_futures::subscription::tracker][WARN] Error sending event to subscription: TrySendError { kind: Full }
[1669885771][iced_futures::subscription::tracker][WARN] Error sending event to subscription: TrySendError { kind: Full }
```
By filtering the events to use only the events listened by the application, we may not reach some buffer size limit