### PR TITLE
gui: coinbase transaction output scripts may not represent valid addresses

### DIFF
--- a/gui/src/app/view/home.rs
+++ b/gui/src/app/view/home.rs
@@ -158,17 +158,14 @@ fn event_list_view(i: usize, event: &HistoryTransaction) -> Column<'_, Message> 
                 .to_string(),
             ) {
                 Some(p1_regular(label))
+            } else if let Ok(addr) =
+                bitcoin::Address::from_script(&output.script_pubkey, event.network)
+            {
+                event.labels.get(&addr.to_string()).map(|label| {
+                    p1_regular(format!("address label: {}", label)).style(color::GREY_3)
+                })
             } else {
-                event
-                    .labels
-                    .get(
-                        &bitcoin::Address::from_script(&output.script_pubkey, event.network)
-                            .unwrap()
-                            .to_string(),
-                    )
-                    .map(|label| {
-                        p1_regular(format!("address label: {}", label)).style(color::GREY_3)
-                    })
+                None
             };
             if event.is_external() {
                 if !event.change_indexes.contains(&output_index) {

--- a/gui/src/app/view/psbt.rs
+++ b/gui/src/app/view/psbt.rs
@@ -820,8 +820,8 @@ fn payment_view<'a>(
     labels_editing: &'a HashMap<String, form::Value<String>>,
 ) -> Element<'a, Message> {
     let addr = Address::from_script(&output.script_pubkey, network)
-        .unwrap()
-        .to_string();
+        .ok()
+        .map(|a| a.to_string());
     let outpoint = OutPoint {
         txid,
         vout: i as u32,
@@ -848,7 +848,7 @@ fn payment_view<'a>(
                 )
                 .push(amount(&Amount::from_sat(output.value))),
         )
-        .push(
+        .push_maybe(addr.map(|addr| {
             Column::new()
                 .push(
                     Row::new()
@@ -880,8 +880,8 @@ fn payment_view<'a>(
                                 .push(p1_bold("Address label:").style(color::GREY_3))
                                 .push(p2_regular(label).style(color::GREY_3)),
                         )
-                })),
-        )
+                }))
+        }))
         .into()
 }
 

--- a/gui/src/daemon/model.rs
+++ b/gui/src/daemon/model.rs
@@ -365,9 +365,9 @@ impl Labelled for HistoryTransaction {
                 txid,
                 vout: vout as u32,
             }));
-            items.push(LabelItem::Address(
-                Address::from_script(&output.script_pubkey, self.network).unwrap(),
-            ));
+            if let Ok(addr) = Address::from_script(&output.script_pubkey, self.network) {
+                items.push(LabelItem::Address(addr));
+            }
         }
         items
     }


### PR DESCRIPTION
close #738
liana-gui v2 also tried to display addresses from transaction outputs to user when clicking on transaction detail.