### PR TITLE
bitcoind: don't set load_on_startup when loading watchonly wallet

### DIFF
--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -652,10 +652,7 @@ impl BitcoinD {
         }
         let res = self.make_fallible_node_request(
             "loadwallet",
-            &params!(
-                Json::String(self.watchonly_wallet_path.clone()),
-                Json::Bool(true), // load_on_startup
-            ),
+            &params!(Json::String(self.watchonly_wallet_path.clone()),),
         );
         match res {
             Err(BitcoindError::Server(jsonrpc::Error::Rpc(ref e))) => {


### PR DESCRIPTION
This was necessary to transition wallets that were created without this flag, but since v2 they are always created with it so this is redundant: it'd unnecessarily try to update the flag over and over again on bitcoind's side, always with the same value.

Fixes #641.