### PR TITLE
gui: installer: convey registering on a signing device isn't always required

### DIFF
--- a/gui/src/installer/mod.rs
+++ b/gui/src/installer/mod.rs
@@ -113,7 +113,7 @@ impl Installer {
                     DefineDescriptor::new(self.signer.clone()).into(),
                     BackupMnemonic::new(self.signer.clone()).into(),
                     BackupDescriptor::default().into(),
-                    RegisterDescriptor::default().into(),
+                    RegisterDescriptor::new_create_wallet().into(),
                     DefineBitcoind::new().into(),
                     Final::new(hot_signer_fingerprint).into(),
                 ];
@@ -126,7 +126,7 @@ impl Installer {
                     ImportDescriptor::new(false).into(),
                     BackupMnemonic::new(self.signer.clone()).into(),
                     BackupDescriptor::default().into(),
-                    RegisterDescriptor::default().into(),
+                    RegisterDescriptor::new_import_wallet().into(),
                     DefineBitcoind::new().into(),
                     Final::new(hot_signer_fingerprint).into(),
                 ];
@@ -137,7 +137,7 @@ impl Installer {
                     Welcome::default().into(),
                     ImportDescriptor::new(true).into(),
                     RecoverMnemonic::default().into(),
-                    RegisterDescriptor::default().into(),
+                    RegisterDescriptor::new_import_wallet().into(),
                     DefineBitcoind::new().into(),
                     Final::new(hot_signer_fingerprint).into(),
                 ];

--- a/gui/src/installer/prompt.rs
+++ b/gui/src/installer/prompt.rs
@@ -6,6 +6,6 @@ pub const DEFINE_DESCRIPTOR_RECOVERY_PATH_TOOLTIP: &str =
     "Set key(s) that can be used to spend coins after a defined period of time.\n Different sets of keys can be set to become available at different times.";
 pub const DEFINE_DESCRIPTOR_FINGERPRINT_TOOLTIP: &str =
     "The alias is applied on all the keys derived from the same seed";
-pub const REGISTER_DESCRIPTOR_HELP: &str = "To be used with the wallet, a device needs the descriptor. If the descriptor contains one or more keys imported from an external signing device, the descriptor must be registered on it. Registration confirms that the device is able to handle the policy. Registration on a device is not a substitute for backing up the descriptor.";
+pub const REGISTER_DESCRIPTOR_HELP: &str = "To be used with the wallet, a signing device needs the descriptor. If the descriptor contains one or more keys imported from an external signing device, the descriptor must be registered on it. Registration confirms that the device is able to handle the policy. Registration on a device is not a substitute for backing up the descriptor.";
 pub const MNEMONIC_HELP: &str = "A hot key generated on this computer was used for creating this wallet. It needs to be backed up. \n Keep it in a safe place. Never share it with anyone.";
 pub const RECOVER_MNEMONIC_HELP: &str = "If you were using a hot key (a key stored on the computer) in your wallet, you will need to recover it from mnemonics to be able to sign transactions again. Otherwise you can directly go the next step.";

--- a/gui/src/installer/step/descriptor.rs
+++ b/gui/src/installer/step/descriptor.rs
@@ -1312,7 +1312,6 @@ impl From<ImportDescriptor> for Box<dyn Step> {
     }
 }
 
-#[derive(Default)]
 pub struct RegisterDescriptor {
     descriptor: Option<LianaDescriptor>,
     keys_aliases: HashMap<Fingerprint, String>,
@@ -1323,6 +1322,36 @@ pub struct RegisterDescriptor {
     registered: HashSet<Fingerprint>,
     error: Option<Error>,
     done: bool,
+    /// Whether this step is part of the descriptor creation process. This is used to detect when
+    /// it's instead shown as part of the descriptor *import* process, where we can't detect
+    /// whether a signing device is used, to explicit this step is not required if the user isn't
+    /// using a signing device.
+    created_desc: bool,
+}
+
+impl RegisterDescriptor {
+    fn new(created_desc: bool) -> Self {
+        Self {
+            created_desc,
+            descriptor: Default::default(),
+            keys_aliases: Default::default(),
+            processing: Default::default(),
+            chosen_hw: Default::default(),
+            hws: Default::default(),
+            hmacs: Default::default(),
+            registered: Default::default(),
+            error: Default::default(),
+            done: Default::default(),
+        }
+    }
+
+    pub fn new_create_wallet() -> Self {
+        Self::new(true)
+    }
+
+    pub fn new_import_wallet() -> Self {
+        Self::new(false)
+    }
 }
 
 impl Step for RegisterDescriptor {
@@ -1413,6 +1442,7 @@ impl Step for RegisterDescriptor {
             self.processing,
             self.chosen_hw,
             self.done,
+            self.created_desc,
         )
     }
 }

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -659,11 +659,15 @@ pub fn register_descriptor<'a>(
     processing: bool,
     chosen_hw: Option<usize>,
     done: bool,
+    created_desc: bool,
 ) -> Element<'a, Message> {
     layout(
         progress,
         "Register descriptor",
         Column::new()
+            .push_maybe((!created_desc).then_some(
+                text("This step is only necessary if you are using a signing device.").bold(),
+            ))
             .push(card::simple(
                 Column::new()
                     .push(text("The descriptor:").small().bold())
@@ -686,8 +690,13 @@ pub fn register_descriptor<'a>(
                             .align_items(Alignment::Center)
                             .push(
                                 Container::new(
-                                    text("Select hardware wallet to register descriptor on:")
-                                        .bold(),
+                                    if created_desc {
+                                        text("Select hardware wallet to register descriptor on:")
+                                        .bold()
+                                    } else {
+                                        text("If necessary, please select the signing device to register descriptor on:")
+                                        .bold()
+                                    },
                                 )
                                 .width(Length::Fill),
                             )
@@ -714,12 +723,12 @@ pub fn register_descriptor<'a>(
                     )
                     .width(Length::Fill),
             )
-            .push(checkbox(
+            .push_maybe(created_desc.then_some(checkbox(
                 "I have registered the descriptor on my device(s)",
                 done,
                 Message::UserActionDone,
-            ))
-            .push(if done && !processing {
+            )))
+            .push(if !created_desc || (done && !processing) {
                 button::primary(None, "Next")
                     .on_press(Message::Next)
                     .width(Length::Fixed(200.0))


### PR DESCRIPTION
As discussed in #545, in some cases we nudge the user to register the descriptor on their signing device although they might not have one. Those cases only ever arise when importing a descriptor (either when recovering from backup or participating in the creation of a descriptor on another laptop), since when the descriptor is created beforehand we can simply detect whether a signing device was used and thereby needs to be registered (implemented since https://github.com/wizardsardine/liana/pull/470). 

Therefore, detect when the registration step arises as part of an import process and if so adjust the language to convey registration on a signing device may not be necessary.

Result:
![image](https://github.com/wizardsardine/liana/assets/22457751/b6964dbc-c1e4-4059-b85a-c61492ba523c)

Fixes #545.