### PR TITLE
bitcoind: set `load_on_startup` to `true` when loading watchonly wallet

### DIFF
--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -646,7 +646,10 @@ impl BitcoinD {
         }
         let res = self.make_fallible_node_request(
             "loadwallet",
-            &params!(Json::String(self.watchonly_wallet_path.clone()),),
+            &params!(
+                Json::String(self.watchonly_wallet_path.clone()),
+                Json::Bool(true), // load_on_startup
+            ),
         );
         match res {
             Err(BitcoindError::Server(jsonrpc::Error::Rpc(ref e))) => {


### PR DESCRIPTION
we used to not set 'load_on_startup' when creating a watchonly wallet. This could create some complications when people are using agressive pruning configurations.

Fix this by overwriting this parameter when loading watchonly wallets. We can always revert this in the future if for some reason a user wants to have it set to false and no be overwritten everytime Liana loads it.

Fixes #594.