### PR TITLE
installer: start new bitcoind download if not finished previously

### DIFF
--- a/gui/src/installer/step/bitcoind.rs
+++ b/gui/src/installer/step/bitcoind.rs
@@ -658,6 +658,13 @@ impl Step for InternalBitcoindStep {
                         bitcoind.stop();
                     }
                     self.internal_bitcoind = None;
+                    if let Some(download) = self.exe_download.as_ref() {
+                        // Clear exe_download if not Finished.
+                        if let DownloadState::Finished { .. } = download.state {
+                        } else {
+                            self.exe_download = None;
+                        }
+                    }
                     self.started = None; // clear both Ok and Err
                     return Command::perform(async {}, |_| Message::Previous);
                 }


### PR DESCRIPTION
In case the user clicks on "Previous" before the bitcoind download has finished, this PR will clear the incomplete download (or a download that completed with errors) from `InternalBitcoindStep`.

If the user then returns to this step, either a new download will start or the finished download will be available still. This fixes a bug following #746 for users that already have bitcoind v25.0 installed. If they click "Previous" while downloading 25.1, then upon returning to this step, the existing 25.0 bitcoind will be started.