### PR TITLE
lib: non-blocking daemon shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ required-features = ["daemon"]
 [features]
 default = ["daemon"]
 daemon = ["libc"]
+nonblocking_shutdown = []
 
 [dependencies]
 # For managing transactions (it re-exports the bitcoin crate)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,10 +458,22 @@ impl DaemonHandle {
         Ok(())
     }
 
-    // NOTE: this moves out the data as it should not be reused after shutdown
     /// Shut down the Liana daemon.
     pub fn shutdown(self) {
         self.bitcoin_poller.stop();
+    }
+
+    /// Tell the daemon to shut down. This will return before the shutdown completes. The structure
+    /// must not be reused after triggering shutdown.
+    #[cfg(feature = "nonblocking_shutdown")]
+    pub fn trigger_shutdown(&self) {
+        self.bitcoin_poller.trigger_stop()
+    }
+
+    /// Whether the daemon has finished shutting down.
+    #[cfg(feature = "nonblocking_shutdown")]
+    pub fn shutdown_complete(&self) -> bool {
+        self.bitcoin_poller.is_stopped()
     }
 
     // We need a shutdown utility that does not move for implementing Drop for the DummyLiana


### PR DESCRIPTION
This makes it possible to trigger the shutdown of the daemon through the DaemonHandle, without having to block while waiting for the poller thread to join.

Incidently, this allows to avoid having to move `self` which in turns allows to fix a GUI bug (see
https://github.com/wizardsardine/liana/issues/622).