### PR TITLE
gui(spend): display warnings for draft PSBTs

### DIFF
--- a/gui/src/app/message.rs
+++ b/gui/src/app/message.rs
@@ -29,7 +29,7 @@ pub enum Message {
     Coins(Result<Vec<Coin>, Error>),
     Labels(Result<HashMap<String, String>, Error>),
     SpendTxs(Result<Vec<SpendTx>, Error>),
-    Psbt(Result<Psbt, Error>),
+    Psbt(Result<(Psbt, Vec<String>), Error>),
     RbfPsbt(Result<Txid, Error>),
     Recovery(Result<SpendTx, Error>),
     Signed(Fingerprint, Result<Psbt, Error>),

--- a/gui/src/app/view/spend/mod.rs
+++ b/gui/src/app/view/spend/mod.rs
@@ -33,6 +33,7 @@ use crate::{
 pub fn spend_view<'a>(
     cache: &'a Cache,
     tx: &'a SpendTx,
+    spend_warnings: &'a Vec<String>,
     saved: bool,
     desc_info: &'a LianaPolicy,
     key_aliases: &'a HashMap<Fingerprint, String>,
@@ -48,6 +49,21 @@ pub fn spend_view<'a>(
             .spacing(20)
             .push(Container::new(h3("Send")).width(Length::Fill))
             .push(psbt::spend_header(tx, labels_editing))
+            .push_maybe(if spend_warnings.is_empty() || saved {
+                None
+            } else {
+                Some(spend_warnings.iter().fold(
+                    Column::new().padding(15).spacing(5),
+                    |col, warning| {
+                        col.push(
+                            Row::new()
+                                .spacing(5)
+                                .push(icon::warning_icon().style(color::ORANGE))
+                                .push(text(warning).style(color::ORANGE)),
+                        )
+                    },
+                ))
+            })
             .push(psbt::spend_overview_view(tx, desc_info, key_aliases))
             .push(
                 Column::new()


### PR DESCRIPTION
This is to complete #811.

It displays any warnings generated by `createspend` on the draft PSBT view, which could currently be those from https://github.com/wizardsardine/liana/pull/905 and https://github.com/wizardsardine/liana/pull/873. Once the PSBT has been saved, these warnings will no longer be shown.

Below are some screenshots.

With a warning:
![image](https://github.com/wizardsardine/liana/assets/121959000/fb2167d9-4800-4849-8622-ff20ac55623e)

![image](https://github.com/wizardsardine/liana/assets/121959000/e1ab9ec2-00ae-457f-81e1-9b3a2863af31)

Without a warning:
![image](https://github.com/wizardsardine/liana/assets/121959000/73b5b4bd-55b5-40ee-b587-4f57bfd57b4c)

![image](https://github.com/wizardsardine/liana/assets/121959000/e9b23d4e-bb13-4ae7-944e-258f9c9a0abd)
