### PR TITLE
gui: set max feerate in RBF modal

### DIFF
--- a/gui/src/app/state/transactions.rs
+++ b/gui/src/app/state/transactions.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use iced::Command;
-use liana::miniscript::bitcoin::Txid;
+use liana::{miniscript::bitcoin::Txid, spend::MAX_FEERATE};
 use liana_ui::{
     component::{form, modal::Modal},
     widget::*,
@@ -287,7 +287,7 @@ impl CreateRbfModal {
                 self.warning = None;
                 if let Ok(value) = s.parse::<u64>() {
                     self.feerate_val.value = s;
-                    self.feerate_val.valid = value >= self.min_feerate_vb;
+                    self.feerate_val.valid = value >= self.min_feerate_vb && value <= MAX_FEERATE;
                     if self.feerate_val.valid {
                         self.feerate_vb = Some(value);
                     }

--- a/gui/src/app/view/transactions.rs
+++ b/gui/src/app/view/transactions.rs
@@ -187,7 +187,9 @@ pub fn create_rbf_modal<'a>(
                             form::Form::new_trimmed("", feerate, move |msg| {
                                 Message::CreateRbf(CreateRbfMessage::FeerateEdited(msg))
                             })
-                            .warning("Invalid feerate")
+                            .warning(
+                                "Feerate must be greater than previous value and less than or equal to 1000 sats/vbyte",
+                            )
                             .size(20)
                             .padding(10),
                         )


### PR DESCRIPTION
This applies a similar change to feerate form validation as in #863 to ensure value is not too high.

![image](https://github.com/wizardsardine/liana/assets/121959000/caa31a99-8bc7-43bb-a2c2-a9d41d752f50)
