### PR TITLE
Add derivation_index to GetAddressResult

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -75,9 +75,10 @@ This command does not take any parameter for now.
 
 #### Response
 
-| Field         | Type   | Description        |
-| ------------- | ------ | ------------------ |
-| `address`     | string | A Bitcoin address  |
+| Field                  | Type    | Description                           |
+| ---------------------- | ------- | ------------------------------------- |
+| `address`              | string  | A Bitcoin address                     |
+| `derivation_index`     | integer | The derivation index for this address |
 
 
 ### `listaddresses`


### PR DESCRIPTION
The derivation index is required for
for client to derive and verify the address
on hardware wallets.