### PR TITLE
Cargo: drop two keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Antoine Poinsot <darosior@protonmail.com>"]
 edition = "2018"
 repository = "https://github.com/wizardsardine/liana"
 license-file = "LICENCE"
-keywords = ["bitcoin", "wallet", "safe", "script", "miniscript", "inheritance", "recovery"]
+keywords = ["bitcoin", "wallet", "miniscript", "inheritance", "recovery"]
 description = "Liana wallet daemon"
 exclude = [".github/", ".cirrus.yml", "tests/",  "test_data/", "contrib/", "pyproject.toml"]
 


### PR DESCRIPTION
We had too many keywords to be able to publish on crates.io