### PR TITLE
poller: spend transaction RBF handling

### DIFF
--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -115,7 +115,8 @@ fn update_coins(
         .values()
         .chain(received.iter())
         .filter_map(|coin| {
-            if coin.spend_txid.is_none() {
+            // Always check for spends when the spend tx is not confirmed as it might get RBF'd.
+            if coin.spend_txid.is_none() || coin.spend_block.is_none() {
                 Some(coin.outpoint)
             } else {
                 None


### PR DESCRIPTION
It turns out we didn't actually notice RBF'd spends.

Fixes #382. And also fixes #73.