### PR TITLE
gui(settings): load updated bitcoind settings after saving

### DIFF
--- a/gui/src/app/state/settings/bitcoind.rs
+++ b/gui/src/app/state/settings/bitcoind.rs
@@ -72,7 +72,12 @@ impl State for BitcoindSettingsState {
                     self.warning = None;
                     if let Some(current) = self.current {
                         if let Some(setting) = self.settings.get_mut(current) {
-                            setting.edited(true)
+                            setting.edited(true);
+                            return Command::perform(async {}, |_| {
+                                Message::View(view::Message::Settings(
+                                    view::SettingsMessage::EditBitcoindSettings,
+                                ))
+                            });
                         }
                     }
                     self.current = None;


### PR DESCRIPTION
Currently, the Bitcoin Core settings page doesn't show the updated values after saving changes and needs to be reloaded in order to refresh. This change makes the Bitcoin Core settings page reload after changes are saved so that they are shown immediately.