### PR TITLE
Make sure we're actuall caught up to tip before starting up

### DIFF
--- a/src/bitcoin/d/mod.rs
+++ b/src/bitcoin/d/mod.rs
@@ -751,12 +751,10 @@ impl BitcoinD {
     pub fn sync_progress(&self) -> SyncProgress {
         // TODO: don't harass lianad, be smarter like in revaultd.
         let chain_info = self.block_chain_info();
-        let percentage = roundup_progress(
-            chain_info
-                .get("verificationprogress")
-                .and_then(Json::as_f64)
-                .expect("No valid 'verificationprogress' in getblockchaininfo response?"),
-        );
+        let percentage = chain_info
+            .get("verificationprogress")
+            .and_then(Json::as_f64)
+            .expect("No valid 'verificationprogress' in getblockchaininfo response?");
         let headers = chain_info
             .get("headers")
             .and_then(Json::as_u64)
@@ -1140,11 +1138,37 @@ impl BitcoinD {
 #[derive(Debug, Clone, Copy)]
 pub struct SyncProgress {
     /// Chain verification progress as a percentage between 0 and 1.
-    pub percentage: f64,
+    percentage: f64,
     /// Headers count for the best known tip.
     pub headers: u64,
     /// Number of blocks validated toward the best known tip.
     pub blocks: u64,
+}
+
+impl SyncProgress {
+    pub fn new(percentage: f64, headers: u64, blocks: u64) -> Self {
+        Self {
+            percentage,
+            headers,
+            blocks,
+        }
+    }
+
+    /// Get the verification progress, roundup up to to three decimal places. This will not return
+    /// 1.0 (ie 100% verification progress) until the verification is complete.
+    pub fn rounded_up_progress(&self) -> f64 {
+        let progress = roundup_progress(self.percentage);
+        if progress == 1.0 && self.blocks != self.headers {
+            // Don't return a 100% progress until we are actually done syncing.
+            0.999
+        } else {
+            progress
+        }
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.rounded_up_progress() == 1.0
+    }
 }
 
 /// An entry in the 'listdescriptors' result.

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     bitcoin::d::{BitcoindError, CachedTxGetter, LSBlockEntry},
     descriptors,
 };
+pub use d::SyncProgress;
 
 use std::{fmt, sync};
 
@@ -42,8 +43,9 @@ pub trait BitcoinInterface: Send {
     fn genesis_block(&self) -> BlockChainTip;
 
     /// Get the progress of the block chain synchronization.
-    /// Returns a percentage between 0 and 1.
-    fn sync_progress(&self) -> f64;
+    /// Returns a rounded up percentage between 0 and 1. Use the `is_synced` method to be sure the
+    /// backend is completely synced to the best known tip.
+    fn sync_progress(&self) -> SyncProgress;
 
     /// Get the best block info.
     fn chain_tip(&self) -> BlockChainTip;
@@ -117,7 +119,7 @@ impl BitcoinInterface for d::BitcoinD {
         BlockChainTip { hash, height }
     }
 
-    fn sync_progress(&self) -> f64 {
+    fn sync_progress(&self) -> SyncProgress {
         self.sync_progress()
     }
 
@@ -333,7 +335,7 @@ impl BitcoinInterface for sync::Arc<sync::Mutex<dyn BitcoinInterface + 'static>>
         self.lock().unwrap().genesis_block()
     }
 
-    fn sync_progress(&self) -> f64 {
+    fn sync_progress(&self) -> SyncProgress {
         self.lock().unwrap().sync_progress()
     }
 

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -358,8 +358,10 @@ pub fn looper(
         if !synced {
             let progress = bit.sync_progress();
             log::info!(
-                "Block chain synchronization progress: {:.2}%",
-                progress.rounded_up_progress() * 100.0
+                "Block chain synchronization progress: {:.2}% ({} blocks / {} headers)",
+                progress.rounded_up_progress() * 100.0,
+                progress.blocks,
+                progress.headers
             );
             synced = progress.is_complete();
             if !synced {

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bitcoin::{BitcoinInterface, BlockChainTip, SyncProgress, UTxO},
+    bitcoin::{BitcoinInterface, BlockChainTip, UTxO},
     database::{Coin, DatabaseConnection, DatabaseInterface},
     descriptors,
 };
@@ -356,16 +356,12 @@ pub fn looper(
 
         // Don't poll until the Bitcoin backend is fully synced.
         if !synced {
-            let SyncProgress {
-                percentage,
-                headers,
-                blocks,
-            } = bit.sync_progress();
+            let progress = bit.sync_progress();
             log::info!(
                 "Block chain synchronization progress: {:.2}%",
-                percentage * 100.0
+                progress.rounded_up_progress() * 100.0
             );
-            synced = headers == blocks;
+            synced = progress.is_complete();
             if !synced {
                 continue;
             }

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bitcoin::{BitcoinInterface, BlockChainTip, UTxO},
+    bitcoin::{BitcoinInterface, BlockChainTip, SyncProgress, UTxO},
     database::{Coin, DatabaseConnection, DatabaseInterface},
     descriptors,
 };
@@ -356,12 +356,16 @@ pub fn looper(
 
         // Don't poll until the Bitcoin backend is fully synced.
         if !synced {
-            let sync_progress = bit.sync_progress();
+            let SyncProgress {
+                percentage,
+                headers,
+                blocks,
+            } = bit.sync_progress();
             log::info!(
                 "Block chain synchronization progress: {:.2}%",
-                sync_progress * 100.0
+                percentage * 100.0
             );
-            synced = sync_progress == 1.0;
+            synced = headers == blocks;
             if !synced {
                 continue;
             }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -263,7 +263,7 @@ impl DaemonControl {
             version: VERSION.to_string(),
             network: self.config.bitcoin_config.network,
             block_height,
-            sync: self.bitcoin.sync_progress(),
+            sync: self.bitcoin.sync_progress().percentage,
             descriptors: GetInfoDescriptors {
                 main: self.config.main_descriptor.clone(),
             },

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -263,7 +263,7 @@ impl DaemonControl {
             version: VERSION.to_string(),
             network: self.config.bitcoin_config.network,
             block_height,
-            sync: self.bitcoin.sync_progress().percentage,
+            sync: self.bitcoin.sync_progress().rounded_up_progress(),
             descriptors: GetInfoDescriptors {
                 main: self.config.main_descriptor.clone(),
             },

--- a/src/descriptors/mod.rs
+++ b/src/descriptors/mod.rs
@@ -830,7 +830,6 @@ mod tests {
         assert_eq!(signed_single_psbt.inputs[0].partial_sigs.len(), 1);
         assert_eq!(info.primary_path.threshold, 1);
         assert_eq!(info.primary_path.sigs_count, 1);
-        dbg!(&info.primary_path.signed_pubkeys);
         assert!(
             info.primary_path.signed_pubkeys.len() == 1
                 && info.primary_path.signed_pubkeys.contains_key(&prim_key_fg)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -671,7 +671,7 @@ mod tests {
     // Send them a response to 'getblockchaininfo' saying we are far from being synced
     fn complete_sync_check(server: &net::TcpListener) {
         let net_resp = [
-            "HTTP/1.1 200\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"verificationprogress\":0.1}}\n".as_bytes(),
+            "HTTP/1.1 200\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"verificationprogress\":0.1,\"headers\":1000,\"blocks\":100}}\n".as_bytes(),
         ]
         .concat();
         let (mut stream, _) = server.accept().unwrap();

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -43,11 +43,7 @@ impl BitcoinInterface for DummyBitcoind {
     }
 
     fn sync_progress(&self) -> SyncProgress {
-        SyncProgress {
-            percentage: 1.0,
-            headers: 1_000,
-            blocks: 1_000,
-        }
+        SyncProgress::new(1.0, 1_000, 1_000)
     }
 
     fn chain_tip(&self) -> BlockChainTip {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bitcoin::{BitcoinInterface, Block, BlockChainTip, UTxO},
+    bitcoin::{BitcoinInterface, Block, BlockChainTip, SyncProgress, UTxO},
     config::{BitcoinConfig, Config},
     database::{BlockInfo, Coin, CoinStatus, DatabaseConnection, DatabaseInterface, LabelItem},
     descriptors, DaemonHandle,
@@ -42,8 +42,12 @@ impl BitcoinInterface for DummyBitcoind {
         BlockChainTip { hash, height: 0 }
     }
 
-    fn sync_progress(&self) -> f64 {
-        1.0
+    fn sync_progress(&self) -> SyncProgress {
+        SyncProgress {
+            percentage: 1.0,
+            headers: 1_000,
+            blocks: 1_000,
+        }
     }
 
     fn chain_tip(&self) -> BlockChainTip {


### PR DESCRIPTION
Fixes #726. We actually do update our internal state before we are synced but we weren't waiting for the chain to be entirely synced.