### PR TITLE
fix: home list events filter

### DIFF
--- a/gui/src/app/view/home.rs
+++ b/gui/src/app/view/home.rs
@@ -86,23 +86,26 @@ pub fn home_view<'a>(
             Column::new()
                 .spacing(10)
                 .push(h4_bold("Last payments"))
-                .push(
-                    pending_events
-                        .iter()
-                        .enumerate()
-                        .fold(Column::new().spacing(10), |col, (i, event)| {
+                .push(pending_events.iter().enumerate().fold(
+                    Column::new().spacing(10),
+                    |col, (i, event)| {
+                        if !event.is_self_send() {
                             col.push(event_list_view(i, event))
-                        }),
-                )
-                .push(
-                    events
-                        .iter()
-                        .filter(|event| !event.is_self_send())
-                        .enumerate()
-                        .fold(Column::new().spacing(10), |col, (i, event)| {
+                        } else {
+                            col
+                        }
+                    },
+                ))
+                .push(events.iter().enumerate().fold(
+                    Column::new().spacing(10),
+                    |col, (i, event)| {
+                        if !event.is_self_send() {
                             col.push(event_list_view(i + pending_events.len(), event))
-                        }),
-                )
+                        } else {
+                            col
+                        }
+                    },
+                ))
                 .push_maybe(
                     if events.len() % HISTORY_EVENT_PAGE_SIZE as usize == 0 && !events.is_empty() {
                         Some(


### PR DESCRIPTION
We still list the self-send transactions but
we do not display them, because they are required
in order to have the next timestamp for the pagination. This commit fix a misplaced filter that mixed up
events index for the event selection.

close #463