### PR TITLE
Go directly to installer if datadir empty

### DIFF
--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -334,7 +334,12 @@ impl Config {
                 Err(ConfigError::NotFound) => Ok(Config::Install(datadir_path, network)),
                 Err(e) => Err(format!("Failed to read configuration file: {}", e).into()),
             }
-        } else if !datadir_path.exists() {
+        } else if !datadir_path.exists()
+            || (!datadir_path.join("bitcoin").exists()
+                && !datadir_path.join("testnet").exists()
+                && !datadir_path.join("signet").exists()
+                && !datadir_path.join("regtest").exists())
+        {
             Ok(Config::Install(datadir_path, bitcoin::Network::Bitcoin))
         } else {
             Ok(Config::Launcher(datadir_path))


### PR DESCRIPTION
address #263, now if there is a .liana dir already existing but not network folder (`bitcoin`/`testnet`/`signet`/`regtest`) inside, liana start directly into installer (before is was starting the launcher even if no network to launch, and displaying a weird 'Install liana on another network')