### PR TITLE
Add scrollable to descriptor in wallet settings

### DIFF
--- a/gui/src/app/view/settings.rs
+++ b/gui/src/app/view/settings.rs
@@ -1,7 +1,11 @@
 use std::collections::HashSet;
 use std::str::FromStr;
 
-use iced::{alignment, widget::Space, Alignment, Length};
+use iced::{
+    alignment,
+    widget::{scrollable, Space},
+    Alignment, Length,
+};
 
 use liana::miniscript::bitcoin::{util::bip32::Fingerprint, Network};
 
@@ -549,7 +553,11 @@ pub fn wallet_settings<'a>(
             .push(card::simple(
                 Column::new()
                     .push(text("Wallet descriptor:").bold())
-                    .push(text(descriptor.to_owned()).small())
+                    .push(
+                        scrollable(text(descriptor.to_owned()).small()).horizontal_scroll(
+                            scrollable::Properties::new().width(2).scroller_width(2),
+                        ),
+                    )
                     .push(
                         Row::new()
                             .spacing(10)


### PR DESCRIPTION
![2023-04-10T15:28:30,590127511+02:00](https://user-images.githubusercontent.com/6933020/230910890-924ee1b9-ac65-4778-9286-b17aa4a11a81.png)

The wallet descriptor is cut in wallet settings, while this fix does not improve totally the UX it enable the user to have a total view of the descriptor