### PR TITLE
Get ordered list of recovery paths

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -725,8 +725,10 @@ impl DaemonControl {
         // Query the coins that we can spend through the specified recovery path (if no recovery
         // path specified, use the first available one) from the database.
         let current_height = self.bitcoin.chain_tip().height;
-        let timelock =
-            timelock.unwrap_or_else(|| self.config.main_descriptor.first_timelock_value());
+        let timelock = timelock.unwrap_or_else(|| {
+            let timelocks = self.config.main_descriptor.timelock_values();
+            timelocks[0] // Access the first timelock value
+        });
         let height_delta: i32 = timelock.try_into().expect("Must fit, it's a u16");
         let sweepable_coins = db_conn
             .coins(CoinType::Unspent)

--- a/src/descriptors/mod.rs
+++ b/src/descriptors/mod.rs
@@ -180,7 +180,13 @@ impl LianaDescriptor {
 
     /// Get an ordered list of timelocks of the recovery paths.
     pub fn timelock_values(&self) -> Vec<u16> {
-        self.policy().recovery_paths.keys().copied().collect()
+        let timelocks: Vec<u16> = self.policy().recovery_paths.keys().copied().collect();
+        // Assert that the resulting vector is not empty
+        assert!(
+            !timelocks.is_empty(),
+            "The timelock_values vector should never be empty"
+        );
+        timelocks
     }
 
     /// Get the maximum size in WU of a satisfaction for this descriptor.

--- a/src/descriptors/mod.rs
+++ b/src/descriptors/mod.rs
@@ -178,15 +178,13 @@ impl LianaDescriptor {
             .expect("We never create a Liana descriptor with an invalid Liana policy.")
     }
 
-    /// Get the value (in blocks) of the smallest relative timelock of the recovery paths.
-    pub fn first_timelock_value(&self) -> u16 {
-        *self
-            .policy()
+    /// Get an ordered list of timelocks of the recovery paths.
+    pub fn timelock_values(&self) -> Vec<u16> {
+        self.policy()
             .recovery_paths
             .iter()
-            .next()
-            .expect("There is always at least one recovery path")
-            .0
+            .map(|(timelock, _)| *timelock)
+            .collect()
     }
 
     /// Get the maximum size in WU of a satisfaction for this descriptor.

--- a/src/descriptors/mod.rs
+++ b/src/descriptors/mod.rs
@@ -180,11 +180,7 @@ impl LianaDescriptor {
 
     /// Get an ordered list of timelocks of the recovery paths.
     pub fn timelock_values(&self) -> Vec<u16> {
-        self.policy()
-            .recovery_paths
-            .iter()
-            .map(|(timelock, _)| *timelock)
-            .collect()
+        self.policy().recovery_paths.keys().copied().collect()
     }
 
     /// Get the maximum size in WU of a satisfaction for this descriptor.
@@ -591,13 +587,13 @@ mod tests {
         LianaDescriptor::from_str("wsh(or_i(pk([abcdef01]tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/<0;1>/*),pk([abcdef01]tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/<0;1>/*)))").unwrap_err();
 
         let desc = LianaDescriptor::from_str("wsh(andor(pk([abcdef01]tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/<0;1>/*),older(1),pk([abcdef01]tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/<0;1>/*)))").unwrap();
-        assert_eq!(desc.first_timelock_value(), 1);
+        assert_eq!(desc.timelock_values(), vec![1]);
 
         let desc = LianaDescriptor::from_str("wsh(andor(pk([abcdef01]tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/<0;1>/*),older(42000),pk([abcdef01]tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/<0;1>/*)))").unwrap();
-        assert_eq!(desc.first_timelock_value(), 42000);
+        assert_eq!(desc.timelock_values(), vec![42000]);
 
         let desc = LianaDescriptor::from_str("wsh(andor(pk([abcdef01]tpubDEN9WSToTyy9ZQfaYqSKfmVqmq1VVLNtYfj3Vkqh67et57eJ5sTKZQBkHqSwPUsoSskJeaYnPttHe2VrkCsKA27kUaN9SDc5zhqeLzKa1rr/<0;1>/*),older(65535),pk([abcdef01]tpubD8LYfn6njiA2inCoxwM7EuN3cuLVcaHAwLYeups13dpevd3nHLRdK9NdQksWXrhLQVxcUZRpnp5CkJ1FhE61WRAsHxDNAkvGkoQkAeWDYjV/<0;1>/*)))").unwrap();
-        assert_eq!(desc.first_timelock_value(), 0xffff);
+        assert_eq!(desc.timelock_values(), vec![0xffff]);
     }
 
     #[test]


### PR DESCRIPTION
The new function gets the ordered list, as discussed as part of https://github.com/wizardsardine/liana/issues/517