### PR TITLE
doc(api): fix order of params for `createspend`

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -125,8 +125,8 @@ This command will refuse to create any output worth less than 5k sats.
 
 | Field          | Type              | Description                                                       |
 | -------------- | ----------------- | ----------------------------------------------------------------- |
+| `destinations` | object            | Map from Bitcoin address to value.                                |
 | `outpoints`    | list of string    | List of the coins to be spent, as `txid:vout`.                    |
-| `destinations` | object            | Map from Bitcoin address to value                                 |
 | `feerate`      | integer           | Target feerate for the transaction, in satoshis per virtual byte. |
 
 #### Response


### PR DESCRIPTION
This fixes the documented order of parameters for the `createspend` command.

I also added a full stop to the `destinations` description for consistency.