### PR TITLE
installer: do not reload last step on next message

### DIFF
--- a/gui/src/installer/mod.rs
+++ b/gui/src/installer/mod.rs
@@ -106,6 +106,10 @@ impl Installer {
         if current_step.apply(&mut self.context) {
             if self.current < self.steps.len() - 1 {
                 self.current += 1;
+            } else {
+                // The step is already the last current step.
+                // No need to reload the current step.
+                return Command::none();
             }
             // skip the step according to the current context.
             while self


### PR DESCRIPTION
If a user clicked very fast a lot on the Next button to trigger multiple Next messages, then the last
step of the install reloads multiple time.
This commit introduce a check that ignore next message if the step is the last one.