### PR TITLE
fix gui jsonrpc client: wrong createspend args

### DIFF
--- a/gui/src/daemon/client/mod.rs
+++ b/gui/src/daemon/client/mod.rs
@@ -88,8 +88,8 @@ impl<C: Client + Debug> Daemon for Lianad<C> {
         self.call(
             "createspend",
             Some(vec![
-                json!(coins_outpoints),
                 json!(destinations),
+                json!(coins_outpoints),
                 json!(feerate_vb),
             ]),
         )


### PR DESCRIPTION
Wrong order.
We should find a way to test the jsonrpc client agains the liana rpc api.