### PR TITLE
commands: add weights before converting to vbytes

### DIFF
--- a/src/descriptors/mod.rs
+++ b/src/descriptors/mod.rs
@@ -17,7 +17,7 @@ pub use keys::*;
 pub mod analysis;
 pub use analysis::*;
 
-const WITNESS_FACTOR: usize = 4;
+pub const WITNESS_FACTOR: usize = 4;
 
 #[derive(Debug)]
 pub enum LianaDescError {


### PR DESCRIPTION
The `sanity_check_psbt()` function checks, among other things, that the feerate in sats/vbytes is in the required range. When estimating the transaction size, converting each part to vbytes first can lead to a larger result due to rounding multiple times and therefore a lower feerate, which could fall below 1 and fail the sanity check.

This issue has arisen in #560 when creating a transaction using coin selection.