### PR TITLE
gui: enable use of RBF on unconfirmed transactions

### DIFF
--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -254,8 +254,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_coin_select"
-version = "0.1.0"
-source = "git+https://github.com/evanlinjin/bdk?branch=new_bdk_coin_select#2a06d73ac7a5dca933b19b51078f5279691364ed"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0320167c3655e83f0415d52f39618902e449186ffc7dfb090f922f79675c316"
 
 [[package]]
 name = "bech32"
@@ -2430,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "liana"
 version = "2.0.0"
-source = "git+https://github.com/wizardsardine/liana?branch=master#514535d8d6fec705c7271241f68276c42b918150"
+source = "git+https://github.com/wizardsardine/liana?branch=master#6151c57af492dacc8502b0ea1ec1cd04580e08dc"
 dependencies = [
  "backtrace",
  "bdk_coin_select",

--- a/gui/src/app/menu.rs
+++ b/gui/src/app/menu.rs
@@ -1,4 +1,4 @@
-use liana::miniscript::bitcoin::OutPoint;
+use liana::miniscript::bitcoin::{OutPoint, Txid};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Menu {
     Home,
@@ -10,4 +10,5 @@ pub enum Menu {
     CreateSpendTx,
     Recovery,
     RefreshCoins(Vec<OutPoint>),
+    PsbtPreSelected(Txid),
 }

--- a/gui/src/app/state/psbts.rs
+++ b/gui/src/app/state/psbts.rs
@@ -120,7 +120,7 @@ impl State for PsbtsPanel {
     fn load(&self, daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {
         let daemon = daemon.clone();
         Command::perform(
-            async move { daemon.list_spend_transactions().map_err(|e| e.into()) },
+            async move { daemon.list_spend_transactions(None).map_err(|e| e.into()) },
             Message::SpendTxs,
         )
     }

--- a/gui/src/app/state/psbts.rs
+++ b/gui/src/app/state/psbts.rs
@@ -32,6 +32,18 @@ impl PsbtsPanel {
             import_tx: None,
         }
     }
+
+    pub fn new_preselected(wallet: Arc<Wallet>, spend_tx: SpendTx) -> Self {
+        let psbt_state = psbt::PsbtState::new(wallet.clone(), spend_tx.clone(), true);
+
+        Self {
+            wallet,
+            spend_txs: vec![spend_tx],
+            warning: None,
+            selected_tx: Some(psbt_state),
+            import_tx: None,
+        }
+    }
 }
 
 impl State for PsbtsPanel {

--- a/gui/src/app/view/message.rs
+++ b/gui/src/app/view/message.rs
@@ -17,6 +17,7 @@ pub enum Message {
     Next,
     Previous,
     SelectHardwareWallet(usize),
+    CreateRbf(CreateRbfMessage),
 }
 
 #[derive(Debug, Clone)]
@@ -74,6 +75,14 @@ pub enum SettingsMessage {
 pub enum SettingsEditMessage {
     Select,
     FieldEdited(&'static str, String),
+    Cancel,
+    Confirm,
+}
+
+#[derive(Debug, Clone)]
+pub enum CreateRbfMessage {
+    New(bool),
+    FeerateEdited(String),
     Cancel,
     Confirm,
 }

--- a/gui/src/daemon/client/mod.rs
+++ b/gui/src/daemon/client/mod.rs
@@ -96,6 +96,22 @@ impl<C: Client + Debug> Daemon for Lianad<C> {
         )
     }
 
+    fn rbf_psbt(
+        &self,
+        txid: &Txid,
+        is_cancel: bool,
+        feerate_vb: Option<u64>,
+    ) -> Result<CreateSpendResult, DaemonError> {
+        self.call(
+            "rbfpsbt",
+            Some(vec![
+                json!(txid.to_string()),
+                json!(is_cancel.to_string()),
+                json!(feerate_vb),
+            ]),
+        )
+    }
+
     fn update_spend_tx(&self, psbt: &Psbt) -> Result<(), DaemonError> {
         let spend_tx = base64::encode(psbt.serialize());
         let _res: serde_json::value::Value = self.call("updatespend", Some(vec![spend_tx]))?;

--- a/gui/src/daemon/embedded.rs
+++ b/gui/src/daemon/embedded.rs
@@ -96,6 +96,17 @@ impl Daemon for EmbeddedDaemon {
             })
     }
 
+    fn rbf_psbt(
+        &self,
+        txid: &Txid,
+        is_cancel: bool,
+        feerate_vb: Option<u64>,
+    ) -> Result<CreateSpendResult, DaemonError> {
+        self.control()?
+            .rbf_psbt(txid, is_cancel, feerate_vb)
+            .map_err(|e| DaemonError::Unexpected(e.to_string()))
+    }
+
     fn update_spend_tx(&self, psbt: &Psbt) -> Result<(), DaemonError> {
         self.control()?
             .update_spend(psbt.clone())

--- a/gui/src/daemon/embedded.rs
+++ b/gui/src/daemon/embedded.rs
@@ -89,7 +89,7 @@ impl Daemon for EmbeddedDaemon {
         feerate_vb: u64,
     ) -> Result<CreateSpendResult, DaemonError> {
         self.control()?
-            .create_spend(destinations, coins_outpoints, feerate_vb)
+            .create_spend(destinations, coins_outpoints, feerate_vb, None)
             .map_err(|e| match e {
                 CommandError::CoinSelectionError(_) => DaemonError::CoinSelectionError,
                 e => DaemonError::Unexpected(e.to_string()),

--- a/gui/src/daemon/mod.rs
+++ b/gui/src/daemon/mod.rs
@@ -63,6 +63,12 @@ pub trait Daemon: Debug {
         destinations: &HashMap<Address<address::NetworkUnchecked>, u64>,
         feerate_vb: u64,
     ) -> Result<model::CreateSpendResult, DaemonError>;
+    fn rbf_psbt(
+        &self,
+        txid: &Txid,
+        is_cancel: bool,
+        feerate_vb: Option<u64>,
+    ) -> Result<model::CreateSpendResult, DaemonError>;
     fn update_spend_tx(&self, psbt: &Psbt) -> Result<(), DaemonError>;
     fn delete_spend_tx(&self, txid: &Txid) -> Result<(), DaemonError>;
     fn broadcast_spend_tx(&self, txid: &Txid) -> Result<(), DaemonError>;

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -370,7 +370,7 @@ pub async fn load_application(
         Wallet::new(info.descriptors.main).load_settings(&gui_config, &datadir_path, network)?;
 
     let coins = daemon.list_coins().map(|res| res.coins)?;
-    let spend_txs = daemon.list_spend_transactions()?;
+    let spend_txs = daemon.list_spend_transactions(None)?;
 
     let cache = Cache {
         datadir_path,


### PR DESCRIPTION
This is to resolve #43.

When viewing an unconfirmed transaction, a user can now either bump its fee or cancel it. This will generate a new PSBT that the user can jump to in order to sign and broadcast it.

I haven't added any comparison between the previous and replacement inputs as suggested in https://github.com/wizardsardine/liana/issues/43#issuecomment-1825623520. I think that would be a bigger change and might be better as a follow-up.

I decided not to add "Unconfirmed" on the transaction screen as suggested in https://github.com/wizardsardine/liana/issues/43#issuecomment-1831763013 as I thought it might be better as a separate PR.

I haven't yet added the RBF buttons to the home screen, but that could also be done as a follow-up :)

In a separate commit, I pass `None` to `create_spend` following #821.