### PR TITLE
gui: do not check empty addresses for duplicates

### DIFF
--- a/gui/src/app/state/spend/step.rs
+++ b/gui/src/app/state/spend/step.rs
@@ -77,7 +77,7 @@ impl ChooseRecipients {
             if !recipient.valid() {
                 self.is_valid = false;
             }
-            if !self.is_duplicate {
+            if !self.is_duplicate && !recipient.address.value.is_empty() {
                 self.is_duplicate = self.recipients[..i]
                     .iter()
                     .any(|r| r.address.value == recipient.address.value);


### PR DESCRIPTION
This is to resolve #190.

The check for a duplicate is skipped if the recipient address is an empty string.

I was able to run the GUI locally and it seemed to work as required.