### PR TITLE
gui: display headers sync progress too in loader

### DIFF
--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -322,7 +322,11 @@ impl Loader {
                 let last_update_tip = reader
                     .lines()
                     .into_iter()
-                    .filter(|l| l.as_ref().map(|l| l.contains("UpdateTip")).unwrap_or(false))
+                    .filter(|l| {
+                        l.as_ref()
+                            .map(|l| l.contains("UpdateTip") || l.contains("blockheaders"))
+                            .unwrap_or(false)
+                    })
                     .last();
                 match last_update_tip {
                     Some(Ok(line)) => (Message::BitcoindLog(Some(line)), log_path),


### PR DESCRIPTION
Maybe we should just get rid of the filtering since there is no stability guarantees wrt logging. On the other hand we'd probably need to increase the update frequency if we do that. In the meantime at least display also the blockheaders so the sync doesn't appear to be stuck for 5 minutes at startup.

Fixes #780.