### PR TITLE
commands: optionally filter `listcoins` by status and outpoint

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -81,14 +81,20 @@ This command does not take any parameter for now.
 
 ### `listcoins`
 
-List all our transaction outputs, regardless of their state (unspent or not).
+List all our transaction outputs, optionally filtered by status and/or outpoint.
 
 #### Request
 
-This command does not take any parameter for now.
+| Field          | Type              | Description                                                       |
+| -------------- | ----------------- | ----------------------------------------------------------------- |
+| `statuses`     | list of string    | List of statuses to filter coins by (see below).                  |
+| `outpoints`    | list of string    | List of outpoints to filter coins by, as `txid:vout`.             |
 
-| Field         | Type              | Description                                                 |
-| ------------- | ----------------- | ----------------------------------------------------------- |
+A coin may have one of the following four statuses:
+- `unconfirmed`: deposit transaction has not yet been included in a block and coin has not been included in a spend transaction
+- `confirmed`: deposit transaction has been included in a block and coin has not been included in a spend transaction
+- `spending`: coin (whose deposit transaction may not yet have been confirmed) has been included in an unconfirmed spend transaction
+- `spent`: coin has been included in a confirmed spend transaction
 
 #### Response
 

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -1,6 +1,6 @@
 use crate::{
     bitcoin::{BitcoinInterface, BlockChainTip, UTxO},
-    database::{Coin, CoinType, DatabaseConnection, DatabaseInterface},
+    database::{Coin, DatabaseConnection, DatabaseInterface},
     descriptors,
 };
 
@@ -34,7 +34,7 @@ fn update_coins(
     secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
 ) -> UpdatedCoins {
     let network = db_conn.network();
-    let curr_coins = db_conn.coins(CoinType::All);
+    let curr_coins = db_conn.coins(&[], &[]);
     log::debug!("Current coins: {:?}", curr_coins);
 
     // Start by fetching newly received coins.

--- a/src/database/sqlite/mod.rs
+++ b/src/database/sqlite/mod.rs
@@ -487,7 +487,7 @@ impl SqliteConn {
         .expect("Database must be available")
     }
 
-    /// Mark a set of coins as spent.
+    /// Mark a set of coins as spending.
     pub fn spend_coins<'a>(
         &mut self,
         outpoints: impl IntoIterator<Item = &'a (bitcoin::OutPoint, bitcoin::Txid)>,

--- a/src/database/sqlite/mod.rs
+++ b/src/database/sqlite/mod.rs
@@ -422,13 +422,7 @@ impl SqliteConn {
 
     /// List coins that are being spent and whose spending transaction is still unconfirmed.
     pub fn list_spending_coins(&mut self) -> Vec<DbCoin> {
-        db_query(
-            &mut self.conn,
-            "SELECT * FROM coins WHERE spend_txid IS NOT NULL AND spend_block_time IS NULL",
-            rusqlite::params![],
-            |row| row.try_into(),
-        )
-        .expect("Db must not fail")
+        self.coins(&[CoinStatus::Spending], &[])
     }
 
     // FIXME: don't take the whole coin, we don't need it.


### PR DESCRIPTION
This is to resolve #676.

I've renamed `CoinType` to `CoinStatus` and updated its values.

The `listcoins` command and related functions can be optionally filtered by coin status and/or outpoint.

Opening this as draft to check that I'm on the right track.

Remaining tasks:
- [x] Update tests
- [x] Update API doc
- [x] Possibly use the updated functions elsewhere, e.g. `list_spending_coins()`