### PR TITLE
`lianad`: print a more helpful error message on startup failure

### DIFF
--- a/src/bin/daemon.rs
+++ b/src/bin/daemon.rs
@@ -13,8 +13,9 @@ fn parse_args(args: Vec<String>) -> Option<PathBuf> {
     }
 
     if args.len() != 3 {
-        eprintln!("Unknown arguments '{:?}'.", args);
-        eprintln!("Only '--conf <configuration file path>' is supported.");
+        eprintln!("A TOML configuration file is required to run lianad. By default lianad looks for a 'config.toml' file in its data directory. A different one may be provided like so: '--conf <config file path>'.");
+        eprintln!("A documented example of the configuration file is available at https://github.com/wizardsardine/liana/blob/607c0abddab2ff5761b371c6020b0793b1a1bc97/contrib/lianad_config_example.toml.");
+        eprintln!("The default data directory path is a 'liana/' folder in the XDG standard configuration directory for all OSes but Linux ones, where it's '~/.liana/'.");
         process::exit(1);
     }
 

--- a/src/bin/daemon.rs
+++ b/src/bin/daemon.rs
@@ -9,7 +9,7 @@ use liana::{config::Config, DaemonHandle};
 
 fn print_help_exit() {
     eprintln!("A TOML configuration file is required to run lianad. By default lianad looks for a 'config.toml' file in its data directory. A different one may be provided like so: '--conf <config file path>'.");
-    eprintln!("A documented sample is available at https://github.com/wizardsardine/liana/blob/607c0abddab2ff5761b371c6020b0793b1a1bc97/contrib/lianad_config_example.toml.");
+    eprintln!("A documented sample is available at 'contrib/lianad_config_example.toml' in the source tree (https://github.com/wizardsardine/liana/blob/v1.0/contrib/lianad_config_example.toml).");
     eprintln!("The default data directory path is a 'liana/' folder in the XDG standard configuration directory for all OSes but Linux ones, where it's '~/.liana/'.");
     process::exit(1);
 }
@@ -19,7 +19,10 @@ fn parse_args(args: Vec<String>) -> Option<PathBuf> {
         return None;
     }
 
-    if args.len() != 3 {
+    let is_help = args
+        .iter()
+        .any(|arg| arg.contains("help") || arg.contains("-h"));
+    if args.len() != 3 || is_help {
         print_help_exit();
     }
 

--- a/src/bin/daemon.rs
+++ b/src/bin/daemon.rs
@@ -7,16 +7,20 @@ use std::{
 
 use liana::{config::Config, DaemonHandle};
 
+fn print_help_exit() {
+    eprintln!("A TOML configuration file is required to run lianad. By default lianad looks for a 'config.toml' file in its data directory. A different one may be provided like so: '--conf <config file path>'.");
+    eprintln!("A documented sample is available at https://github.com/wizardsardine/liana/blob/607c0abddab2ff5761b371c6020b0793b1a1bc97/contrib/lianad_config_example.toml.");
+    eprintln!("The default data directory path is a 'liana/' folder in the XDG standard configuration directory for all OSes but Linux ones, where it's '~/.liana/'.");
+    process::exit(1);
+}
+
 fn parse_args(args: Vec<String>) -> Option<PathBuf> {
     if args.len() == 1 {
         return None;
     }
 
     if args.len() != 3 {
-        eprintln!("A TOML configuration file is required to run lianad. By default lianad looks for a 'config.toml' file in its data directory. A different one may be provided like so: '--conf <config file path>'.");
-        eprintln!("A documented example of the configuration file is available at https://github.com/wizardsardine/liana/blob/607c0abddab2ff5761b371c6020b0793b1a1bc97/contrib/lianad_config_example.toml.");
-        eprintln!("The default data directory path is a 'liana/' folder in the XDG standard configuration directory for all OSes but Linux ones, where it's '~/.liana/'.");
-        process::exit(1);
+        print_help_exit();
     }
 
     Some(PathBuf::from(args[2].to_owned()))
@@ -53,7 +57,8 @@ fn main() {
 
     let config = Config::from_file(conf_file).unwrap_or_else(|e| {
         eprintln!("Error parsing config: {}", e);
-        process::exit(1);
+        print_help_exit();
+        unreachable!();
     });
     setup_logger(config.log_level).unwrap_or_else(|e| {
         eprintln!("Error setting up logger: {}", e);


### PR DESCRIPTION
Specifically, link to a sample configuration file. How are users supposed to know how to write the config file otherwise?

Fixes #559.