### PR TITLE
Add more bitcoind-related setup logging

### DIFF
--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -265,7 +265,9 @@ impl BitcoinD {
             watchonly_wallet_path: watchonly_wallet_path.clone(),
             retries: 0,
         };
+        log::info!("Checking the connection to bitcoind.");
         dummy_bitcoind.check_connection()?;
+        log::info!("Connection to bitcoind checked.");
 
         // Now the connection is checked, create the clients with an appropriate timeout.
         let node_client = Client::with_transport(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,12 +292,14 @@ fn setup_bitcoind(
             wo_name,
         )?;
 
+        log::info!("Creating a new watchonly wallet on bitcoind.");
         bitcoind.create_watchonly_wallet(&config.main_descriptor)?;
-        log::info!("Created a new watchonly wallet on bitcoind.");
+        log::info!("Watchonly wallet created.");
     }
+    log::info!("Loading our watchonly wallet on bitcoind.");
     bitcoind.maybe_load_watchonly_wallet()?;
     bitcoind.wallet_sanity_checks(&config.main_descriptor)?;
-    log::info!("Connection to bitcoind established and checked.");
+    log::info!("Watchonly wallet loaded on bitcoind and sanity checked.");
 
     Ok(bitcoind)
 }

--- a/tests/test_framework/lianad.py
+++ b/tests/test_framework/lianad.py
@@ -119,7 +119,6 @@ class Lianad(TailableProc):
         self.wait_for_logs(
             [
                 "Database initialized and checked",
-                "Connection to bitcoind established and checked.",
                 "JSONRPC server started.",
             ]
         )


### PR DESCRIPTION
At startup it sometimes appear we may be hanging when setting up bitcoind. Add more logging to give more information about what's taking long to setup (for instance, loading the watchonly wallet).

Related to https://github.com/wizardsardine/liana/issues/475.