### PR TITLE
bitcoind: create watchonly wallet with `load_on_startup = true`

### DIFF
--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -512,13 +512,19 @@ impl BitcoinD {
     }
 
     fn create_wallet(&self, wallet_path: String) -> Result<(), String> {
+        // NOTE: we set load_on_startup to make sure the wallet will get updated before the
+        // historical blocks are deleted in case the bitcoind is pruned.
         let res = self
             .make_fallible_node_request(
                 "createwallet",
                 &params!(
                     Json::String(wallet_path),
-                    Json::Bool(true), // watchonly
-                    Json::Bool(true), // blank
+                    Json::Bool(true),  // watchonly
+                    Json::Bool(true),  // blank
+                    Json::Null,        // passphrase
+                    Json::Bool(false), // avoid_reuse
+                    Json::Bool(true),  // descriptors
+                    Json::Bool(true)   // load_on_startup
                 ),
             )
             .map_err(|e| e.to_string())?;


### PR DESCRIPTION
Upon startup bitcoind will update loaded wallets before pruning historical chain data.

This is a trivial fix for people using an aggressively pruned `bitcoind` to not be forced to `-reindex` if they haven't started their Liana wallet for longer than their prune target allows for.

See https://github.com/wizardsardine/liana/issues/570#issuecomment-1658108967 for a discussion about this.