### PR TITLE
installer: Finalize installation and start automatically on final step

### DIFF
--- a/gui/src/installer/mod.rs
+++ b/gui/src/installer/mod.rs
@@ -120,7 +120,6 @@ impl Installer {
     }
 
     pub fn update(&mut self, message: Message) -> Command<Message> {
-        let hot_signer_fingerprint = self.signer.lock().unwrap().fingerprint();
         match message {
             Message::CreateWallet => {
                 self.steps = vec![
@@ -132,7 +131,7 @@ impl Installer {
                     SelectBitcoindTypeStep::new().into(),
                     InternalBitcoindStep::new(&self.context.data_dir).into(),
                     DefineBitcoind::new().into(),
-                    Final::new(hot_signer_fingerprint).into(),
+                    Final::new().into(),
                 ];
                 self.next()
             }
@@ -147,7 +146,7 @@ impl Installer {
                     SelectBitcoindTypeStep::new().into(),
                     InternalBitcoindStep::new(&self.context.data_dir).into(),
                     DefineBitcoind::new().into(),
-                    Final::new(hot_signer_fingerprint).into(),
+                    Final::new().into(),
                 ];
                 self.next()
             }
@@ -160,7 +159,7 @@ impl Installer {
                     SelectBitcoindTypeStep::new().into(),
                     InternalBitcoindStep::new(&self.context.data_dir).into(),
                     DefineBitcoind::new().into(),
-                    Final::new(hot_signer_fingerprint).into(),
+                    Final::new().into(),
                 ];
                 self.next()
             }

--- a/gui/src/installer/step/mod.rs
+++ b/gui/src/installer/step/mod.rs
@@ -16,7 +16,6 @@ pub use mnemonic::{BackupMnemonic, RecoverMnemonic};
 use std::path::PathBuf;
 
 use iced::{Command, Subscription};
-use liana::miniscript::bitcoin::bip32::Fingerprint;
 
 use liana_ui::widget::*;
 
@@ -66,40 +65,28 @@ pub struct Final {
     internal_bitcoind: Option<Bitcoind>,
     warning: Option<String>,
     config_path: Option<PathBuf>,
-    hot_signer_fingerprint: Fingerprint,
-    hot_signer_is_not_used: bool,
 }
 
 impl Final {
-    pub fn new(hot_signer_fingerprint: Fingerprint) -> Self {
+    pub fn new() -> Self {
         Self {
             internal_bitcoind: None,
             generating: false,
             warning: None,
             config_path: None,
-            hot_signer_fingerprint,
-            hot_signer_is_not_used: false,
         }
+    }
+}
+
+impl Default for Final {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 impl Step for Final {
     fn load_context(&mut self, ctx: &Context) {
         self.internal_bitcoind = ctx.internal_bitcoind.clone();
-        if let Some(signer) = &ctx.recovered_signer {
-            self.hot_signer_fingerprint = signer.fingerprint();
-            self.hot_signer_is_not_used = false;
-        } else if ctx
-            .descriptor
-            .as_ref()
-            .unwrap()
-            .to_string()
-            .contains(&self.hot_signer_fingerprint.to_string())
-        {
-            self.hot_signer_is_not_used = false;
-        } else {
-            self.hot_signer_is_not_used = true;
-        }
     }
     fn load(&self) -> Command<Message> {
         if !self.generating && self.config_path.is_none() {

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -302,7 +302,7 @@ pub fn define_descriptor<'a>(
             .push(Space::with_height(Length::Fixed(20.0)))
             .spacing(50),
         false,
-        None,
+        Some(Message::Previous),
     )
 }
 
@@ -422,7 +422,7 @@ pub fn import_descriptor<'a>(
             .push_maybe(error.map(|e| card::error("Invalid descriptor", e.to_string())))
             .spacing(50),
         true,
-        None,
+        Some(Message::Previous),
     )
 }
 
@@ -630,7 +630,7 @@ pub fn participate_xpub<'a>(
             })
             .spacing(50),
         true,
-        None,
+        Some(Message::Previous),
     )
 }
 
@@ -722,7 +722,7 @@ pub fn register_descriptor<'a>(
             })
             .spacing(50),
         true,
-        None,
+        Some(Message::Previous),
     )
 }
 
@@ -790,7 +790,7 @@ pub fn backup_descriptor<'a>(
             })
             .spacing(50),
         true,
-        None,
+        Some(Message::Previous),
     )
 }
 
@@ -877,7 +877,7 @@ pub fn define_bitcoin<'a>(
             )
             .spacing(50),
         true,
-        None,
+        Some(Message::Previous),
     )
 }
 
@@ -971,7 +971,7 @@ pub fn select_bitcoind_type<'a>(progress: (usize, usize)) -> Element<'a, Message
                 ),
         ),
         true,
-        None,
+        Some(Message::Previous),
     )
 }
 
@@ -1093,6 +1093,11 @@ pub fn install<'a>(
     config_path: Option<&std::path::PathBuf>,
     warning: Option<&'a String>,
 ) -> Element<'a, Message> {
+    let prev_msg = if !generating && warning.is_some() {
+        Some(Message::Previous)
+    } else {
+        None
+    };
     layout(
         progress,
         "Finalize installation",
@@ -1114,7 +1119,7 @@ pub fn install<'a>(
             .spacing(10)
             .width(Length::Fill),
         true,
-        None,
+        prev_msg,
     )
 }
 
@@ -1624,7 +1629,7 @@ pub fn backup_mnemonic<'a>(
             })
             .spacing(50),
         true,
-        None,
+        Some(Message::Previous),
     )
 }
 
@@ -1727,7 +1732,7 @@ pub fn recover_mnemonic<'a>(
             })
             .spacing(50),
         true,
-        None,
+        Some(Message::Previous),
     )
 }
 
@@ -1738,6 +1743,10 @@ fn layout<'a>(
     padding_left: bool,
     previous_message: Option<Message>,
 ) -> Element<'a, Message> {
+    let mut prev_button = button::transparent(Some(icon::previous_icon()), "Previous");
+    if let Some(msg) = previous_message {
+        prev_button = prev_button.on_press(msg);
+    }
     Container::new(scrollable(
         Column::new()
             .width(Length::Fill)
@@ -1746,12 +1755,9 @@ fn layout<'a>(
                 Row::new()
                     .align_items(Alignment::Center)
                     .push(
-                        Container::new(
-                            button::transparent(Some(icon::previous_icon()), "Previous")
-                                .on_press(previous_message.unwrap_or(Message::Previous)),
-                        )
-                        .width(Length::FillPortion(2))
-                        .center_x(),
+                        Container::new(prev_button)
+                            .width(Length::FillPortion(2))
+                            .center_x(),
                     )
                     .push(Container::new(h3(title)).width(Length::FillPortion(8)))
                     .push(


### PR DESCRIPTION
This is to resolve #679.

The following changes have been made:
- Change title of final step to "Finalize installation"
- Install and load wallet automatically when reaching final step
- Remove fields from `Final` step that are no longer used

This is how the page looks when installing:
![image](https://github.com/wizardsardine/liana/assets/121959000/a5f2b35d-4c4b-4316-9b7b-744a19daf597)

The following is only shown for ~1 sec once wallet has been installed and before loading wallet:
![image](https://github.com/wizardsardine/liana/assets/121959000/830240a1-860c-4c89-890a-e1fb91adfc25)
