### PR TITLE
Store in DB the time a Spend transaction draft was last updated

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -174,6 +174,7 @@ This command does not take any parameter for now.
 | Field          | Type              | Description                                                             |
 | -------------- | ----------------- | ----------------------------------------------------------------------- |
 | `psbt`         | string            | Base64-encoded PSBT of the Spend transaction.                           |
+| `updated_at`   | int or null       | UNIX timestamp of the last time this PSBT was updated.                  |
 
 
 ### `delspendtx`

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -563,7 +563,7 @@ impl DaemonControl {
         let spend_txs = db_conn
             .list_spend()
             .into_iter()
-            .map(|psbt| ListSpendEntry { psbt })
+            .map(|(psbt, updated_at)| ListSpendEntry { psbt, updated_at })
             .collect();
         ListSpendResult { spend_txs }
     }
@@ -840,6 +840,7 @@ pub struct CreateSpendResult {
 pub struct ListSpendEntry {
     #[serde(serialize_with = "ser_base64", deserialize_with = "deser_base64")]
     pub psbt: Psbt,
+    pub updated_at: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -112,8 +112,8 @@ pub trait DatabaseConnection {
     /// Insert a new Spend transaction or replace an existing one.
     fn store_spend(&mut self, psbt: &Psbt);
 
-    /// List all existing Spend transactions.
-    fn list_spend(&mut self) -> Vec<Psbt>;
+    /// List all existing Spend transactions, along with an optional last update timestamp.
+    fn list_spend(&mut self) -> Vec<(Psbt, Option<u32>)>;
 
     /// Delete a Spend transaction from database.
     fn delete_spend(&mut self, txid: &bitcoin::Txid);
@@ -241,10 +241,10 @@ impl DatabaseConnection for SqliteConn {
         self.store_spend(psbt)
     }
 
-    fn list_spend(&mut self) -> Vec<Psbt> {
+    fn list_spend(&mut self) -> Vec<(Psbt, Option<u32>)> {
         self.list_spend()
             .into_iter()
-            .map(|db_spend| db_spend.psbt)
+            .map(|db_spend| (db_spend.psbt, db_spend.updated_at))
             .collect()
     }
 

--- a/src/database/sqlite/schema.rs
+++ b/src/database/sqlite/schema.rs
@@ -74,7 +74,8 @@ CREATE TABLE addresses (
 CREATE TABLE spend_transactions (
     id INTEGER PRIMARY KEY NOT NULL,
     psbt BLOB UNIQUE NOT NULL,
-    txid BLOB UNIQUE NOT NULL
+    txid BLOB UNIQUE NOT NULL,
+    updated_at INTEGER
 );
 ";
 
@@ -253,6 +254,7 @@ pub struct DbSpendTransaction {
     pub id: i64,
     pub psbt: Psbt,
     pub txid: bitcoin::Txid,
+    pub updated_at: Option<u32>,
 }
 
 impl TryFrom<&rusqlite::Row<'_>> for DbSpendTransaction {
@@ -268,6 +270,13 @@ impl TryFrom<&rusqlite::Row<'_>> for DbSpendTransaction {
         let txid: bitcoin::Txid = encode::deserialize(&txid).expect("We only store valid txids");
         assert_eq!(txid, psbt.unsigned_tx.txid());
 
-        Ok(DbSpendTransaction { id, psbt, txid })
+        let updated_at = row.get(3)?;
+
+        Ok(DbSpendTransaction {
+            id,
+            psbt,
+            txid,
+            updated_at,
+        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,10 +184,10 @@ fn setup_sqlite(
         .iter()
         .collect();
     let options = if fresh_data_dir {
-        Some(FreshDbOptions {
-            bitcoind_network: config.bitcoin_config.network,
-            main_descriptor: config.main_descriptor.clone(),
-        })
+        Some(FreshDbOptions::new(
+            config.bitcoin_config.network,
+            config.main_descriptor.clone(),
+        ))
     } else {
         None
     };

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -12,7 +12,7 @@ from io import BytesIO
 from .serializations import CTransaction, PSBT
 
 TIMEOUT = int(os.getenv("TIMEOUT", 20))
-EXECUTOR_WORKERS = int(os.getenv("EXECUTOR_WORKERS", 20))
+EXECUTOR_WORKERS = int(os.getenv("EXECUTOR_WORKERS", 5))
 VERBOSE = os.getenv("VERBOSE", "0") == "1"
 LOG_LEVEL = os.getenv("LOG_LEVEL", "debug")
 assert LOG_LEVEL in ["trace", "debug", "info", "warn", "error"]

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -159,6 +159,7 @@ def test_list_spend(lianad, bitcoind):
     assert "psbt" in res_b
 
     # Store them both in DB.
+    time_before_update = int(time.time())
     assert len(lianad.rpc.listspendtxs()["spend_txs"]) == 0
     lianad.rpc.updatespend(res["psbt"])
     lianad.rpc.updatespend(res_b["psbt"])
@@ -168,7 +169,9 @@ def test_list_spend(lianad, bitcoind):
     list_res = lianad.rpc.listspendtxs()["spend_txs"]
     assert len(list_res) == 2
     first_psbt = next(entry for entry in list_res if entry["psbt"] == res["psbt"])
+    assert time_before_update <= first_psbt["updated_at"] <= int(time.time())
     second_psbt = next(entry for entry in list_res if entry["psbt"] == res_b["psbt"])
+    assert time_before_update <= second_psbt["updated_at"] <= int(time.time())
 
     # If we delete the first one, we'll get only the second one.
     first_psbt = PSBT.from_base64(res["psbt"])


### PR DESCRIPTION
This is an alternative to #390. 

We add a new column in the `spend_transactions` SQLite table, and as such introduce a straightforward migration system. This field is in turn always set in `updatespendtx` when we store the new PSBT, and listed in `listspendtxs` entries. It is useful for instance to sort spend transactions on the GUI (#281).