### PR TITLE
Add Xcode_12.2.xip to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ TODO
 **/dist
 gui/ui/Cargo.lock
 gui/ui/examples/design-system/Cargo.lock
+Xcode_12.2.xip


### PR DESCRIPTION
It simplifies a little bit my life when doing `VERSION=0.4 ./contrib/release/release.sh`