### PR TITLE
installer: remove legacy warning on incompatible descriptor.

### DIFF
--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -390,7 +390,7 @@ pub fn import_descriptor<'a>(
             form::Form::new("Descriptor", imported_descriptor, |msg| {
                 Message::DefineDescriptor(message::DefineDescriptor::ImportDescriptor(msg))
             })
-            .warning("Incompatible descriptor. Note that starting from v0.2 Liana requires extended keys in a descriptor to have an origin.")
+            .warning("Incompatible descriptor.")
             .size(20)
             .padding(10),
         )


### PR DESCRIPTION
Fixes #613.