### PR TITLE
gui: add button to get next receive address

### DIFF
--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -278,21 +278,25 @@ impl State for ReceivePanel {
     }
     fn update(
         &mut self,
-        _daemon: Arc<dyn Daemon + Sync + Send>,
+        daemon: Arc<dyn Daemon + Sync + Send>,
         _cache: &Cache,
         message: Message,
     ) -> Command<Message> {
-        if let Message::ReceiveAddress(res) = message {
-            match res {
-                Ok(address) => {
-                    self.warning = None;
-                    self.qr_code = Some(qr_code::State::new(address.to_qr_uri()).unwrap());
-                    self.address = Some(address);
+        match message {
+            Message::ReceiveAddress(res) => {
+                match res {
+                    Ok(address) => {
+                        self.warning = None;
+                        self.qr_code = Some(qr_code::State::new(address.to_qr_uri()).unwrap());
+                        self.address = Some(address);
+                    }
+                    Err(e) => self.warning = Some(e),
                 }
-                Err(e) => self.warning = Some(e),
+                Command::none()
             }
-        };
-        Command::none()
+            Message::View(view::Message::Next) => self.load(daemon),
+            _ => Command::none(),
+        }
     }
 
     fn load(&self, daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {

--- a/gui/src/app/view/receive.rs
+++ b/gui/src/app/view/receive.rs
@@ -1,12 +1,12 @@
 use iced::{
     widget::qr_code::{self, QRCode},
-    Alignment,
+    Alignment, Length,
 };
 
 use liana::miniscript::bitcoin;
 
 use liana_ui::{
-    component::{card, text::*},
+    component::{button, card, text::*},
     icon, theme,
     widget::*,
 };
@@ -14,21 +14,31 @@ use liana_ui::{
 use super::message::Message;
 
 pub fn receive<'a>(address: &'a bitcoin::Address, qr: &'a qr_code::State) -> Element<'a, Message> {
-    card::simple(
-        Column::new()
-            .push(QRCode::new(qr).cell_size(10))
-            .push(
-                Row::new()
-                    .push(text(address.to_string()).small())
-                    .push(
-                        Button::new(icon::clipboard_icon())
-                            .on_press(Message::Clipboard(address.to_string()))
-                            .style(theme::Button::TransparentBorder),
-                    )
-                    .align_items(Alignment::Center),
-            )
-            .align_items(Alignment::Center)
-            .spacing(20),
-    )
-    .into()
+    Column::new()
+        .push(card::simple(
+            Column::new()
+                .push(QRCode::new(qr).cell_size(10))
+                .push(
+                    Row::new()
+                        .push(text(address.to_string()).small())
+                        .push(
+                            Button::new(icon::clipboard_icon())
+                                .on_press(Message::Clipboard(address.to_string()))
+                                .style(theme::Button::TransparentBorder),
+                        )
+                        .align_items(Alignment::Center),
+                )
+                .align_items(Alignment::Center)
+                .spacing(20),
+        ))
+        .push(
+            Column::new().push(
+                button::primary(None, "Generate new")
+                    .on_press(Message::Next)
+                    .width(Length::Units(150)),
+            ),
+        )
+        .spacing(20)
+        .align_items(Alignment::Center)
+        .into()
 }


### PR DESCRIPTION
This aims to resolve #114.

I've added a "Next" button to the Receive screen, which gets a new address. I'm not sure if I've done this the right way and will be happy to make any changes as required.

I compared several addresses against those returned by `bdk-cli` and they matched.

Thank you.