### PR TITLE
fix installer final step view

### DIFF
--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -1034,8 +1034,7 @@ pub fn install<'a>(
                 )
             })
             .spacing(10)
-            .width(Length::Fill)
-            .height(Length::Fill),
+            .width(Length::Fill),
         true,
     )
 }


### PR DESCRIPTION
The height of the content was filling too much and user can scroll down to the abyss