### PR TITLE
Reset the daemon and GUI versions post 0.4 branch-off

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub struct Version {
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+        write!(f, "{}.{}.{}-dev", self.major, self.minor, self.patch)
     }
 }
 

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -20,7 +20,7 @@ from test_framework.utils import (
 
 def test_getinfo(lianad):
     res = lianad.rpc.getinfo()
-    assert res["version"] == "0.4.0"
+    assert res["version"] == "0.4.0-dev"
     assert res["network"] == "regtest"
     wait_for(lambda: lianad.rpc.getinfo()["block_height"] == 101)
     res = lianad.rpc.getinfo()


### PR DESCRIPTION
Let's use `u32::MAX` as patch version to denote a development build.