### PR TITLE
config: add user:password option for RPC authentication

### DIFF
--- a/contrib/lianad_config_example.toml
+++ b/contrib/lianad_config_example.toml
@@ -31,8 +31,10 @@ poll_interval_secs = 30
 
 # This section is specific to the bitcoind implementation of the Bitcoin backend. This is the only
 # implementation available for now.
-# In order to be able to connect to bitcoind, it needs to know on what port it is listening as well
-# as where the authentication cookie is located.
+# In order to be able to connect to bitcoind, it needs to know on what port it is listening and
+# how to authenticate, either by specifying the cookie location with "cookie_path" or otherwise
+# passing a colon-separated user and password with "auth".
 [bitcoind_config]
 addr = "127.0.0.1:18332"
 cookie_path = "/home/wizardsardine/.bitcoin/testnet3/.cookie"
+# auth = "my_user:my_password"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,7 +433,7 @@ impl DaemonHandle {
 mod tests {
     use super::*;
     use crate::{
-        config::{BitcoinConfig, BitcoindConfig},
+        config::{BitcoinConfig, BitcoindConfig, BitcoindRpcAuth},
         descriptors::LianaDescriptor,
         testutils::*,
     };
@@ -659,7 +659,7 @@ mod tests {
         };
         let bitcoind_config = BitcoindConfig {
             addr,
-            cookie_path: cookie,
+            rpc_auth: BitcoindRpcAuth::CookieFile(cookie),
         };
 
         // Create a dummy config with this bitcoind


### PR DESCRIPTION
As a first step towards #356, this adds the option to specify a user and password in Liana's config file for bitcoind RPC authentication.

The GUI installer & settings will need to be updated in a follow-up PR to add this option.