### PR TITLE
Bitcoin state poller: a bug fix and a few RBF handling improvements

### DIFF
--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -261,8 +261,18 @@ impl BitcoinInterface for d::BitcoinD {
             // spender for this coin with it and mark it as confirmed.
             for txid in &res.conflicting_txs {
                 if let Some(tx) = tx_getter.get_transaction(txid) {
+                    // FIXME: if a conflict was mined we should somehow wipe the spend_txid of this
+                    // coin.
                     if let Some(block) = tx.block {
-                        spent.push((*op, *txid, block))
+                        // Being part of our watchonly wallet isn't enough, as it could be a
+                        // conflicting transaction which spends a different set of coins. Make sure
+                        // it does actually spend this coin.
+                        for txin in tx.tx.input {
+                            if &txin.previous_output == op {
+                                spent.push((*op, *txid, block));
+                                break;
+                            }
+                        }
                     }
                 }
             }

--- a/src/bitcoin/mod.rs
+++ b/src/bitcoin/mod.rs
@@ -293,6 +293,8 @@ impl BitcoinInterface for d::BitcoinD {
                             Conflict::Dropped
                         })
                         .or_else(|| {
+                            // If the coin is actually being spent, but by another transaction, it
+                            // will just be set at the next poll in `spending_coins()`.
                             if self.is_in_mempool(txid) {
                                 Some(Conflict::Dropped)
                             } else {

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -112,6 +112,8 @@ fn update_coins(
     // We need to take the newly received ones into account as well, as they may have been
     // spent within the previous tip and the current one, and we may not poll this chunk of the
     // chain anymore.
+    // NOTE: curr_coins contain the "spending" coins. So this takes care of updating the spend_txid
+    // if a coin's spending transaction gets RBF'd.
     let to_be_spent: Vec<bitcoin::OutPoint> = curr_coins
         .values()
         .chain(received.iter())

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -109,6 +109,9 @@ pub trait DatabaseConnection {
     /// Mark a set of coins as being spent by a specified txid of a pending transaction.
     fn spend_coins(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid)]);
 
+    /// Mark a set of coins as not being spent anymore.
+    fn unspend_coins(&mut self, outpoints: &[bitcoin::OutPoint]);
+
     /// Mark a set of coins as spent by a specified txid at a specified block time.
     fn confirm_spend(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid, i32, u32)]);
 
@@ -230,6 +233,10 @@ impl DatabaseConnection for SqliteConn {
 
     fn spend_coins<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid)]) {
         self.spend_coins(outpoints)
+    }
+
+    fn unspend_coins(&mut self, outpoints: &[bitcoin::OutPoint]) {
+        self.unspend_coins(outpoints)
     }
 
     fn confirm_spend<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid, i32, u32)]) {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -278,6 +278,16 @@ impl DatabaseConnection for DummyDatabase {
         }
     }
 
+    fn unspend_coins<'a>(&mut self, outpoints: &[bitcoin::OutPoint]) {
+        for op in outpoints {
+            let mut db = self.db.write().unwrap();
+            let spent = &mut db.coins.get_mut(op).unwrap();
+            assert!(spent.spend_txid.is_some());
+            spent.spend_txid = None;
+            spent.spend_block = None;
+        }
+    }
+
     fn confirm_spend<'a>(&mut self, outpoints: &[(bitcoin::OutPoint, bitcoin::Txid, i32, u32)]) {
         for (op, spend_txid, height, time) in outpoints {
             let mut db = self.db.write().unwrap();

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -82,8 +82,11 @@ impl BitcoinInterface for DummyBitcoind {
     fn spent_coins(
         &self,
         _: &[(bitcoin::OutPoint, bitcoin::Txid)],
-    ) -> Vec<(bitcoin::OutPoint, bitcoin::Txid, Block)> {
-        Vec::new()
+    ) -> (
+        Vec<(bitcoin::OutPoint, bitcoin::Txid, Block)>,
+        Vec<bitcoin::OutPoint>,
+    ) {
+        (Vec::new(), Vec::new())
     }
 
     fn common_ancestor(&self, _: &BlockChainTip) -> Option<BlockChainTip> {

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -480,7 +480,7 @@ def test_spend_replacement(lianad, bitcoind):
         == first_txid
     )
 
-    # Even once the RBF gets merged, the first coin's spend txid isn't updated.
+    # Even once the RBF gets mined, the first coin's spend txid isn't updated.
     bitcoind.generate_block(1, wait_for_mempool=third_txid)
     wait_for(
         lambda: all(
@@ -488,8 +488,7 @@ def test_spend_replacement(lianad, bitcoind):
             for c in lianad.rpc.listcoins([], second_outpoints)["coins"]
         )
     )
-    # FIXME: the code is incorrectly assigning the third txid to the first coin.
-    # assert (
-    # lianad.rpc.listcoins([], [first_outpoints[0]])["coins"][0]["spend_info"]["txid"]
-    # == first_txid
-    # )
+    assert (
+        lianad.rpc.listcoins([], [first_outpoints[0]])["coins"][0]["spend_info"]["txid"]
+        == first_txid
+    )

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -480,7 +480,7 @@ def test_spend_replacement(lianad, bitcoind):
         == first_txid
     )
 
-    # Even once the RBF gets mined, the first coin's spend txid isn't updated.
+    # Once the RBF gets mined, the first coin's spend txid is wiped.
     bitcoind.generate_block(1, wait_for_mempool=third_txid)
     wait_for(
         lambda: all(
@@ -488,7 +488,7 @@ def test_spend_replacement(lianad, bitcoind):
             for c in lianad.rpc.listcoins([], second_outpoints)["coins"]
         )
     )
-    assert (
-        lianad.rpc.listcoins([], [first_outpoints[0]])["coins"][0]["spend_info"]["txid"]
-        == first_txid
+    wait_for(
+        lambda: lianad.rpc.listcoins([], [first_outpoints[0]])["coins"][0]["spend_info"]
+        is None
     )


### PR DESCRIPTION
We start by illustrating the current logic of the poller with regard to replacements in a functional test. This exposes a bug: we could incorrectly assign a transaction which conflicts with a spend transaction for one of our coin as spending this coin whereas it in fact didn't.

After fixing this bug, we proceed to make it possible to wipe the spending status back to unspent. First when a conflict is mined, then also when it's only accepted into our mempool. This matches how we treat replacements for deposit transactions.