### PR TITLE
3.x: Backport #777:  "installer: start new bitcoind download if not finished"

### DIFF
--- a/gui/src/installer/step/bitcoind.rs
+++ b/gui/src/installer/step/bitcoind.rs
@@ -658,6 +658,13 @@ impl Step for InternalBitcoindStep {
                         bitcoind.stop();
                     }
                     self.internal_bitcoind = None;
+                    if let Some(download) = self.exe_download.as_ref() {
+                        // Clear exe_download if not Finished.
+                        if let DownloadState::Finished { .. } = download.state {
+                        } else {
+                            self.exe_download = None;
+                        }
+                    }
                     self.started = None; // clear both Ok and Err
                     return Command::perform(async {}, |_| Message::Previous);
                 }


### PR DESCRIPTION
In case user clicks on Previous before bitcoind download has finished, this will clear the incomplete download from `InternalBitcoindStep` so that a new download will start if the user returns to this step.