### PR TITLE
fix dependencies link for build

### DIFF
--- a/gui/README.md
+++ b/gui/README.md
@@ -6,11 +6,13 @@ The Liana graphical interface.
 
 You will need a few dependencies in order to run correctly this software. For Linux systems, those
 are:
+- [`udev`](https://www.freedesktop.org/software/systemd/man/udev.html) (On Debian/Ubuntu `apt install udev`)
 - [`fontconfig`](https://www.freedesktop.org/wiki/Software/fontconfig/) for access to fonts (On Debian/Ubuntu `apt install libfontconfig1-dev`)
 - [`libudev-dev`](https://www.freedesktop.org/software/systemd/man/libudev.html) to communicate with devices through USB (On Debian/Ubuntu `apt install libudev-dev`)
 
 In addition, if you want to build the project from source, you will need:
 - [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/) (On Debian/Ubuntu `apt install pkg-config`)
+- `cmake` (On Debian/Ubuntu apt install cmake)
 
 
 ## Usage


### PR DESCRIPTION
the previous link was o the running dependencies for GUI instead of the building dependencies
btw I also experience a missing cmake on a Debian 11.7, should I add it to the dependencies (or just add a comment about that in the doc?)