### PR TITLE
bitcoind: Make `BitcoinD` public and add `stop` method

### DIFF
--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -1096,6 +1096,11 @@ impl BitcoinD {
             }
         }
     }
+
+    /// Stop bitcoind.
+    pub fn stop(&self) {
+        self.make_node_request("stop", &[]);
+    }
 }
 
 /// An entry in the 'listdescriptors' result.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,11 @@ mod testutils;
 pub use bip39;
 pub use miniscript;
 
-pub use crate::bitcoin::d::{BitcoindError, WalletError};
+pub use crate::bitcoin::d::{BitcoinD, BitcoindError, WalletError};
 #[cfg(feature = "daemon")]
 use crate::jsonrpc::server::{rpcserver_loop, rpcserver_setup};
 use crate::{
-    bitcoin::{d::BitcoinD, poller, BitcoinInterface},
+    bitcoin::{poller, BitcoinInterface},
     config::Config,
     database::{
         sqlite::{FreshDbOptions, SqliteDb, SqliteDbError},


### PR DESCRIPTION
This is needed as part of https://github.com/wizardsardine/liana/pull/592 for both checking connectivity to the internal `bitcoind` and stopping it when closing Liana.