### PR TITLE
GUI: installer: don't generate multiple times the same xpub in "participate"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 This release significantly simplifies the installation of Liana. It also fixes a number of small
 bugs and glitches.
 
+### Breaking changes
+
+- Descriptors created with Liana v2 may not be backward compatible with Liana v1.
+
 ### Features
 
 - We made it possible to re-use an xpub within a descriptor, so long as it uses a different

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -480,17 +480,6 @@ pub fn signer_xpubs(xpubs: &Vec<String>) -> Element<Message> {
                             ),
                     )
                 }))
-            })
-            .push_maybe(if !xpubs.is_empty() {
-                Some(
-                    Container::new(
-                        button::secondary(Some(icon::plus_icon()), "New public key")
-                            .on_press(Message::UseHotSigner),
-                    )
-                    .padding(10),
-                )
-            } else {
-                None
             }),
     )
     .style(theme::Container::Card(theme::Card::Simple))
@@ -563,19 +552,6 @@ pub fn hardware_wallet_xpubs<'a>(
                             ),
                     )
                 }))
-            })
-            .push_maybe(if !xpubs.is_empty() {
-                Some(
-                    Container::new(if !processing {
-                        button::secondary(Some(icon::plus_icon()), "New public key")
-                            .on_press(Message::Select(i))
-                    } else {
-                        button::secondary(Some(icon::plus_icon()), "New public key")
-                    })
-                    .padding(10),
-                )
-            } else {
-                None
             }),
     )
     .style(theme::Container::Card(theme::Card::Simple))
@@ -642,7 +618,7 @@ pub fn participate_xpub<'a>(
                     .width(Length::Fill),
             )
             .push(checkbox(
-                "I have shared my public keys",
+                "I have shared my extended public key",
                 shared,
                 Message::UserActionDone,
             ))


### PR DESCRIPTION
This is a quick and dirty fix to be backported. Doing something like #291 could make sense in the future.