### PR TITLE
Expose spend module and coins fields

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -123,14 +123,16 @@ A coin may have one of the following four statuses:
 
 #### Response
 
-| Field          | Type          | Description                                                                                                        |
-| -------------- | ------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `address`      | string        | Address containing the script pubkey of the coin                                                                   |
-| `amount`       | int           | Value of the TxO in satoshis.                                                                                      |
-| `outpoint`     | string        | Transaction id and output index of this coin.                                                                      |
-| `block_height` | int or null   | Block height the transaction was confirmed at, or `null`.                                                          |
-| `spend_info`   | object        | Information about the transaction spending this coin. See [Spending transaction info](#spending_transaction_info). |
-| `is_immature`  | bool          | Whether this coin was created by a coinbase transaction that is still immature.                                    |
+| Field              | Type          | Description                                                                                                        |
+| ------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `address`          | string        | Address containing the script pubkey of the coin                                                                   |
+| `amount`           | int           | Value of the TxO in satoshis.                                                                                      |
+| `derivation_index` | int           | Derivation index used to create the coin deposit address.                                                          |
+| `outpoint`         | string        | Transaction id and output index of this coin.                                                                      |
+| `block_height`     | int or null   | Block height the transaction was confirmed at, or `null`.                                                          |
+| `spend_info`       | object        | Information about the transaction spending this coin. See [Spending transaction info](#spending_transaction_info). |
+| `is_immature`      | bool          | Whether this coin was created by a coinbase transaction that is still immature.                                    |
+| `is_change`        | bool          | Whether the coin deposit address was derived from the change descriptor.                                           |
 
 
 ##### Spending transaction info

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -417,6 +417,8 @@ impl DaemonControl {
                     spend_txid,
                     spend_block,
                     is_immature,
+                    is_change,
+                    derivation_index,
                     ..
                 } = coin;
                 let spend_info = spend_txid.map(|txid| LCSpendInfo {
@@ -430,10 +432,12 @@ impl DaemonControl {
                 ListCoinsEntry {
                     address,
                     amount,
+                    derivation_index,
                     outpoint,
                     block_height,
                     spend_info,
                     is_immature,
+                    is_change,
                 }
             })
             .collect();
@@ -1104,10 +1108,14 @@ pub struct ListCoinsEntry {
     )]
     pub address: bitcoin::Address,
     pub block_height: Option<i32>,
+    /// Derivation index used to create the coin deposit address.
+    pub derivation_index: bip32::ChildNumber,
     /// Information about the transaction spending this coin.
     pub spend_info: Option<LCSpendInfo>,
     /// Whether this coin was created by a coinbase transaction that is still immature.
     pub is_immature: bool,
+    /// Whether the coin deposit address was derived from the change descriptor.
+    pub is_change: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub mod descriptors;
 mod jsonrpc;
 mod random;
 pub mod signer;
-mod spend;
+pub mod spend;
 #[cfg(test)]
 mod testutils;
 

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -82,13 +82,15 @@ def test_listcoins(lianad, bitcoind):
 
     # If we send a coin, we'll get a new entry. Note we monitor for unconfirmed
     # funds as well.
-    addr_a = lianad.rpc.getnewaddress()["address"]
-    txid_a = bitcoind.rpc.sendtoaddress(addr_a, 1)
+    addr_a = lianad.rpc.getnewaddress()
+    txid_a = bitcoind.rpc.sendtoaddress(addr_a["address"], 1)
     wait_for(lambda: len(lianad.rpc.listcoins()["coins"]) == 1)
     res = lianad.rpc.listcoins()["coins"]
     outpoint_a = res[0]["outpoint"]
     assert txid_a == outpoint_a[:64]
     assert res[0]["amount"] == 1 * COIN
+    assert res[0]["derivation_index"] == addr_a["derivation_index"]
+    assert res[0]["is_change"] == False
     assert res[0]["block_height"] is None
     assert res[0]["spend_info"] is None
 


### PR DESCRIPTION
In order to externally use create_spend, the spend module must be exposed and the listcoinsentry must include the derivation_index and is_change fields.