### PR TITLE
tests: don't wait for lianad to log on shutdown

### DIFF
--- a/tests/test_framework/lianad.py
+++ b/tests/test_framework/lianad.py
@@ -127,9 +127,6 @@ class Lianad(TailableProc):
     def stop(self, timeout=5):
         try:
             self.rpc.stop()
-            self.wait_for_log(
-                "Stopping the liana daemon.",
-            )
             self.proc.wait(timeout)
         except Exception as e:
             logging.error(f"{self.prefix} : error when calling stop: '{e}'")


### PR DESCRIPTION
It seems to be causing some races that i don't want to be investigating at the moment. It's redundant anyways as we are already checking for the return code of the process.

It's fixing the annoying "Process died while waiting for logs" when stopping the daemon. AKA:
> Yes it died i stopped it that's the point.