### PR TITLE
Fixed the decimal issue in the progress bar.

### DIFF
--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -413,7 +413,7 @@ pub fn view(step: &Step) -> Element<ViewMessage> {
             Column::new()
                 .width(Length::Fill)
                 .spacing(5)
-                .push(text(format!("Progress {:.2}%", 100.0 * *progress)))
+                .push(text(format!("Progress {:.4}%", 100.0 * *progress)))
                 .push(ProgressBar::new(0.0..=1.0, *progress as f32).width(Length::Fill))
                 .push(text(if *progress > 0.98 {
                     SYNCING_PROGRESS_3


### PR DESCRIPTION
#### Currently, the percentage is shown to 2 decimal places, but the second decimal is always 0.

I have increased the number of decimal places of the "sync" entry in Liana's getinfo command to 4 to fix this issue.

Solves #907 