### PR TITLE
Apply coin selection for spend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "bdk_coin_select"
+version = "0.1.0"
+source = "git+https://github.com/evanlinjin/bdk?branch=new_bdk_coin_select#2a06d73ac7a5dca933b19b51078f5279691364ed"
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +231,7 @@ name = "liana"
 version = "2.0.0"
 dependencies = [
  "backtrace",
+ "bdk_coin_select",
  "bip39",
  "dirs",
  "fern",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ nonblocking_shutdown = []
 # For managing transactions (it re-exports the bitcoin crate)
 miniscript = { version = "10.0", features = ["serde", "compiler", "base64"] }
 
+bdk_coin_select = { git = "https://github.com/evanlinjin/bdk", branch = "new_bdk_coin_select" }
+
 # Don't reinvent the wheel
 dirs = "5.0"
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -143,6 +143,9 @@ A coin may have one of the following four statuses:
 
 Create a transaction spending one or more of our coins. All coins must exist and not be spent.
 
+If no coins are specified in `outpoints`, they will be selected automatically from the set of
+confirmed coins (see [`listcoins`](#listcoins) for coin status definitions).
+
 Will error if the given coins are not sufficient to cover the transaction cost at 90% (or more) of
 the given feerate. If on the contrary the transaction is more than sufficiently funded, it will
 create a change output when economically rationale to do so.

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -1,7 +1,16 @@
-use std::str::FromStr;
+use bdk_coin_select::{
+    change_policy, metrics::LowestFee, Candidate, CoinSelector, DrainWeights, FeeRate,
+    InsufficientFunds, Target, TXIN_BASE_WEIGHT,
+};
+use log::warn;
+use std::{convert::TryInto, str::FromStr};
 
 use miniscript::bitcoin::{self, consensus, hashes::hex::FromHex};
 use serde::{de, Deserialize, Deserializer, Serializer};
+
+use crate::database::Coin;
+
+use super::{CandidateCoin, DUST_OUTPUT_SATS, LONG_TERM_FEERATE_VB};
 
 pub fn deser_fromstr<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
@@ -61,4 +70,120 @@ where
     let s = String::deserialize(d)?;
     let s = Vec::from_hex(&s).map_err(de::Error::custom)?;
     consensus::deserialize(&s).map_err(de::Error::custom)
+}
+
+/// Select coins for spend.
+///
+/// Returns the selected coins and the change amount, which could be zero.
+///
+/// `candidate_coins` are the coins to consider for selection.
+///
+/// `base_tx` is the transaction to select coins for. It should be without any inputs
+/// and without a change output, but with all non-change outputs added.
+///
+/// `change_txo` is the change output to add if needed (with any value).
+///
+/// `feerate_vb` is the minimum feerate (in sats/vb). Note that the selected coins
+/// and change may result in a slightly lower feerate than this as the underlying
+/// function instead uses a minimum feerate of `feerate_vb / 4.0` sats/wu.
+///
+/// `min_fee` is the minimum fee (in sats) that the selection must have.
+///
+/// `max_sat_weight` is the maximum size difference (in vb) of
+/// an input in the transaction before and after satisfaction.
+pub fn select_coins_for_spend(
+    candidate_coins: &[CandidateCoin],
+    base_tx: bitcoin::Transaction,
+    change_txo: bitcoin::TxOut,
+    feerate_vb: f32,
+    min_fee: u64,
+    max_sat_weight: u32,
+) -> Result<(Vec<Coin>, bitcoin::Amount), InsufficientFunds> {
+    let out_value_nochange = base_tx.output.iter().map(|o| o.value).sum();
+
+    // Create the coin selector from the given candidates. NOTE: the coin selector keeps track
+    // of the original ordering of candidates so we can select any mandatory candidates using their
+    // original indices.
+    let base_weight: u32 = base_tx
+        .weight()
+        .to_wu()
+        .try_into()
+        .expect("Transaction weight must fit in u32");
+    let max_input_weight = TXIN_BASE_WEIGHT + max_sat_weight;
+    let candidates: Vec<Candidate> = candidate_coins
+        .iter()
+        .map(|cand| Candidate {
+            input_count: 1,
+            value: cand.coin.amount.to_sat(),
+            weight: max_input_weight,
+            is_segwit: true, // We only support receiving on Segwit scripts.
+        })
+        .collect();
+    let mut selector = CoinSelector::new(&candidates, base_weight);
+    for (i, cand) in candidate_coins.iter().enumerate() {
+        if cand.must_select {
+            // It's fine because the index passed to `select` refers to the original candidates ordering
+            // (and in any case the ordering of candidates is still the same in the coin selector).
+            selector.select(i);
+        }
+    }
+
+    // Now set the change policy. We use a policy which ensures no change output is created with a
+    // lower value than our custom dust limit. NOTE: the change output weight must account for a
+    // potential difference in the size of the outputs count varint. This is why we take the whole
+    // change txo as argument and compute the weight difference below.
+    let long_term_feerate = FeeRate::from_sat_per_vb(LONG_TERM_FEERATE_VB);
+    let drain_weights = DrainWeights {
+        output_weight: {
+            let mut tx_with_change = base_tx;
+            tx_with_change.output.push(change_txo);
+            tx_with_change
+                .weight()
+                .to_wu()
+                .checked_sub(base_weight.into())
+                .expect("base_weight can't be larger")
+                .try_into()
+                .expect("tx size must always fit in u32")
+        },
+        spend_weight: max_input_weight,
+    };
+    let change_policy =
+        change_policy::min_value_and_waste(drain_weights, DUST_OUTPUT_SATS, long_term_feerate);
+
+    // Finally, run the coin selection algorithm. We use a BnB with 100k iterations and if it
+    // couldn't find any solution we fall back to selecting coins by descending value.
+    let target = Target {
+        value: out_value_nochange,
+        feerate: FeeRate::from_sat_per_vb(feerate_vb),
+        min_fee,
+    };
+    if let Err(e) = selector.run_bnb(
+        LowestFee {
+            target,
+            long_term_feerate,
+            change_policy: &change_policy,
+        },
+        100_000,
+    ) {
+        warn!(
+            "Coin selection error: '{}'. Selecting coins by descending value per weight unit...",
+            e.to_string()
+        );
+        selector.sort_candidates_by_descending_value_pwu();
+        // If more coins still need to be selected to meet target, then `change_policy(&selector, target)`
+        // will give `Drain::none()`, i.e. no change, and this will simply select more coins until
+        // they cover the target.
+        selector.select_until_target_met(target, change_policy(&selector, target))?;
+    }
+    // By now, selection is complete and we can check how much change to give according to our policy.
+    let drain = change_policy(&selector, target);
+    let change_amount = bitcoin::Amount::from_sat(drain.value);
+    Ok((
+        selector
+            .selected_indices()
+            .iter()
+            .map(|i| candidate_coins[*i].coin)
+            .collect(),
+        change_amount,
+    ))
 }

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -151,7 +151,7 @@ impl error::Error for Error {}
 impl From<commands::CommandError> for Error {
     fn from(e: commands::CommandError) -> Error {
         match e {
-            commands::CommandError::NoOutpoint
+            commands::CommandError::NoOutpointForSelfSend
             | commands::CommandError::UnknownOutpoint(..)
             | commands::CommandError::InvalidFeerate(..)
             | commands::CommandError::AlreadySpent(..)
@@ -170,6 +170,7 @@ impl From<commands::CommandError> for Error {
             }
             commands::CommandError::FetchingTransaction(..)
             | commands::CommandError::SanityCheckFailure(_)
+            | commands::CommandError::CoinSelectionError(..)
             | commands::CommandError::RescanTrigger(..) => {
                 Error::new(ErrorCode::InternalError, e.to_string())
             }


### PR DESCRIPTION
These are some initial changes towards #51.

I've added a `selectcoinsforspend` command that applies BnB coin selection using a waste metric.

This coin selection is then used in `createspend` if no coins are specified.

@darosior The changes are still in their early stages so I'm creating this draft PR to facilitate discussion about the approach in general and specific details.