### PR TITLE
gui: installer: more robust poll for cookie file at bitcoind startup

### DIFF
--- a/gui/src/utils/mod.rs
+++ b/gui/src/utils/mod.rs
@@ -1,21 +1,5 @@
-use std::path::Path;
-
 #[cfg(test)]
 pub mod sandbox;
 
 #[cfg(test)]
 pub mod mock;
-
-/// Polls for a file's existence at given interval up to a maximum number of polls.
-/// Returns `true` once file exists and otherwise `false`.
-pub fn poll_for_file(path: &Path, interval_millis: u64, max_polls: u16) -> bool {
-    for i in 0..max_polls {
-        if path.exists() {
-            return true;
-        }
-        if i < max_polls.saturating_sub(1) {
-            std::thread::sleep(std::time::Duration::from_millis(interval_millis));
-        }
-    }
-    false
-}


### PR DESCRIPTION
We would formerly wait a definite number of seconds for the cookie file to appear. But this approach presents a fundamental issue: how long is enough before we can be reasonably sure bitcoind will never start?

For instance on mainnet the checks performed at startup could take more than the 3 seconds we would previously wait for. If it does we would have incorrectly errored and let bitcoind run in the background.

Instead, assume bitcoind would exit if it errors. Until it does so, continue polling for the cookie file. This approach also presents drawbacks (for instance what if bitcoind is performing a very long operation before creating the cookie file?), but the former approach wouldn't be an acceptable solution in this case either. And the new one is preferable as its failure scenario seems much less probable.