### PR TITLE
gui: ensure we can retry starting in case of error

### DIFF
--- a/gui/src/installer/step/bitcoind.rs
+++ b/gui/src/installer/step/bitcoind.rs
@@ -652,9 +652,9 @@ impl Step for InternalBitcoindStep {
                 message::InternalBitcoindMsg::Previous => {
                     if let Some(bitcoind) = &self.internal_bitcoind {
                         bitcoind.stop();
-                        self.started = None;
                     }
                     self.internal_bitcoind = None;
+                    self.started = None; // clear both Ok and Err
                     return Command::perform(async {}, |_| Message::Previous);
                 }
                 message::InternalBitcoindMsg::Reload => {


### PR DESCRIPTION
This will ensure we can retry starting internal `bitcoind` in case of transient errors.