### PR TITLE
gui: show more info on synchronisation screen

### DIFF
--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -31,6 +31,10 @@ use crate::{
     daemon::{client, embedded::EmbeddedDaemon, model::*, Daemon, DaemonError},
 };
 
+const SYNCING_PROGRESS_1: &str = "Bitcoin Core is synchronising the blockchain. A full synchronisation typically take a few days, and is resource intensive. Once the initial synchronisation is done, the next ones will be much faster.";
+const SYNCING_PROGRESS_2: &str = "Bitcoin Core is synchronising the blockchain. This will take a while, depending on the last time it was done, your internet connection, and your computer performance.";
+const SYNCING_PROGRESS_3: &str = "Bitcoin Core is synchronising the blockchain. This may take a few minutes, depending on the last time it was done, your internet connection, and your computer performance.";
+
 type Lianad = client::Lianad<client::jsonrpc::JsonRPCClient>;
 
 pub struct Loader {
@@ -358,8 +362,16 @@ pub fn view(step: &Step) -> Element<ViewMessage> {
             None,
             Column::new()
                 .width(Length::Fill)
+                .spacing(5)
+                .push(text(format!("Progress {:.2}%", 100.0 * *progress)))
                 .push(ProgressBar::new(0.0..=1.0, *progress as f32).width(Length::Fill))
-                .push(text("Syncing the wallet with the blockchain..."))
+                .push(text(if *progress > 0.98 {
+                    SYNCING_PROGRESS_3
+                } else if *progress > 0.9 {
+                    SYNCING_PROGRESS_2
+                } else {
+                    SYNCING_PROGRESS_1
+                }))
                 .push(p2_regular(bitcoind_logs).style(color::GREY_3)),
         ),
         Step::Error(error) => cover(


### PR DESCRIPTION
This is to resolve #646.

I've added the specified text to the synchronisation screen and also display the progress as a percentage above the progress bar.

This is how it looks (on signet with Liana-managed bitcoind):

![image](https://github.com/wizardsardine/liana/assets/121959000/c274a373-3691-4035-a04e-e443853a4074)

![image](https://github.com/wizardsardine/liana/assets/121959000/bc2e9055-a9d6-4f68-b303-0ffa82bc08ab)

![image](https://github.com/wizardsardine/liana/assets/121959000/1a58a21c-f5ee-403e-bf40-09bdb1a6bf6f)

Also, for external bitcoind:

![image](https://github.com/wizardsardine/liana/assets/121959000/e85efe6c-9f45-4cf7-97ba-15e40492655d)
