### PR TITLE
installer: show message when starting already-installed bitcoind

### DIFF
--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -1064,15 +1064,17 @@ pub fn start_internal_bitcoind<'a>(
                         )
                     }
                 })
-            } else if let Some(InstallState::Finished) = install_state {
-                Some(Container::new(
-                    Row::new()
-                        .spacing(10)
-                        .align_items(Alignment::Center)
-                        .push(text("Starting...")),
-                ))
             } else {
-                Some(Container::new(Space::with_height(Length::Fixed(25.0))))
+                match (install_state, exe_path) {
+                    // We have either just installed bitcoind or it was already installed.
+                    (Some(InstallState::Finished), _) | (None, Some(_)) => Some(Container::new(
+                        Row::new()
+                            .spacing(10)
+                            .align_items(Alignment::Center)
+                            .push(text("Starting...")),
+                    )),
+                    _ => Some(Container::new(Space::with_height(Length::Fixed(25.0)))),
+                }
             })
             .spacing(50)
             .push(


### PR DESCRIPTION
This is to resolve #714.

The "Starting..." message will now be shown also in case bitcoind was already installed on a previous occasion:

![image](https://github.com/wizardsardine/liana/assets/121959000/dd385962-4fee-43e7-9177-96ff8b538e3f)
