### PR TITLE
fix not found settings file error for old gui versions.

### DIFF
--- a/gui/src/app/settings.rs
+++ b/gui/src/app/settings.rs
@@ -47,6 +47,7 @@ impl Settings {
 
         let mut settings_file = OpenOptions::new()
             .write(true)
+            .create(true)
             .truncate(true)
             .open(path)
             .map_err(|e| SettingsError::WritingFile(e.to_string()))?;

--- a/gui/src/app/wallet.rs
+++ b/gui/src/app/wallet.rs
@@ -91,7 +91,16 @@ impl Wallet {
                     self.with_hardware_wallets(gui_config_hws)
                 }
             }
-            Err(settings::SettingsError::NotFound) => self.with_hardware_wallets(gui_config_hws),
+            Err(settings::SettingsError::NotFound) => {
+                let wallet = self.with_hardware_wallets(gui_config_hws);
+                let s = settings::Settings {
+                    wallets: vec![settings::WalletSetting::from(&wallet)],
+                };
+
+                tracing::info!("Settings file not found, creating one");
+                s.to_file(datadir_path.to_path_buf(), network)?;
+                wallet
+            }
             Err(e) => return Err(e.into()),
         };
 


### PR DESCRIPTION
After migrating from a 0.1 or 0.2 version of the gui user may want to update the keys aliases in the settings This commit makes sure that a settings file exists when wallet is loaded.