### PR TITLE
Cargo: use the published bdk_coin_select

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,8 +51,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bdk_coin_select"
-version = "0.1.0"
-source = "git+https://github.com/evanlinjin/bdk?branch=new_bdk_coin_select#2a06d73ac7a5dca933b19b51078f5279691364ed"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0320167c3655e83f0415d52f39618902e449186ffc7dfb090f922f79675c316"
 
 [[package]]
 name = "bech32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ nonblocking_shutdown = []
 # For managing transactions (it re-exports the bitcoin crate)
 miniscript = { version = "10.0", features = ["serde", "compiler", "base64"] }
 
-bdk_coin_select = { git = "https://github.com/evanlinjin/bdk", branch = "new_bdk_coin_select" }
+# Coin selection algorithms for spend transaction creation.
+bdk_coin_select = { version = "0.1.0" }
 
 # Don't reinvent the wheel
 dirs = "5.0"


### PR DESCRIPTION
Draft until https://github.com/bitcoindevkit/coin-select/pull/9 is published on crates.io.