### PR TITLE
gui(installer): clear checkbox if descriptor is changed

### DIFF
--- a/gui/src/installer/step/descriptor.rs
+++ b/gui/src/installer/step/descriptor.rs
@@ -1515,7 +1515,10 @@ impl Step for BackupDescriptor {
         Command::none()
     }
     fn load_context(&mut self, ctx: &Context) {
-        self.descriptor = ctx.descriptor.clone();
+        if self.descriptor != ctx.descriptor {
+            self.descriptor = ctx.descriptor.clone();
+            self.done = false;
+        }
     }
     fn view(&self, _hws: &HardwareWallets, progress: (usize, usize)) -> Element<Message> {
         let desc = self.descriptor.as_ref().unwrap();


### PR DESCRIPTION
Currently, once the box has been ticked to confirm the descriptor has been backed up, it remains ticked even if the user goes back and changes the descriptor.

This PR will clear the checkbox if the descriptor is changed so that the user knows it needs to be backed up