### PR TITLE
Make compilable on aarch64 (M1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,11 +60,11 @@ base64 = "0.13"
 # Used for generating mnemonics
 getrandom = "0.2"
 
+# Used for the hot signer
+bip39 = "2.0"
+
 # Additional entropy for generating mnemonics
 [target.'cfg(target_arch = "x86")'.dependencies]
 rdrand = "0.8"
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 rdrand = "0.8"
-
-# Used for the hot signer
-bip39 = "2.0"


### PR DESCRIPTION
I ran into some issues while trying to build this on an M1 Mac. First, the `bip39` crate was somehow not being imported correctly and secondly there wasn't a way to just use the `hardware_randomness()` if `cpu_randomness()` wasn't available. Not sure how to do the `#[cfg]` stuff correctly so feel free to close and do another way. Just wanted to post somewhere in case someone else runs into this. 