### PR TITLE
Add instructions to build daemon for testing

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -8,6 +8,20 @@ Python scripts are used for the automation, and specifically the [`pytest` frame
 Credits: this test framework was taken and adapted from revaultd, which was itself adapted from
 [C-lightning's test framework](https://github.com/ElementsProject/lightning/tree/master/contrib/pyln-testing).
 
+### Building the project for testing
+
+To run the tests, we must build the debug version of `lianad`. Follow the instructions at [`doc/BUILD.md`](../doc/BUILD.md) but instead of running
+```
+$ cargo build --release
+```
+Run
+```
+$ cargo build
+```
+to build the daemon for testing.  
+The `lianad` and `liana-cli` binaries will be in the `target/debug` directory at the root of the
+repository.
+
 ### Test dependencies
 
 Functional tests dependencies can be installed using `pip`. Use a virtual environment.


### PR DESCRIPTION
@darosior  I tried following the testing instructions and I got an error that indicated that the `target/debug` directory did not exist. This PR adds instructions that specifically ask devs to build the project before testing. I think this will be helpful to others when trying to run the tests.