### PR TITLE
gui: display aliases on installer final step

### DIFF
--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -937,26 +937,44 @@ pub fn install<'a>(
                                                     acc.push(
                                                         Row::new()
                                                             .spacing(5)
-                                                            .push(text(hw.0.to_string()).small())
+                                                            .push_maybe(
+                                                                context.keys.iter().find_map(|k| {
+                                                                    if k.master_fingerprint == hw.1
+                                                                    {
+                                                                        Some(
+                                                                            text(k.name.clone())
+                                                                                .small()
+                                                                                .bold(),
+                                                                        )
+                                                                    } else {
+                                                                        None
+                                                                    }
+                                                                }),
+                                                            )
                                                             .push(
-                                                                text(format!(
-                                                                    "(fingerprint: {})",
-                                                                    hw.1
-                                                                ))
-                                                                .small(),
-                                                            ),
+                                                                text(format!("#{}", hw.1)).small(),
+                                                            )
+                                                            .push(text(hw.0.to_string()).small()),
                                                     )
                                                 },
                                             ))
                                         })
                                         .push_maybe(context.signer.as_ref().map(|signer| {
-                                            Row::new().push(text("This computer").small()).push(
-                                                text(format!(
-                                                    "(fingerprint: {})",
-                                                    signer.fingerprint()
-                                                ))
-                                                .small(),
-                                            )
+                                            Row::new()
+                                                .spacing(5)
+                                                .push_maybe(context.keys.iter().find_map(|k| {
+                                                    if k.master_fingerprint == signer.fingerprint()
+                                                    {
+                                                        Some(text(k.name.clone()).small().bold())
+                                                    } else {
+                                                        None
+                                                    }
+                                                }))
+                                                .push(
+                                                    text(format!("#{}", signer.fingerprint()))
+                                                        .small(),
+                                                )
+                                                .push(text("This computer").small())
                                         })),
                                 )
                                 .width(Length::Fill),


### PR DESCRIPTION
This is to resolve #436.

For the alias, I'm selecting the element from `context.keys` that has the same fingerprint as `hw` / `context.signer` and then displaying the name of this key. This logic could possibly be extracted to a function.

I haven't yet been able to test with a hardware device, but will try to get my Specter DIY up and running soon :)