### PR TITLE
Fix the tracking of immature coinbase deposits

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -96,6 +96,7 @@ This command does not take any parameter for now.
 | `outpoint`     | string        | Transaction id and output index of this coin.                                                                      |
 | `block_height` | int or null   | Block height the transaction was confirmed at, or `null`.                                                          |
 | `spend_info`   | object        | Information about the transaction spending this coin. See [Spending transaction info](#spending_transaction_info). |
+| `is_immature`  | bool          | Whether this coin was created by a coinbase transaction that is still immature.                                    |
 
 
 ##### Spending transaction info

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -66,6 +66,7 @@ fn update_coins(
             if !curr_coins.contains_key(&utxo.outpoint) {
                 let coin = Coin {
                     outpoint,
+                    is_immature: false,
                     amount,
                     derivation_index,
                     is_change,

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -24,6 +24,8 @@ struct UpdatedCoins {
 // or spent.
 // NOTE: A coin may be updated multiple times at once. That is, a coin may be received, confirmed,
 // and spent in a single poll.
+// NOTE: Coinbase transaction deposits are very much an afterthought here. We treat them as
+// unconfirmed until the CB tx matures.
 fn update_coins(
     bit: &impl BitcoinInterface,
     db_conn: &mut Box<dyn DatabaseConnection>,
@@ -42,6 +44,7 @@ fn update_coins(
             outpoint,
             amount,
             address,
+            is_immature,
             ..
         } = utxo;
         // We can only really treat them if we know the derivation index that was used.
@@ -66,7 +69,7 @@ fn update_coins(
             if !curr_coins.contains_key(&utxo.outpoint) {
                 let coin = Coin {
                     outpoint,
-                    is_immature: false,
+                    is_immature,
                     amount,
                     derivation_index,
                     is_change,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -300,6 +300,7 @@ impl DaemonControl {
                     block_info,
                     spend_txid,
                     spend_block,
+                    is_immature,
                     ..
                 } = coin;
                 let spend_info = spend_txid.map(|txid| LCSpendInfo {
@@ -312,6 +313,7 @@ impl DaemonControl {
                     outpoint,
                     block_height,
                     spend_info,
+                    is_immature,
                 }
             })
             .collect();
@@ -846,6 +848,8 @@ pub struct ListCoinsEntry {
     pub block_height: Option<i32>,
     /// Information about the transaction spending this coin.
     pub spend_info: Option<LCSpendInfo>,
+    /// Whether this coin was created by a coinbase transaction that is still immature.
+    pub is_immature: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -976,6 +976,7 @@ mod tests {
         let mut db_conn = control.db().lock().unwrap().connection();
         db_conn.new_unspent_coins(&[Coin {
             outpoint: dummy_op,
+            is_immature: false,
             block_info: None,
             amount: bitcoin::Amount::from_sat(100_000),
             derivation_index: bip32::ChildNumber::from(13),
@@ -1081,6 +1082,7 @@ mod tests {
         };
         db_conn.new_unspent_coins(&[Coin {
             outpoint: dummy_op_dup,
+            is_immature: false,
             block_info: None,
             amount: bitcoin::Amount::from_sat(400_000),
             derivation_index: bip32::ChildNumber::from(42),
@@ -1127,6 +1129,7 @@ mod tests {
         db_conn.new_unspent_coins(&[
             Coin {
                 outpoint: dummy_op_a,
+                is_immature: false,
                 block_info: None,
                 amount: bitcoin::Amount::from_sat(100_000),
                 derivation_index: bip32::ChildNumber::from(13),
@@ -1136,6 +1139,7 @@ mod tests {
             },
             Coin {
                 outpoint: dummy_op_b,
+                is_immature: false,
                 block_info: None,
                 amount: bitcoin::Amount::from_sat(115_680),
                 derivation_index: bip32::ChildNumber::from(34),
@@ -1303,6 +1307,7 @@ mod tests {
             // Deposit 1
             Coin {
                 is_change: false,
+                is_immature: false,
                 outpoint: OutPoint {
                     txid: deposit1.txid(),
                     vout: 0,
@@ -1316,6 +1321,7 @@ mod tests {
             // Deposit 2
             Coin {
                 is_change: false,
+                is_immature: false,
                 outpoint: OutPoint {
                     txid: deposit2.txid(),
                     vout: 0,
@@ -1329,6 +1335,7 @@ mod tests {
             // This coin is a change output.
             Coin {
                 is_change: true,
+                is_immature: false,
                 outpoint: OutPoint::new(spend_tx.txid(), 1),
                 block_info: Some(BlockInfo { height: 3, time: 3 }),
                 spend_block: None,
@@ -1339,6 +1346,7 @@ mod tests {
             // Deposit 3
             Coin {
                 is_change: false,
+                is_immature: false,
                 outpoint: OutPoint {
                     txid: deposit3.txid(),
                     vout: 0,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -281,6 +281,7 @@ impl From<DbBlockInfo> for BlockInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Coin {
     pub outpoint: bitcoin::OutPoint,
+    pub is_immature: bool,
     pub block_info: Option<BlockInfo>,
     pub amount: bitcoin::Amount,
     pub derivation_index: bip32::ChildNumber,
@@ -293,6 +294,7 @@ impl std::convert::From<DbCoin> for Coin {
     fn from(db_coin: DbCoin) -> Coin {
         let DbCoin {
             outpoint,
+            is_immature,
             block_info,
             amount,
             derivation_index,
@@ -303,6 +305,7 @@ impl std::convert::From<DbCoin> for Coin {
         } = db_coin;
         Coin {
             outpoint,
+            is_immature,
             block_info: block_info.map(BlockInfo::from),
             amount,
             derivation_index,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -91,6 +91,9 @@ pub trait DatabaseConnection {
     fn remove_coins(&mut self, coins: &[bitcoin::OutPoint]);
 
     /// Mark a set of coins as being confirmed at a specified height and block time.
+    /// NOTE: if the coin comes from an immature coinbase transaction, this will mark it as mature.
+    /// Immature coinbase deposits must not be confirmed before they are 100 blocks deep in the
+    /// chain.
     fn confirm_coins(&mut self, outpoints: &[(bitcoin::OutPoint, i32, u32)]);
 
     /// Mark a set of coins as being spent by a specified txid of a pending transaction.

--- a/src/database/sqlite/schema.rs
+++ b/src/database/sqlite/schema.rs
@@ -39,6 +39,10 @@ CREATE TABLE wallets (
  *
  * The 'spend_block_height' and 'spend_block.time' are only present if the spending
  * transaction for this coin exists and was confirmed.
+ *
+ * The 'is_immature' field is for coinbase deposits that are not yet buried under 100
+ * blocks. Note coinbase deposits can't be change. They also technically can't be
+ * unconfirmed but we keep them as such until they become mature.
  */
 CREATE TABLE coins (
     id INTEGER PRIMARY KEY NOT NULL,
@@ -53,6 +57,8 @@ CREATE TABLE coins (
     spend_txid BLOB,
     spend_block_height INTEGER,
     spend_block_time INTEGER,
+    is_immature BOOLEAN NOT NULL CHECK (is_immature IN (0,1)),
+    CHECK (is_change IS 0 OR is_immature IS 0),
     UNIQUE (txid, vout),
     FOREIGN KEY (wallet_id) REFERENCES wallets (id)
         ON UPDATE RESTRICT
@@ -156,6 +162,8 @@ pub struct DbBlockInfo {
 pub struct DbCoin {
     pub id: i64,
     pub wallet_id: i64,
+    /// Whether this coin was created by a yet-to-be-mature coinbase transaction.
+    pub is_immature: bool,
     pub outpoint: bitcoin::OutPoint,
     pub block_info: Option<DbBlockInfo>,
     pub amount: bitcoin::Amount,
@@ -201,9 +209,16 @@ impl TryFrom<&rusqlite::Row<'_>> for DbCoin {
             time: spend_time.expect("Must be there if height is"),
         });
 
+        let is_immature: bool = row.get(12)?;
+        assert!(
+            !is_immature || !is_change,
+            "A coin cannot be both created in a coinbase and be change"
+        );
+
         Ok(DbCoin {
             id,
             wallet_id,
+            is_immature,
             outpoint,
             block_info,
             amount,

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -155,6 +155,7 @@ impl From<commands::CommandError> for Error {
             | commands::CommandError::UnknownOutpoint(..)
             | commands::CommandError::InvalidFeerate(..)
             | commands::CommandError::AlreadySpent(..)
+            | commands::CommandError::ImmatureCoinbase(..)
             | commands::CommandError::Address(..)
             | commands::CommandError::InvalidOutputValue(..)
             | commands::CommandError::InsufficientFunds(..)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -232,13 +232,16 @@ def test_migration(lianad_multisig, bitcoind):
     # Set the old binary and re-create the datadir.
     lianad.cmd_line[0] = OLD_LIANAD_PATH
     lianad.restart_fresh(bitcoind)
-    assert lianad.rpc.getinfo()["version"] == "0.3.0"
+    old_lianad_ver = lianad.rpc.getinfo()["version"]
+    assert old_lianad_ver in ["0.3.0", "1.0.0"]
 
     # Perform some transactions. On Liana v0.3 there was no "updated_at" for Spend
     # transaction drafts.
     receive_and_send(lianad, bitcoind)
     spend_txs = lianad.rpc.listspendtxs()["spend_txs"]
-    assert len(spend_txs) == 2 and all("updated_at" not in s for s in spend_txs)
+    assert len(spend_txs) == 2
+    if old_lianad_ver == "0.3.0":
+        assert all("updated_at" not in s for s in spend_txs)
 
     # Set back the new binary. We should be able to read and, if necessary, upgrade
     # the old database and generally all files from the datadir.


### PR DESCRIPTION
#567 uncovered that we were actually not tracking coinbase deposits correctly. In fact we would most likely miss them all in any real situation. This is because we would filter out immature coinbase deposits from the result of `listsinceblock` and not consider them newly received coins. But they would be confirmed, and as the chain moves forward we'd not scan this range anymore even once they've become mature.

This PR fixes it by the simplest possible manner: record immature coinbase deposits as unconfirmed and only mark them as confirmed once they've become mature. This is a bit clumsy, but should be fine for the number of users that would receive payouts from coinbase transactions (ie most likely 0). Also, we don't accurately update coinbase coins on reorg. This is unnecessary as it'd be very unlikely that a mature coinbase would become immature and if there is a 100 blocks reorg that would invalidate it altogether we'd have bigger problems.

Fixes #567.
Still as draft as i want to go over this one more time before asking for review, as this if pretty intricate and touches core parts of our codebase.