### PR TITLE
Add alias to hotsigner component

### DIFF
--- a/gui/src/app/state/spend/detail.rs
+++ b/gui/src/app/state/spend/detail.rs
@@ -379,6 +379,10 @@ impl Action for SignAction {
             self.error.as_ref(),
             &self.hws,
             self.wallet.signer.as_ref().map(|s| s.fingerprint()),
+            self.wallet
+                .signer
+                .as_ref()
+                .and_then(|signer| self.wallet.keys_aliases.get(&signer.fingerprint)),
             self.processing,
             self.chosen_hw,
             &self.signed,

--- a/gui/src/app/view/hw.rs
+++ b/gui/src/app/view/hw.rs
@@ -17,12 +17,20 @@ pub fn hw_list_view(
             version,
             fingerprint,
             alias,
+            registered,
             ..
         } => {
             if chosen && processing {
                 hw::processing_hardware_wallet(kind, version.as_ref(), fingerprint, alias.as_ref())
             } else if signed {
                 hw::sign_success_hardware_wallet(
+                    kind,
+                    version.as_ref(),
+                    fingerprint,
+                    alias.as_ref(),
+                )
+            } else if *registered == Some(false) {
+                hw::unregistered_hardware_wallet(
                     kind,
                     version.as_ref(),
                     fingerprint,

--- a/gui/src/app/view/spend/detail.rs
+++ b/gui/src/app/view/spend/detail.rs
@@ -18,7 +18,7 @@ use liana_ui::{
     component::{
         badge, button, card,
         collapse::Collapse,
-        form, separation,
+        form, hw, separation,
         text::{text, Text},
     },
     icon, theme,
@@ -710,6 +710,7 @@ pub fn sign_action<'a>(
     warning: Option<&Error>,
     hws: &'a [HardwareWallet],
     signer: Option<Fingerprint>,
+    signer_alias: Option<&'a String>,
     processing: bool,
     chosen_hw: Option<usize>,
     signed: &[Fingerprint],
@@ -746,35 +747,11 @@ pub fn sign_action<'a>(
                             },
                         ))
                         .push_maybe(signer.map(|fingerprint| {
-                            Button::new(
-                                Row::new()
-                                    .align_items(Alignment::Center)
-                                    .push(
-                                        Column::new()
-                                            .width(Length::Fill)
-                                            .push(text("This computer").bold())
-                                            .push(
-                                                text(format!("fingerprint: {}", fingerprint))
-                                                    .small(),
-                                            )
-                                            .spacing(5)
-                                            .width(Length::Fill),
-                                    )
-                                    .push_maybe(if signed.contains(&fingerprint) {
-                                        Some(
-                                            Row::new()
-                                                .align_items(Alignment::Center)
-                                                .spacing(5)
-                                                .push(
-                                                    icon::circle_check_icon()
-                                                        .style(color::legacy::SUCCESS),
-                                                )
-                                                .push(text("Signed").style(color::legacy::SUCCESS)),
-                                        )
-                                    } else {
-                                        None
-                                    }),
-                            )
+                            Button::new(if signed.contains(&fingerprint) {
+                                hw::sign_success_hot_signer(fingerprint, signer_alias)
+                            } else {
+                                hw::hot_signer(fingerprint, signer_alias)
+                            })
                             .on_press(Message::Spend(SpendTxMessage::SelectHotSigner))
                             .padding(10)
                             .style(theme::Button::Secondary)

--- a/gui/src/signer.rs
+++ b/gui/src/signer.rs
@@ -15,7 +15,7 @@ use liana::{
 pub struct Signer {
     curve: secp256k1::Secp256k1<secp256k1::SignOnly>,
     key: HotSigner,
-    fingerprint: Fingerprint,
+    pub fingerprint: Fingerprint,
 }
 
 impl std::fmt::Debug for Signer {

--- a/gui/ui/src/component/hw.rs
+++ b/gui/ui/src/component/hw.rs
@@ -235,3 +235,109 @@ pub fn unsupported_hardware_wallet<'a, T: 'a, K: Display, V: Display>(
     )
     .padding(10)
 }
+
+pub fn sign_success_hot_signer<'a, T: 'a, F: Display>(
+    fingerprint: F,
+    alias: Option<impl Into<Cow<'a, str>>>,
+) -> Container<'a, T> {
+    container(
+        row(vec![
+            column(vec![
+                Row::new()
+                    .spacing(5)
+                    .push_maybe(alias.map(|a| text(a).bold()))
+                    .push(text(format!("#{}", fingerprint)))
+                    .into(),
+                Row::new()
+                    .spacing(5)
+                    .push(text("This computer").small())
+                    .into(),
+            ])
+            .width(Length::Fill)
+            .into(),
+            row(vec![
+                icon::circle_check_icon()
+                    .style(color::legacy::SUCCESS)
+                    .into(),
+                text("Signed").style(color::legacy::SUCCESS).into(),
+            ])
+            .align_items(Alignment::Center)
+            .spacing(5)
+            .into(),
+        ])
+        .align_items(Alignment::Center),
+    )
+    .padding(10)
+}
+
+pub fn selected_hot_signer<'a, T: 'a, F: Display>(
+    fingerprint: F,
+    alias: Option<impl Into<Cow<'a, str>>>,
+) -> Container<'a, T> {
+    container(
+        row(vec![
+            column(vec![
+                Row::new()
+                    .spacing(5)
+                    .push_maybe(alias.map(|a| text(a).bold()))
+                    .push(text(format!("#{}", fingerprint)))
+                    .into(),
+                Row::new()
+                    .spacing(5)
+                    .push(text("This computer").small())
+                    .push(text("(A derived key from a mnemonic stored locally)").small())
+                    .into(),
+            ])
+            .width(Length::Fill)
+            .into(),
+            icon::circle_check_icon()
+                .style(color::legacy::SUCCESS)
+                .into(),
+        ])
+        .align_items(Alignment::Center),
+    )
+    .padding(10)
+}
+
+pub fn unselected_hot_signer<'a, T: 'a, F: Display>(
+    fingerprint: F,
+    alias: Option<impl Into<Cow<'a, str>>>,
+) -> Container<'a, T> {
+    Container::new(
+        column(vec![
+            Row::new()
+                .spacing(5)
+                .push_maybe(alias.map(|a| text(a).bold()))
+                .push(text(format!("#{}", fingerprint)))
+                .into(),
+            Row::new()
+                .spacing(5)
+                .push(text("This computer").small())
+                .push(text("(A derived key from a mnemonic stored locally)").small())
+                .into(),
+        ])
+        .width(Length::Fill),
+    )
+    .padding(10)
+}
+
+pub fn hot_signer<'a, T: 'a, F: Display>(
+    fingerprint: F,
+    alias: Option<impl Into<Cow<'a, str>>>,
+) -> Container<'a, T> {
+    Container::new(
+        column(vec![
+            Row::new()
+                .spacing(5)
+                .push_maybe(alias.map(|a| text(a).bold()))
+                .push(text(format!("#{}", fingerprint)))
+                .into(),
+            Row::new()
+                .spacing(5)
+                .push(text("This computer").small())
+                .into(),
+        ])
+        .width(Length::Fill),
+    )
+    .padding(10)
+}


### PR DESCRIPTION
When a hot signer is suggested to user and an alias was entered then the alias must be displayed with the "This computer" label as signer kind.