### PR TITLE
gui: display (estimated) feerate

### DIFF
--- a/gui/src/app/state/recovery.rs
+++ b/gui/src/app/state/recovery.rs
@@ -155,7 +155,7 @@ impl State for RecoveryPanel {
                                 .cloned()
                                 .collect();
                             let sigs = desc.partial_spend_info(&psbt).unwrap();
-                            Ok(SpendTx::new(None, psbt, coins, sigs))
+                            Ok(SpendTx::new(None, psbt, coins, sigs, desc.max_sat_vbytes()))
                         },
                         Message::Recovery,
                     );

--- a/gui/src/app/state/spend/step.rs
+++ b/gui/src/app/state/spend/step.rs
@@ -432,7 +432,13 @@ impl Step for SaveSpend {
             .unwrap();
         self.spend = Some(psbt::PsbtState::new(
             self.wallet.clone(),
-            SpendTx::new(None, psbt, draft.inputs.clone(), sigs),
+            SpendTx::new(
+                None,
+                psbt,
+                draft.inputs.clone(),
+                sigs,
+                self.wallet.main_descriptor.max_sat_vbytes(),
+            ),
             false,
         ));
     }

--- a/gui/src/app/view/home.rs
+++ b/gui/src/app/view/home.rs
@@ -210,6 +210,15 @@ pub fn payment_view<'a>(
                     .align_items(Alignment::Center)
                     .push(h3("Miner fee: ").style(color::GREY_3))
                     .push(amount_with_size(&fee_amount, H3_SIZE))
+                    .push(text(" ").size(H3_SIZE))
+                    .push(
+                        text(format!(
+                            "({} sats/vbyte)",
+                            fee_amount.to_sat() / tx.tx.vsize() as u64
+                        ))
+                        .size(H4_SIZE)
+                        .style(color::GREY_3),
+                    )
             }))
             .push(card::simple(
                 Column::new()

--- a/gui/src/app/view/psbt.rs
+++ b/gui/src/app/view/psbt.rs
@@ -196,7 +196,13 @@ pub fn spend_header<'a>(tx: &SpendTx) -> Element<'a, Message> {
                     Row::new()
                         .align_items(Alignment::Center)
                         .push(h3("Miner fee: ").style(color::GREY_3))
-                        .push(amount_with_size(&tx.fee_amount, H3_SIZE)),
+                        .push(amount_with_size(&tx.fee_amount, H3_SIZE))
+                        .push(text(" ").size(H3_SIZE))
+                        .push(
+                            text(format!("(~{} sats/vbyte)", &tx.min_feerate_vb()))
+                                .size(H4_SIZE)
+                                .style(color::GREY_3),
+                        ),
                 ),
         )
         .into()

--- a/gui/src/app/view/transactions.rs
+++ b/gui/src/app/view/transactions.rs
@@ -171,6 +171,15 @@ pub fn tx_view<'a>(
                                 .align_items(Alignment::Center)
                                 .push(h3("Miner fee: ").style(color::GREY_3))
                                 .push(amount_with_size(&fee_amount, H3_SIZE))
+                                .push(text(" ").size(H3_SIZE))
+                                .push(
+                                    text(format!(
+                                        "({} sats/vbyte)",
+                                        fee_amount.to_sat() / tx.tx.vsize() as u64
+                                    ))
+                                    .size(H4_SIZE)
+                                    .style(color::GREY_3),
+                                )
                         })),
                 ),
             )

--- a/gui/src/daemon/mod.rs
+++ b/gui/src/daemon/mod.rs
@@ -97,7 +97,13 @@ pub trait Daemon: Debug {
                 .main
                 .partial_spend_info(&tx.psbt)
                 .map_err(|e| DaemonError::Unexpected(e.to_string()))?;
-            spend_txs.push(model::SpendTx::new(tx.updated_at, tx.psbt, coins, sigs))
+            spend_txs.push(model::SpendTx::new(
+                tx.updated_at,
+                tx.psbt,
+                coins,
+                sigs,
+                info.descriptors.main.max_sat_vbytes(),
+            ))
         }
         spend_txs.sort_by(|a, b| {
             if a.status == b.status {


### PR DESCRIPTION
This is to resolve #558.

For transactions that have been broadcast, the feerate is calculated using the transaction's actual size. For PSBTs, the feerate is calculated using the max satisfaction size for all inputs, whether they have been signed or not (see https://github.com/wizardsardine/liana/issues/558#issuecomment-1750128022).

In both cases, the calculated feerate currently has type `u64`.

This is an example of a transaction on the Home tab:
![image](https://github.com/wizardsardine/liana/assets/121959000/ad81094f-ac16-4dd4-9229-75dbda2ca5b5)

The same transaction on the Transactions tab:
![image](https://github.com/wizardsardine/liana/assets/121959000/576f3f1f-81c0-4f1f-8f9d-fc4e1fdec000)

On the PSBTs tab, the feerate is an estimate:
![image](https://github.com/wizardsardine/liana/assets/121959000/cf7a4d44-fe5e-44a8-b9bb-e429e76540a5)
