### PR TITLE
db: keep NOT NULL constraint on is_immature in migration

### DIFF
--- a/src/database/sqlite/utils.rs
+++ b/src/database/sqlite/utils.rs
@@ -170,11 +170,7 @@ fn migrate_v0_to_v1(conn: &mut rusqlite::Connection) -> Result<(), SqliteDbError
 fn migrate_v1_to_v2(conn: &mut rusqlite::Connection) -> Result<(), SqliteDbError> {
     db_exec(conn, |tx| {
         tx.execute(
-            "ALTER TABLE coins ADD COLUMN is_immature",
-            rusqlite::params![],
-        )?;
-        tx.execute(
-            "UPDATE coins SET is_immature = 0 WHERE is_immature IS NULL",
+            "ALTER TABLE coins ADD COLUMN is_immature BOOLEAN NOT NULL DEFAULT 0 CHECK (is_immature IN (0,1))",
             rusqlite::params![],
         )?;
         tx.execute("UPDATE version SET version = 2", rusqlite::params![])?;


### PR DESCRIPTION
As suggested by Edouard in https://github.com/wizardsardine/liana/pull/578/files#r1285476881 there is no reason not to keep the `NOT NULL` constraint. I also added the `CHECK .. IN (0, 1)`.

This adds an extraneous DEFAULT compared to the schema in freshly created databases, but anything else (altering the column in an SQLite-friendly way after setting all NULL values to 0) would be way too involved.