### PR TITLE
fix wallet name in settings during install

### DIFF
--- a/gui/src/app/wallet.rs
+++ b/gui/src/app/wallet.rs
@@ -12,7 +12,7 @@ use liana::{miniscript::bitcoin, signer::HotSigner};
 use liana::descriptors::LianaDescriptor;
 use liana::miniscript::bitcoin::bip32::Fingerprint;
 
-pub const DEFAULT_WALLET_NAME: &str = "Liana";
+const DEFAULT_WALLET_NAME: &str = "Liana";
 
 pub fn wallet_name(main_descriptor: &LianaDescriptor) -> String {
     let desc = main_descriptor.to_string();

--- a/gui/src/installer/context.rs
+++ b/gui/src/installer/context.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use crate::{
     app::{
         settings::{KeySetting, Settings, WalletSetting},
-        wallet::DEFAULT_WALLET_NAME,
+        wallet::wallet_name,
     },
     bitcoind::Bitcoind,
     hw::HardwareWalletConfig,
@@ -68,13 +68,14 @@ impl Context {
                     .map(|token| HardwareWalletConfig::new(kind, *fingerprint, token))
             })
             .collect();
+        let descriptor = self
+            .descriptor
+            .as_ref()
+            .expect("Must be a descriptor at this point");
         Settings {
             wallets: vec![WalletSetting {
-                name: DEFAULT_WALLET_NAME.to_string(),
-                descriptor_checksum: self
-                    .descriptor
-                    .as_ref()
-                    .unwrap()
+                name: wallet_name(descriptor),
+                descriptor_checksum: descriptor
                     .to_string()
                     .split_once('#')
                     .map(|(_, checksum)| checksum)


### PR DESCRIPTION
DEFAULT_WALLET_NAME aka simple `Liana` was still used during creation of wallet settings during install
this should have been noticed if I did test the wallet creation process in detail and if I removed the public exposition of the const variable. SHAME
based on #760 