### PR TITLE
Delete empty labels when they are updated

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -314,6 +314,7 @@ cover the requested feerate.
 
 Update the labels from a given map of key/value, with the labelled bitcoin addresses, txids and outpoints as keys
 and the label as value. If a label already exist for the given item, the new label overrides the previous one. 
+In order to delete a label, the client has to send a `null` as json value.
 
 #### Request
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -592,9 +592,24 @@ impl DaemonControl {
         Ok(())
     }
 
-    pub fn update_labels(&self, items: &HashMap<LabelItem, String>) {
+    pub fn update_labels(&self, items: &HashMap<LabelItem, Option<String>>) {
         let mut db_conn = self.db.connection();
-        db_conn.update_labels(items);
+        let mut update_labels = HashMap::<LabelItem, String>::new();
+        let mut delete_labels = Vec::<LabelItem>::new();
+        for (item, label) in items {
+            if let Some(label) = label {
+                update_labels.insert(item.clone(), label.clone());
+            } else {
+                delete_labels.push(item.clone());
+            }
+        }
+
+        if !update_labels.is_empty() {
+            db_conn.update_labels(&update_labels);
+        }
+        if !delete_labels.is_empty() {
+            db_conn.delete_labels(&delete_labels);
+        }
     }
 
     pub fn get_labels(&self, items: &HashSet<LabelItem>) -> GetLabelsResult {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -130,6 +130,7 @@ pub trait DatabaseConnection {
     fn delete_spend(&mut self, txid: &bitcoin::Txid);
 
     fn update_labels(&mut self, items: &HashMap<LabelItem, String>);
+    fn delete_labels(&mut self, items: &[LabelItem]);
 
     fn labels(&mut self, labels: &HashSet<LabelItem>) -> HashMap<String, String>;
 
@@ -277,6 +278,10 @@ impl DatabaseConnection for SqliteConn {
 
     fn update_labels(&mut self, items: &HashMap<LabelItem, String>) {
         self.update_labels(items)
+    }
+
+    fn delete_labels(&mut self, items: &[LabelItem]) {
+        self.delete_labels(items)
     }
 
     fn labels(&mut self, items: &HashSet<LabelItem>) -> HashMap<String, String> {

--- a/src/jsonrpc/api.rs
+++ b/src/jsonrpc/api.rs
@@ -223,15 +223,14 @@ fn update_labels(control: &DaemonControl, params: Params) -> Result<serde_json::
         .ok_or_else(|| Error::invalid_params("Invalid 'labels' parameter."))?
         .iter()
     {
-        let value = value
-            .as_str()
-            .map(|s| s.to_string())
-            .ok_or_else(|| Error::invalid_params(format!("Invalid 'labels.{}' value.", item)))?;
-        if value.len() > 100 {
-            return Err(Error::invalid_params(format!(
-                "Invalid 'labels.{}' value length: must be less or equal than 100 characters",
-                item
-            )));
+        let value = value.as_str().map(|s| s.to_string());
+        if let Some(value) = &value {
+            if value.len() > 100 {
+                return Err(Error::invalid_params(format!(
+                    "Invalid 'labels.{}' value length: must be less or equal than 100 characters",
+                    item
+                )));
+            }
         }
         let item =
             LabelItem::from_str(item, control.config.bitcoin_config.network).ok_or_else(|| {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -367,6 +367,10 @@ impl DatabaseConnection for DummyDatabase {
         todo!()
     }
 
+    fn delete_labels(&mut self, _items: &[LabelItem]) {
+        todo!()
+    }
+
     fn labels(&mut self, _items: &HashSet<LabelItem>) -> HashMap<String, String> {
         todo!()
     }

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -952,3 +952,18 @@ def test_labels(lianad, bitcoind):
     assert res[inexistent_txid] == "inex_txid"
     assert res[inexistent_outpoint] == "inex_outpoint"
     assert res[random_address] == "bitcoind-addr"
+
+    lianad.rpc.updatelabels(
+        {
+            inexistent_txid: None,
+            inexistent_outpoint: None,
+            random_address: "this address is random",
+        }
+    )
+    res = lianad.rpc.getlabels([inexistent_txid, inexistent_outpoint, random_address])[
+        "labels"
+    ]
+    assert len(res) == 1
+    assert inexistent_txid not in res
+    assert inexistent_outpoint not in res
+    assert res[random_address] == "this address is random"


### PR DESCRIPTION
In order to delete a label, client sends in the
request a `null` as label value.

It simplifies on the client side the check for empty string in labels returned by the daemon.