### PR TITLE
Update `rust-jsonrpc` and switch to using `minreq`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34efde8d2422fb79ed56db1d3aea8fa5b583351d15a26770cdee2f88813dd702"
 dependencies = [
  "base64",
+ "minreq",
  "serde",
  "serde_json",
 ]
@@ -290,6 +291,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "minreq"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3de406eeb24aba36ed3829532fa01649129677186b44a49debec0ec574ca7da7"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,15 +50,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "base64-compat"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8d4d2746f89841e49230dd26917df1876050f95abafafbe34f47cb534b88d7"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,12 +108,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
@@ -226,13 +211,12 @@ checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "jsonrpc"
-version = "0.12.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8423b78fc94d12ef1a4a9d13c348c9a78766dda0cc18817adf0faf77e670c8"
+checksum = "34efde8d2422fb79ed56db1d3aea8fa5b583351d15a26770cdee2f88813dd702"
 dependencies = [
- "base64-compat",
+ "base64",
  "serde",
- "serde_derive",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ backtrace = "0.3"
 rusqlite = { version = "0.27", features = ["bundled", "unlock_notify"] }
 
 # To talk to bitcoind
-jsonrpc = "0.12"
+jsonrpc = "0.16"
 
 # Used for daemonization
 libc = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ backtrace = "0.3"
 rusqlite = { version = "0.27", features = ["bundled", "unlock_notify"] }
 
 # To talk to bitcoind
-jsonrpc = "0.16"
+jsonrpc = { version = "0.16", features = ["minreq_http"], default-features = false }
 
 # Used for daemonization
 libc = { version = "0.2", optional = true }

--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -77,7 +77,6 @@ impl BitcoindError {
         match self {
             BitcoindError::Server(jsonrpc::Error::Transport(ref e)) => {
                 match e.downcast_ref::<simple_http::Error>() {
-                    Some(simple_http::Error::Timeout) => true,
                     Some(simple_http::Error::SocketError(e)) => e.kind() == io::ErrorKind::TimedOut,
                     _ => false,
                 }
@@ -310,8 +309,7 @@ impl BitcoinD {
                         error = Some(e)
                     } else if let BitcoindError::Server(jsonrpc::Error::Transport(ref err)) = e {
                         match err.downcast_ref::<simple_http::Error>() {
-                            Some(simple_http::Error::Timeout)
-                            | Some(simple_http::Error::SocketError(_))
+                            Some(simple_http::Error::SocketError(_))
                             | Some(simple_http::Error::HttpErrorCode(503)) => {
                                 if i <= self.retries {
                                     std::thread::sleep(Duration::from_secs(1));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,10 +513,12 @@ mod tests {
             "HTTP/1.1 200\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[]}\n".as_bytes();
 
         // Read the first echo, respond to it
-        let (mut stream, _) = server.accept().unwrap();
-        read_til_json_end(&mut stream);
-        stream.write_all(echo_resp).unwrap();
-        stream.flush().unwrap();
+        {
+            let (mut stream, _) = server.accept().unwrap();
+            read_til_json_end(&mut stream);
+            stream.write_all(echo_resp).unwrap();
+            stream.flush().unwrap();
+        }
 
         // Read the second echo, respond to it
         let (mut stream, _) = server.accept().unwrap();
@@ -549,23 +551,27 @@ mod tests {
 
     // Send them responses for the calls involved when creating a fresh wallet
     fn complete_wallet_creation(server: &net::TcpListener) {
-        let net_resp =
-            ["HTTP/1.1 200\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[]}\n".as_bytes()]
-                .concat();
-        let (mut stream, _) = server.accept().unwrap();
-        read_til_json_end(&mut stream);
-        stream.write_all(&net_resp).unwrap();
-        stream.flush().unwrap();
+        {
+            let net_resp =
+                ["HTTP/1.1 200\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[]}\n".as_bytes()]
+                    .concat();
+            let (mut stream, _) = server.accept().unwrap();
+            read_til_json_end(&mut stream);
+            stream.write_all(&net_resp).unwrap();
+            stream.flush().unwrap();
+        }
 
-        let net_resp = [
+        {
+            let net_resp = [
             "HTTP/1.1 200\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"name\":\"dummy\"}}\n"
                 .as_bytes(),
-        ]
-        .concat();
-        let (mut stream, _) = server.accept().unwrap();
-        read_til_json_end(&mut stream);
-        stream.write_all(&net_resp).unwrap();
-        stream.flush().unwrap();
+            ]
+            .concat();
+            let (mut stream, _) = server.accept().unwrap();
+            read_til_json_end(&mut stream);
+            stream.write_all(&net_resp).unwrap();
+            stream.flush().unwrap();
+        }
 
         let net_resp = [
             "HTTP/1.1 200\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[{\"success\":true}]}\n"
@@ -580,12 +586,14 @@ mod tests {
 
     // Send them a dummy result to loadwallet.
     fn complete_wallet_loading(server: &net::TcpListener) {
-        let listwallets_resp =
-            "HTTP/1.1 200\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[]}\n".as_bytes();
-        let (mut stream, _) = server.accept().unwrap();
-        read_til_json_end(&mut stream);
-        stream.write_all(listwallets_resp).unwrap();
-        stream.flush().unwrap();
+        {
+            let listwallets_resp =
+                "HTTP/1.1 200\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[]}\n".as_bytes();
+            let (mut stream, _) = server.accept().unwrap();
+            read_til_json_end(&mut stream);
+            stream.write_all(listwallets_resp).unwrap();
+            stream.flush().unwrap();
+        }
 
         let loadwallet_resp =
             "HTTP/1.1 200\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"name\":\"dummy\"}}\n"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4,6 +4,8 @@ from fixtures import *
 from test_framework.serializations import PSBT
 from test_framework.utils import wait_for, RpcError, OLD_LIANAD_PATH, LIANAD_PATH
 
+from threading import Thread
+
 
 def receive_and_send(lianad, bitcoind):
     n_coins = len(lianad.rpc.listcoins()["coins"])
@@ -218,3 +220,30 @@ def test_migration(lianad_multisig, bitcoind):
     receive_and_send(lianad, bitcoind)
     spend_txs = lianad.rpc.listspendtxs()["spend_txs"]
     assert len(spend_txs) == 2 and all(s["updated_at"] is not None for s in spend_txs)
+
+
+def test_retry_on_workqueue_exceeded(lianad, bitcoind):
+    """Make sure we retry requests to bitcoind if it is temporarily overloaded."""
+    # Start by reducing the work queue to a single slot. Note we need to stop lianad
+    # as we don't support yet restarting a bitcoind due to the cookie file getting
+    # overwritten.
+    lianad.stop()
+    bitcoind.cmd_line += ["-rpcworkqueue=1", "-rpcthreads=1"]
+    bitcoind.stop()
+    bitcoind.start()
+    lianad.start()
+
+    # Stuck the bitcoind RPC server working queue with a command that takes 5 seconds
+    # to be replied to, and make lianad send it a request. Make sure we detect this is
+    # a transient HTTP 503 error and we retry the request. Once the 5 seconds are past
+    # our request succeeds and we get the reply to the lianad RPC command.
+    t = Thread(target=bitcoind.rpc.waitfornewblock, args=(5_000,))
+    t.start()
+    lianad.rpc.getinfo()
+    lianad.wait_for_logs(
+        [
+            "Transient error when sending request to bitcoind.*(status: 503, body: Work queue depth exceeded)",
+            "Retrying RPC request to bitcoind",
+        ]
+    )
+    t.join()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -18,11 +18,13 @@ def receive_and_send(lianad, bitcoind):
     wait_for(lambda: len(lianad.rpc.listcoins()["coins"]) == n_coins + 3)
 
     # Create a spend that will create a change output, sign and broadcast it.
-    outpoints = [next(
-        c["outpoint"]
-        for c in lianad.rpc.listcoins()["coins"]
-        if c["spend_info"] is None
-    )]
+    outpoints = [
+        next(
+            c["outpoint"]
+            for c in lianad.rpc.listcoins()["coins"]
+            if c["spend_info"] is None
+        )
+    ]
     destinations = {
         bitcoind.rpc.getnewaddress(): 200_000,
     }


### PR DESCRIPTION
This makes us take advantage of a more robust, but still lightweight, HTTP implementation.

This PR also cleanups our error handling code and adds a functional test checking we do retry request on transient bitcoind failures.