### PR TITLE
gui: display info-level logs when starting daemon

### DIFF
--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -2458,6 +2458,7 @@ dependencies = [
  "base64 0.13.1",
  "bitcoin_hashes 0.12.0",
  "chrono",
+ "crossbeam-channel",
  "dirs 3.0.2",
  "flate2",
  "hex",

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 async-hwi = "0.0.13"
+crossbeam-channel = "0.5"
 liana = { git = "https://github.com/wizardsardine/liana", branch = "master", default-features = false, features = ["nonblocking_shutdown"] }
 liana_ui = { path = "ui" }
 backtrace = "0.3"

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -149,8 +149,7 @@ impl Application for GUI {
                     network,
                     log_level.unwrap_or_else(|| cfg.log_level().unwrap_or(LevelFilter::INFO)),
                 );
-                let (loader, command) =
-                    Loader::new(datadir_path, cfg, network, None, logger.receiver());
+                let (loader, command) = Loader::new(datadir_path, cfg, network, None);
                 (
                     Self {
                         state: State::Loader(Box::new(loader)),
@@ -201,8 +200,7 @@ impl Application for GUI {
                         self.log_level
                             .unwrap_or_else(|| cfg.log_level().unwrap_or(LevelFilter::INFO)),
                     );
-                    let (loader, command) =
-                        Loader::new(datadir_path, cfg, network, None, self.logger.receiver());
+                    let (loader, command) = Loader::new(datadir_path, cfg, network, None);
                     self.state = State::Loader(Box::new(loader));
                     command.map(|msg| Message::Load(Box::new(msg)))
                 }
@@ -231,7 +229,6 @@ impl Application for GUI {
                         cfg,
                         daemon_cfg.bitcoin_config.network,
                         internal_bitcoind,
-                        self.logger.receiver(),
                     );
                     self.state = State::Loader(Box::new(loader));
                     command.map(|msg| Message::Load(Box::new(msg)))

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -149,7 +149,8 @@ impl Application for GUI {
                     network,
                     log_level.unwrap_or_else(|| cfg.log_level().unwrap_or(LevelFilter::INFO)),
                 );
-                let (loader, command) = Loader::new(datadir_path, cfg, network, None);
+                let (loader, command) =
+                    Loader::new(datadir_path, cfg, network, None, logger.receiver());
                 (
                     Self {
                         state: State::Loader(Box::new(loader)),
@@ -200,7 +201,8 @@ impl Application for GUI {
                         self.log_level
                             .unwrap_or_else(|| cfg.log_level().unwrap_or(LevelFilter::INFO)),
                     );
-                    let (loader, command) = Loader::new(datadir_path, cfg, network, None);
+                    let (loader, command) =
+                        Loader::new(datadir_path, cfg, network, None, self.logger.receiver());
                     self.state = State::Loader(Box::new(loader));
                     command.map(|msg| Message::Load(Box::new(msg)))
                 }
@@ -229,6 +231,7 @@ impl Application for GUI {
                         cfg,
                         daemon_cfg.bitcoin_config.network,
                         internal_bitcoind,
+                        self.logger.receiver(),
                     );
                     self.state = State::Loader(Box::new(loader));
                     command.map(|msg| Message::Load(Box::new(msg)))


### PR DESCRIPTION
This is to resolve #475.

I've tried to follow the approach suggested in https://github.com/wizardsardine/liana/issues/475#issuecomment-1778744189.

I was having trouble using a `mpsc::channel` in the `iced::Subscription` closure as it can't be shared between threads, so for now I've created a channel using `crossbeam_channel::unbounded` instead. Perhaps there's a different way of creating the subscription that would allow me to use `mpsc::channel`.

I'm using the same `Message` variant for both Liana and bitcoind logs, and distinguishing between them in `on_log()` based on the step. I could also use a different message for each case.