### PR TITLE
Update our MSRV from 1.48 to 1.54

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.67.1
+            toolchain: 1.70.0
             components: rustfmt, clippy
             override: true
       - name: rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.48
+          - 1.54
           - nightly
         os:
           - ubuntu-latest
@@ -42,8 +42,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: cargo test --verbose --no-default-features
       - name: Test on Rust ${{ matrix.toolchain }} (non Windows)
-        # See issue https://github.com/wizardsardine/liana/issues/69
-        if: matrix.os != 'windows-latest' && (matrix.os != 'macOS-latest' || matrix.toolchain != '1.48')
+        if: matrix.os != 'windows-latest'
         run: cargo test --verbose --color always -- --nocapture
 
   linter_gui:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,11 @@ query).
 
 ## Minimum Supported Rust Version
 
-`lianad` should always compile and pass tests using **Rust 1.48**.
+`lianad` should always compile and pass tests using **Rust 1.54**. The rationale behind this is
+support something reasonable, and preferably supported by all of:
+- [Guix](https://guix.gnu.org/)
+- Popular distributions' packages (especially Debian which is the most conservative)
+- [Mrustc](https://github.com/thepowersgang/mrustc)
 
 ## Style
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libsqlite3-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,18 +411,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,9 +243,9 @@ checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.23.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ecc4273169aeb654a26ba8c7e087947caad92c9d121886eafa6446d4ebe138"
+checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
 dependencies = [
  "cc",
  "pkg-config",
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.26.3"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba4d3462c8b2e4d7f4fcfcf2b296dc6b65404fbbc7b63daa37fd485c149daf7"
+checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "hashbrown"
@@ -278,18 +278,18 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ fern = "0.6"
 # to work with our custom panic hook.
 backtrace = "0.3"
 
-# Pinned to this version because they broke the MSRV in 0.27...
+# Pinned to this version because they keep breaking their MSRV in point releases...
 # FIXME: this is unfortunate, we don't receive the updates (sometimes critical) from SQLite.
-rusqlite = { version = "0.26.3", features = ["bundled", "unlock_notify"] }
+rusqlite = { version = "0.27", features = ["bundled", "unlock_notify"] }
 
 # To talk to bitcoind
 jsonrpc = "0.12"

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -8,10 +8,7 @@ this repository. They are pinned in a [`Cargo.lock`](../Cargo.lock) file at the 
 We take security very seriously, and toolchain is a big part of that. We are moderatly conservative
 with dependencies and aim to target reasonable compiler versions that have had time to mature (ie
 that had the chance to be reviewed and distributed by third parties, as well as tested by the
-community).  The minimum supported Rust version for `lianad` currently is `1.48`, that is the
-version of [`rustc` shipped in Debian stable](https://packages.debian.org/stable/rustc). (It is also
-inferior to the latest version of `rustc` supported by
-[`mrustc`](https://github.com/thepowersgang/mrustc/) at the time of writing, `1.54`).
+community).  The minimum supported Rust version for `lianad` currently is `1.54`.
 
 If you want to not only build the daemon but the whole wallet including the GUI, you'll
 unfortunately have to use a more recent `cargo`. The minimum version supported by the GUI at the

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -1,6 +1,7 @@
-///! Implementation of the Bitcoin interface using bitcoind.
-///!
-///! We use the RPC interface and a watchonly descriptor wallet.
+//! Implementation of the Bitcoin interface using bitcoind.
+//!
+//! We use the RPC interface and a watchonly descriptor wallet.
+
 mod utils;
 use crate::{
     bitcoin::{Block, BlockChainTip},

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -1,6 +1,7 @@
-///! Interface to the Bitcoin network.
-///!
-///! Broadcast transactions, poll for new unspent coins, gather fee estimates.
+//! Interface to the Bitcoin network.
+//!
+//! Broadcast transactions, poll for new unspent coins, gather fee estimates.
+
 pub mod d;
 pub mod poller;
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,6 +1,7 @@
-///! Database interface for Liana.
-///!
-///! Record wallet metadata, spent and unspent coins, ongoing transactions.
+//! Database interface for Liana.
+//!
+//! Record wallet metadata, spent and unspent coins, ongoing transactions.
+
 pub mod sqlite;
 
 use crate::{

--- a/src/database/sqlite/mod.rs
+++ b/src/database/sqlite/mod.rs
@@ -1,11 +1,12 @@
-///! Implementation of the database interface using SQLite.
-///!
-///! We use a bundled SQLite that is compiled with SQLITE_THREADSAFE. Sqlite.org states:
-///! > Multi-thread. In this mode, SQLite can be safely used by multiple threads provided that
-///! > no single database connection is used simultaneously in two or more threads.
-///!
-///! We leverage SQLite's `unlock_notify` feature to synchronize writes accross connection. More
-///! about it at https://sqlite.org/unlock_notify.html.
+//! Implementation of the database interface using SQLite.
+//!
+//! We use a bundled SQLite that is compiled with SQLITE_THREADSAFE. Sqlite.org states:
+//! > Multi-thread. In this mode, SQLite can be safely used by multiple threads provided that
+//! > no single database connection is used simultaneously in two or more threads.
+//!
+//! We leverage SQLite's `unlock_notify` feature to synchronize writes accross connection. More
+//! about it at https://sqlite.org/unlock_notify.html.
+
 pub mod schema;
 mod utils;
 


### PR DESCRIPTION
The latest Debian stable was released this month with support for Rust up to 1.63.

Fixes #69.