### PR TITLE
fix single payment output label

### DIFF
--- a/gui/src/app/view/home.rs
+++ b/gui/src/app/view/home.rs
@@ -325,6 +325,7 @@ pub fn payment_view<'a>(
                 },
                 &tx.labels,
                 labels_editing,
+                tx.is_single_payment().is_some(),
             ))
             .spacing(20),
     )

--- a/gui/src/app/view/spend/mod.rs
+++ b/gui/src/app/view/spend/mod.rs
@@ -56,6 +56,7 @@ pub fn spend_view<'a>(
                 Some(tx.change_indexes.clone()),
                 &tx.labels,
                 labels_editing,
+                tx.is_single_payment().is_some(),
             ))
             .push(if saved {
                 Row::new()

--- a/gui/src/app/view/transactions.rs
+++ b/gui/src/app/view/transactions.rs
@@ -260,6 +260,7 @@ pub fn tx_view<'a>(
                 },
                 &tx.labels,
                 labels_editing,
+                tx.is_single_payment().is_some(),
             ))
             .spacing(20),
     )


### PR DESCRIPTION
When a transaction has only one payment,
then its txid label is attached to the payment label. While modifying the label of an output it did not change the whole transaction label, which is a bug.