### PR TITLE
gui: Add automated coin selection for spend

### DIFF
--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -253,6 +253,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bdk_coin_select"
+version = "0.1.0"
+source = "git+https://github.com/evanlinjin/bdk?branch=new_bdk_coin_select#2a06d73ac7a5dca933b19b51078f5279691364ed"
+
+[[package]]
 name = "bech32"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,9 +2420,10 @@ dependencies = [
 [[package]]
 name = "liana"
 version = "2.0.0"
-source = "git+https://github.com/wizardsardine/liana?branch=master#87555a8da50702ebec04dbe876e7055432ca805a"
+source = "git+https://github.com/wizardsardine/liana?branch=master#2d303b139d4eeafc6b6505433e18b24cd561ab6b"
 dependencies = [
  "backtrace",
+ "bdk_coin_select",
  "bip39",
  "dirs 5.0.0",
  "fern",

--- a/gui/src/app/error.rs
+++ b/gui/src/app/error.rs
@@ -46,6 +46,7 @@ impl std::fmt::Display for Error {
                 DaemonError::Rpc(code, e) => {
                     write!(f, "[{:?}] {}", code, e)
                 }
+                DaemonError::CoinSelectionError => write!(f, "{}", e),
             },
             Self::Unexpected(e) => write!(f, "Unexpected error: {}", e),
             Self::HardwareWallet(e) => write!(f, "{}", e),

--- a/gui/src/app/view/warning.rs
+++ b/gui/src/app/view/warning.rs
@@ -34,6 +34,9 @@ impl From<&Error> for WarningMessage {
                     WarningMessage("Communication with Daemon failed".to_string())
                 }
                 DaemonError::DaemonStopped => WarningMessage("Daemon stopped".to_string()),
+                DaemonError::CoinSelectionError => {
+                    WarningMessage("Error when selecting coins for spend".to_string())
+                }
             },
             Error::Unexpected(_) => WarningMessage("Unknown error".to_string()),
             Error::HardwareWallet(_) => WarningMessage("Hardware wallet error".to_string()),

--- a/gui/src/daemon/mod.rs
+++ b/gui/src/daemon/mod.rs
@@ -30,6 +30,8 @@ pub enum DaemonError {
     Start(StartupError),
     // Error if the client is not supported.
     ClientNotSupported,
+    /// Error when selecting coins for spend.
+    CoinSelectionError,
 }
 
 impl std::fmt::Display for DaemonError {
@@ -42,6 +44,7 @@ impl std::fmt::Display for DaemonError {
             Self::Unexpected(e) => write!(f, "Daemon unexpected error: {}", e),
             Self::Start(e) => write!(f, "Daemon did not start: {}", e),
             Self::ClientNotSupported => write!(f, "Daemon communication is not supported"),
+            Self::CoinSelectionError => write!(f, "Coin selection error"),
         }
     }
 }


### PR DESCRIPTION
This adds automated coin selection from #560 to the GUI.

The new "Auto-select" button uses automated coin selection to select coins for a spend, which the user can then modify as required.

The button can only be clicked once the recipients and feerate have been validated, and it does not appear when creating a self-send.

I haven't added any validation on the amount before making the button clickable, but it may be hard to anticipate all coin selection errors once fees are taken into consideration.