### PR TITLE
cleanup bitcoind process management

### DIFF
--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -72,9 +72,12 @@ impl App {
 
     fn load_state(&mut self, menu: &Menu) -> Command<Message> {
         self.state = match menu {
-            menu::Menu::Settings => {
-                state::SettingsState::new(self.data_dir.clone(), self.wallet.clone()).into()
-            }
+            menu::Menu::Settings => state::SettingsState::new(
+                self.data_dir.clone(),
+                self.wallet.clone(),
+                self.internal_bitcoind.is_some(),
+            )
+            .into(),
             menu::Menu::Home => Home::new(self.wallet.clone(), &self.cache.coins).into(),
             menu::Menu::Coins => CoinsPanel::new(
                 &self.cache.coins,

--- a/gui/src/app/state/settings/bitcoind.rs
+++ b/gui/src/app/state/settings/bitcoind.rs
@@ -22,13 +22,19 @@ pub struct BitcoindSettingsState {
     warning: Option<Error>,
     config_updated: bool,
     daemon_is_external: bool,
+    bitcoind_is_internal: bool,
 
     settings: Vec<Box<dyn Setting>>,
     current: Option<usize>,
 }
 
 impl BitcoindSettingsState {
-    pub fn new(config: Option<Config>, cache: &Cache, daemon_is_external: bool) -> Self {
+    pub fn new(
+        config: Option<Config>,
+        cache: &Cache,
+        daemon_is_external: bool,
+        bitcoind_is_internal: bool,
+    ) -> Self {
         let settings = if let Some(config) = &config {
             vec![
                 BitcoindSettings::new(
@@ -44,6 +50,7 @@ impl BitcoindSettingsState {
 
         BitcoindSettingsState {
             daemon_is_external,
+            bitcoind_is_internal,
             warning: None,
             config_updated: false,
             settings,
@@ -106,7 +113,8 @@ impl State for BitcoindSettingsState {
     }
 
     fn view<'a>(&'a self, cache: &'a Cache) -> Element<'a, view::Message> {
-        let can_edit = self.current.is_none() && !self.daemon_is_external;
+        let can_edit =
+            self.current.is_none() && !self.daemon_is_external && !self.bitcoind_is_internal;
         view::settings::bitcoind_settings(
             cache,
             self.warning.as_ref(),

--- a/gui/src/app/state/settings/mod.rs
+++ b/gui/src/app/state/settings/mod.rs
@@ -32,14 +32,16 @@ pub struct SettingsState {
     data_dir: PathBuf,
     wallet: Arc<Wallet>,
     setting: Option<Box<dyn State>>,
+    internal_bitcoind: bool,
 }
 
 impl SettingsState {
-    pub fn new(data_dir: PathBuf, wallet: Arc<Wallet>) -> Self {
+    pub fn new(data_dir: PathBuf, wallet: Arc<Wallet>, internal_bitcoind: bool) -> Self {
         Self {
             data_dir,
             wallet,
             setting: None,
+            internal_bitcoind,
         }
     }
 }
@@ -58,6 +60,7 @@ impl State for SettingsState {
                         daemon.config().cloned(),
                         cache,
                         daemon.is_external(),
+                        self.internal_bitcoind,
                     )
                     .into(),
                 );

--- a/gui/src/bitcoind.rs
+++ b/gui/src/bitcoind.rs
@@ -1,8 +1,7 @@
 use liana::{config::BitcoindConfig, miniscript::bitcoin};
+use std::path::Path;
 
 use tracing::{info, warn};
-
-use crate::app::config::InternalBitcoindExeConfig;
 
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
@@ -51,10 +50,10 @@ impl std::fmt::Display for StartInternalBitcoindError {
 /// Start internal bitcoind for the given network.
 pub fn start_internal_bitcoind(
     network: &bitcoin::Network,
-    exe_config: InternalBitcoindExeConfig,
+    bitcoind_datadir: &Path,
+    exe_path: &Path,
 ) -> Result<std::process::Child, StartInternalBitcoindError> {
-    let datadir_path_str = exe_config
-        .data_dir
+    let datadir_path_str = bitcoind_datadir
         .canonicalize()
         .map_err(|e| StartInternalBitcoindError::CouldNotCanonicalizeDataDir(e.to_string()))?
         .to_str()
@@ -71,7 +70,7 @@ pub fn start_internal_bitcoind(
         format!("-chain={}", network.to_core_arg()),
         format!("-datadir={}", datadir_path_str),
     ];
-    let mut command = std::process::Command::new(exe_config.exe_path);
+    let mut command = std::process::Command::new(exe_path);
     #[cfg(target_os = "windows")]
     let command = command.creation_flags(CREATE_NO_WINDOW);
     command

--- a/gui/src/bitcoind.rs
+++ b/gui/src/bitcoind.rs
@@ -1,5 +1,6 @@
 use liana::{config::BitcoindConfig, miniscript::bitcoin};
 use std::path::Path;
+use std::sync::Arc;
 
 use tracing::{info, warn};
 
@@ -46,51 +47,89 @@ impl std::fmt::Display for StartInternalBitcoindError {
         }
     }
 }
-
-/// Start internal bitcoind for the given network.
-pub fn start_internal_bitcoind(
-    network: &bitcoin::Network,
-    bitcoind_datadir: &Path,
-    exe_path: &Path,
-) -> Result<std::process::Child, StartInternalBitcoindError> {
-    let datadir_path_str = bitcoind_datadir
-        .canonicalize()
-        .map_err(|e| StartInternalBitcoindError::CouldNotCanonicalizeDataDir(e.to_string()))?
-        .to_str()
-        .ok_or_else(|| {
-            StartInternalBitcoindError::CouldNotCanonicalizeDataDir(
-                "Couldn't convert path to str.".to_string(),
-            )
-        })?
-        .to_string();
-    #[cfg(target_os = "windows")]
-    // See https://github.com/rust-lang/rust/issues/42869.
-    let datadir_path_str = datadir_path_str.replace("\\\\?\\", "").replace("\\\\?", "");
-    let args = vec![
-        format!("-chain={}", network.to_core_arg()),
-        format!("-datadir={}", datadir_path_str),
-    ];
-    let mut command = std::process::Command::new(exe_path);
-    #[cfg(target_os = "windows")]
-    let command = command.creation_flags(CREATE_NO_WINDOW);
-    command
-        .args(&args)
-        .stdout(std::process::Stdio::null()) // We still get bitcoind's logs in debug.log.
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| StartInternalBitcoindError::CommandError(e.to_string()))
+#[derive(Debug, Clone)]
+pub struct Bitcoind {
+    _process: Arc<std::process::Child>,
+    pub config: BitcoindConfig,
 }
 
-/// Stop (internal) bitcoind.
-pub fn stop_internal_bitcoind(bitcoind_config: &BitcoindConfig) {
-    match liana::BitcoinD::new(bitcoind_config, "internal_bitcoind_stop".to_string()) {
-        Ok(bitcoind) => {
-            info!("Stopping internal bitcoind...");
-            bitcoind.stop();
-            info!("Stopped liana managed bitcoind");
+impl Bitcoind {
+    /// Start internal bitcoind for the given network.
+    pub fn start(
+        network: &bitcoin::Network,
+        mut config: BitcoindConfig,
+        bitcoind_datadir: &Path,
+        exe_path: &Path,
+    ) -> Result<Self, StartInternalBitcoindError> {
+        let datadir_path_str = bitcoind_datadir
+            .canonicalize()
+            .map_err(|e| StartInternalBitcoindError::CouldNotCanonicalizeDataDir(e.to_string()))?
+            .to_str()
+            .ok_or_else(|| {
+                StartInternalBitcoindError::CouldNotCanonicalizeDataDir(
+                    "Couldn't convert path to str.".to_string(),
+                )
+            })?
+            .to_string();
+
+        // See https://github.com/rust-lang/rust/issues/42869.
+        #[cfg(target_os = "windows")]
+        let datadir_path_str = datadir_path_str.replace("\\\\?\\", "").replace("\\\\?", "");
+
+        let args = vec![
+            format!("-chain={}", network.to_core_arg()),
+            format!("-datadir={}", datadir_path_str),
+        ];
+        let mut command = std::process::Command::new(exe_path);
+
+        #[cfg(target_os = "windows")]
+        let command = command.creation_flags(CREATE_NO_WINDOW);
+
+        let process = command
+            .args(&args)
+            .stdout(std::process::Stdio::null()) // We still get bitcoind's logs in debug.log.
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| StartInternalBitcoindError::CommandError(e.to_string()))?;
+
+        if !crate::utils::poll_for_file(&config.cookie_path, 200, 15) {
+            match process.wait_with_output() {
+                Err(e) => {
+                    tracing::error!("Error while waiting for bitcoind to finish: {}", e)
+                }
+                Ok(o) => {
+                    tracing::error!("Exit status: {}", o.status);
+                    tracing::error!("stderr: {}", String::from_utf8_lossy(&o.stderr));
+                }
+            }
+            return Err(StartInternalBitcoindError::CookieFileNotFound(
+                config.cookie_path.to_string_lossy().into_owned(),
+            ));
         }
-        Err(e) => {
-            warn!("Could not create interface to internal bitcoind: '{}'.", e);
+        config.cookie_path = config.cookie_path.canonicalize().map_err(|e| {
+            StartInternalBitcoindError::CouldNotCanonicalizeCookiePath(e.to_string())
+        })?;
+
+        liana::BitcoinD::new(&config, "internal_bitcoind_start".to_string())
+            .map_err(|e| StartInternalBitcoindError::BitcoinDError(e.to_string()))?;
+
+        Ok(Self {
+            config,
+            _process: Arc::new(process),
+        })
+    }
+
+    /// Stop (internal) bitcoind.
+    pub fn stop(&self) {
+        match liana::BitcoinD::new(&self.config, "internal_bitcoind_stop".to_string()) {
+            Ok(bitcoind) => {
+                info!("Stopping internal bitcoind...");
+                bitcoind.stop();
+                info!("Stopped liana managed bitcoind");
+            }
+            Err(e) => {
+                warn!("Could not create interface to internal bitcoind: '{}'.", e);
+            }
         }
     }
 }

--- a/gui/src/installer/context.rs
+++ b/gui/src/installer/context.rs
@@ -8,6 +8,7 @@ use crate::{
         settings::{KeySetting, Settings, WalletSetting},
         wallet::DEFAULT_WALLET_NAME,
     },
+    bitcoind::Bitcoind,
     hw::HardwareWalletConfig,
     signer::Signer,
 };
@@ -36,6 +37,7 @@ pub struct Context {
     pub bitcoind_is_external: bool,
     pub internal_bitcoind_config: Option<InternalBitcoindConfig>,
     pub internal_bitcoind_exe_config: Option<InternalBitcoindExeConfig>,
+    pub internal_bitcoind: Option<Bitcoind>,
 }
 
 impl Context {
@@ -55,6 +57,7 @@ impl Context {
             bitcoind_is_external: true,
             internal_bitcoind_config: None,
             internal_bitcoind_exe_config: None,
+            internal_bitcoind: None,
         }
     }
 

--- a/gui/src/installer/message.rs
+++ b/gui/src/installer/message.rs
@@ -5,7 +5,7 @@ use liana::miniscript::{
 use std::path::PathBuf;
 
 use super::Error;
-use crate::{download::Progress, hw::HardwareWallet};
+use crate::{bitcoind::Bitcoind, download::Progress, hw::HardwareWallet};
 use async_hwi::DeviceKind;
 
 #[derive(Debug, Clone)]
@@ -14,7 +14,7 @@ pub enum Message {
     ParticipateWallet,
     ImportWallet,
     UserActionDone(bool),
-    Exit(PathBuf),
+    Exit(PathBuf, Option<Bitcoind>),
     Clibpboard(String),
     Next,
     Skip,

--- a/gui/src/installer/mod.rs
+++ b/gui/src/installer/mod.rs
@@ -18,7 +18,6 @@ use std::sync::{Arc, Mutex};
 use crate::{
     app::config::InternalBitcoindExeConfig,
     app::{config as gui_config, settings as gui_settings},
-    bitcoind::stop_internal_bitcoind,
     signer::Signer,
 };
 
@@ -84,11 +83,10 @@ impl Installer {
             .expect("There is always a step")
             .stop();
         // Now use context to determine what to stop.
-        if self.context.internal_bitcoind_config.is_some() {
-            if let Some(bitcoind_config) = &self.context.bitcoind_config {
-                stop_internal_bitcoind(bitcoind_config);
-            }
+        if let Some(bitcoind) = &self.context.internal_bitcoind {
+            bitcoind.stop();
         }
+        self.context.internal_bitcoind = None;
     }
 
     fn next(&mut self) -> Command<Message> {

--- a/gui/src/installer/step/bitcoind.rs
+++ b/gui/src/installer/step/bitcoind.rs
@@ -865,16 +865,19 @@ impl Step for InternalBitcoindStep {
                                 return Command::none();
                             }
                         };
-                        let handle =
-                            match start_internal_bitcoind(&self.network, exe_config.clone()) {
-                                Err(e) => {
-                                    self.started = Some(Err(
-                                        StartInternalBitcoindError::CommandError(e.to_string()),
-                                    ));
-                                    return Command::none();
-                                }
-                                Ok(h) => h,
-                            };
+                        let handle = match start_internal_bitcoind(
+                            &self.network,
+                            &exe_config.data_dir,
+                            &exe_config.exe_path,
+                        ) {
+                            Err(e) => {
+                                self.started = Some(Err(StartInternalBitcoindError::CommandError(
+                                    e.to_string(),
+                                )));
+                                return Command::none();
+                            }
+                            Ok(h) => h,
+                        };
                         // Need to wait for cookie file to appear.
                         let cookie_path =
                             internal_bitcoind_cookie_path(&self.bitcoind_datadir, &self.network);

--- a/gui/src/installer/step/bitcoind.rs
+++ b/gui/src/installer/step/bitcoind.rs
@@ -133,30 +133,6 @@ fn download_url() -> String {
     )
 }
 
-pub struct DefineBitcoind {
-    cookie_path: form::Value<String>,
-    address: form::Value<String>,
-    is_running: Option<Result<(), Error>>,
-}
-
-pub struct InternalBitcoindStep {
-    liana_datadir: PathBuf,
-    bitcoind_datadir: PathBuf,
-    network: Network,
-    started: Option<Result<(), StartInternalBitcoindError>>,
-    exe_path: Option<PathBuf>,
-    bitcoind_config: Option<BitcoindConfig>,
-    exe_config: Option<InternalBitcoindExeConfig>,
-    internal_bitcoind_config: Option<InternalBitcoindConfig>,
-    error: Option<String>,
-    exe_download: Option<Download>,
-    install_state: Option<InstallState>,
-}
-
-pub struct SelectBitcoindTypeStep {
-    use_external: bool,
-}
-
 /// Default prune value used by internal bitcoind.
 pub const PRUNE_DEFAULT: u32 = 15_000;
 /// Default ports used by bitcoind across all networks.
@@ -511,6 +487,10 @@ pub fn port_is_valid(port: &u16) -> bool {
     !BITCOIND_DEFAULT_PORTS.contains(port)
 }
 
+pub struct SelectBitcoindTypeStep {
+    use_external: bool,
+}
+
 impl Default for SelectBitcoindTypeStep {
     fn default() -> Self {
         Self::new()
@@ -558,6 +538,12 @@ impl Step for SelectBitcoindTypeStep {
     fn view(&self, progress: (usize, usize)) -> Element<Message> {
         view::select_bitcoind_type(progress)
     }
+}
+
+pub struct DefineBitcoind {
+    cookie_path: form::Value<String>,
+    address: form::Value<String>,
+    is_running: Option<Result<(), Error>>,
 }
 
 impl DefineBitcoind {
@@ -680,6 +666,20 @@ impl From<DefineBitcoind> for Box<dyn Step> {
     fn from(s: DefineBitcoind) -> Box<dyn Step> {
         Box::new(s)
     }
+}
+
+pub struct InternalBitcoindStep {
+    liana_datadir: PathBuf,
+    bitcoind_datadir: PathBuf,
+    network: Network,
+    started: Option<Result<(), StartInternalBitcoindError>>,
+    exe_path: Option<PathBuf>,
+    bitcoind_config: Option<BitcoindConfig>,
+    exe_config: Option<InternalBitcoindExeConfig>,
+    internal_bitcoind_config: Option<InternalBitcoindConfig>,
+    error: Option<String>,
+    exe_download: Option<Download>,
+    install_state: Option<InstallState>,
 }
 
 impl From<InternalBitcoindStep> for Box<dyn Step> {

--- a/gui/src/installer/step/bitcoind.rs
+++ b/gui/src/installer/step/bitcoind.rs
@@ -12,14 +12,14 @@ use iced::{Command, Subscription};
 use liana::{config::BitcoindConfig, miniscript::bitcoin::Network};
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 use tar::Archive;
-use tracing::{error, info};
+use tracing::info;
 
 use jsonrpc::{client::Client, simple_http::SimpleHttpTransport};
 
 use liana_ui::{component::form, widget::*};
 
 use crate::{
-    bitcoind::{start_internal_bitcoind, stop_internal_bitcoind, StartInternalBitcoindError},
+    bitcoind::{Bitcoind, StartInternalBitcoindError},
     download,
     installer::{
         context::Context,
@@ -28,7 +28,6 @@ use crate::{
         step::Step,
         view, Error, InternalBitcoindExeConfig,
     },
-    utils::poll_for_file,
 };
 
 // The approach for tracking download progress is taken from
@@ -680,6 +679,7 @@ pub struct InternalBitcoindStep {
     error: Option<String>,
     exe_download: Option<Download>,
     install_state: Option<InstallState>,
+    internal_bitcoind: Option<Bitcoind>,
 }
 
 impl From<InternalBitcoindStep> for Box<dyn Step> {
@@ -702,6 +702,7 @@ impl InternalBitcoindStep {
             error: None,
             exe_download: None,
             install_state: None,
+            internal_bitcoind: None,
         }
     }
 }
@@ -727,11 +728,9 @@ impl Step for InternalBitcoindStep {
         if let Message::InternalBitcoind(msg) = message {
             match msg {
                 message::InternalBitcoindMsg::Previous => {
-                    if self.internal_bitcoind_config.is_some() {
-                        if let Some(bitcoind_config) = &self.bitcoind_config {
-                            stop_internal_bitcoind(bitcoind_config);
-                            self.started = None;
-                        }
+                    if let Some(bitcoind) = &self.internal_bitcoind {
+                        bitcoind.stop();
+                        self.started = None;
                     }
                     return Command::perform(async {}, |_| Message::Previous);
                 }
@@ -865,39 +864,9 @@ impl Step for InternalBitcoindStep {
                                 return Command::none();
                             }
                         };
-                        let handle = match start_internal_bitcoind(
-                            &self.network,
-                            &exe_config.data_dir,
-                            &exe_config.exe_path,
-                        ) {
-                            Err(e) => {
-                                self.started = Some(Err(StartInternalBitcoindError::CommandError(
-                                    e.to_string(),
-                                )));
-                                return Command::none();
-                            }
-                            Ok(h) => h,
-                        };
-                        // Need to wait for cookie file to appear.
                         let cookie_path =
                             internal_bitcoind_cookie_path(&self.bitcoind_datadir, &self.network);
-                        if !poll_for_file(&cookie_path, 200, 15) {
-                            error!("Cookie file still not present after 3 seconds. Waiting for the bitcoind process to finish.");
-                            match handle.wait_with_output() {
-                                Err(e) => {
-                                    error!("Error while waiting for bitcoind to finish: {}", e)
-                                }
-                                Ok(o) => {
-                                    error!("Exit status: {}", o.status);
-                                    error!("stderr: {}", String::from_utf8_lossy(&o.stderr));
-                                }
-                            }
-                            self.started =
-                                Some(Err(StartInternalBitcoindError::CookieFileNotFound(
-                                    cookie_path.to_string_lossy().into_owned(),
-                                )));
-                            return Command::none();
-                        }
+
                         let rpc_port = self
                             .internal_bitcoind_config
                             .as_ref()
@@ -907,36 +876,30 @@ impl Step for InternalBitcoindStep {
                             .get(&self.network)
                             .expect("Already added")
                             .rpc_port;
-                        let bitcoind_config = match cookie_path.canonicalize() {
-                            Ok(cookie_path) => BitcoindConfig {
+
+                        match Bitcoind::start(
+                            &self.network,
+                            BitcoindConfig {
                                 cookie_path,
                                 addr: internal_bitcoind_address(rpc_port),
                             },
+                            &exe_config.data_dir,
+                            &exe_config.exe_path,
+                        ) {
                             Err(e) => {
-                                self.started = Some(Err(
-                                    StartInternalBitcoindError::CouldNotCanonicalizeCookiePath(
-                                        e.to_string(),
-                                    ),
-                                ));
+                                self.started = Some(Err(StartInternalBitcoindError::CommandError(
+                                    e.to_string(),
+                                )));
                                 return Command::none();
                             }
-                        };
-                        match liana::BitcoinD::new(
-                            &bitcoind_config,
-                            "internal_bitcoind_connection_check".to_string(),
-                        ) {
-                            Ok(_) => {
+                            Ok(bitcoind) => {
                                 self.error = None;
-                                self.bitcoind_config = Some(bitcoind_config);
+                                self.bitcoind_config = Some(bitcoind.config.clone());
                                 self.exe_config = Some(exe_config);
                                 self.started = Some(Ok(()));
+                                self.internal_bitcoind = Some(bitcoind);
                             }
-                            Err(e) => {
-                                self.started = Some(Err(
-                                    StartInternalBitcoindError::BitcoinDError(e.to_string()),
-                                ));
-                            }
-                        }
+                        };
                     }
                 }
             };
@@ -978,6 +941,7 @@ impl Step for InternalBitcoindStep {
             ctx.bitcoind_config = self.bitcoind_config.clone();
             ctx.internal_bitcoind_config = self.internal_bitcoind_config.clone();
             ctx.internal_bitcoind_exe_config = self.exe_config.clone();
+            ctx.internal_bitcoind = self.internal_bitcoind.clone();
             self.error = None;
             return true;
         }
@@ -997,10 +961,8 @@ impl Step for InternalBitcoindStep {
 
     fn stop(&self) {
         // In case the installer is closed before changes written to context, stop bitcoind.
-        if let Some(Ok(_)) = self.started {
-            if let Some(bitcoind_config) = &self.bitcoind_config {
-                stop_internal_bitcoind(bitcoind_config);
-            }
+        if let Some(bitcoind) = &self.internal_bitcoind {
+            bitcoind.stop();
         }
     }
 

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -1248,7 +1248,10 @@ pub fn install<'a>(
                         .push(Container::new(text("Installed !")))
                         .push(Container::new(
                             button::primary(None, "Start")
-                                .on_press(Message::Exit(path.clone()))
+                                .on_press(Message::Exit(
+                                    path.clone(),
+                                    context.internal_bitcoind.clone(),
+                                ))
                                 .width(Length::Fixed(200.0)),
                         ))
                         .align_items(Alignment::Center)

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -361,8 +361,12 @@ pub async fn start_bitcoind_and_daemon(
                 info!("Internal bitcoind is already running");
             } else {
                 info!("Starting internal bitcoind");
-                start_internal_bitcoind(&config.bitcoin_config.network, exe_config)
-                    .map_err(Error::Bitcoind)?;
+                start_internal_bitcoind(
+                    &config.bitcoin_config.network,
+                    &exe_config.data_dir,
+                    &exe_config.exe_path,
+                )
+                .map_err(Error::Bitcoind)?;
                 if !utils::poll_for_file(&bitcoind_config.cookie_path, 200, 15) {
                     return Err(Error::Bitcoind(
                         StartInternalBitcoindError::CookieFileNotFound(


### PR DESCRIPTION
- Small rearrangements of the bitcoind module.
- Add a wrapper around the bitcoind child process and share it to the states:
  Installer -> loader -> app
- It makes it more easy to share the information if the gui started a bitcoind process, no need anymore to check multiple configuration files, just answer the question: do we have a child process started ?