### PR TITLE
gui: use descriptor helper function to get unsigned tx max size

### DIFF
--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -2431,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "liana"
 version = "4.0.0"
-source = "git+https://github.com/wizardsardine/liana?branch=master#87d1c55d2e5b6edc5cc2033759a6a936435b67b6"
+source = "git+https://github.com/wizardsardine/liana?branch=master#dee069e72343a67607f4429125e4c80dc0d73055"
 dependencies = [
  "backtrace",
  "bdk_coin_select",


### PR DESCRIPTION
This is to resolve #880 using the new helper function from #881 to get the max possible size of the unsigned transaction.

The following screenshot is taken using both new and old implementations together and shows the new estimated feerate changes from 0 to 1 sat/vbyte:
![image](https://github.com/wizardsardine/liana/assets/121959000/855fe261-418f-4ebb-a426-15f1ce7007f6)