### PR TITLE
commands: increment address index if current value used for new spend

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -267,7 +267,7 @@ impl DaemonControl {
                     .increment()
                     .expect("Must not get into hardened territory");
                 db_conn.set_change_index(next_index, &self.secp);
-            } else if !is_change && db_conn.receive_index() < *index {
+            } else if !is_change && db_conn.receive_index() <= *index {
                 let next_index = index
                     .increment()
                     .expect("Must not get into hardened territory");

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -212,7 +212,7 @@ impl DatabaseConnection for DummyDatabase {
     }
 
     fn change_index(&mut self) -> bip32::ChildNumber {
-        self.db.read().unwrap().deposit_index
+        self.db.read().unwrap().change_index
     }
 
     fn set_change_index(

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -423,10 +423,9 @@ def test_coin_selection(lianad, bitcoind):
     # Recipient details are the same for both.
     assert spend_psbt_4.tx.vout[0].nValue == psbt_manual.tx.vout[0].nValue
     assert spend_psbt_4.tx.vout[0].scriptPubKey == psbt_manual.tx.vout[0].scriptPubKey
-    # Change details are also the same
-    # (change address is same as neither transaction has been broadcast)
+    # Change amount is the same (change address will be different).
     assert spend_psbt_4.tx.vout[1].nValue == psbt_manual.tx.vout[1].nValue
-    assert spend_psbt_4.tx.vout[1].scriptPubKey == psbt_manual.tx.vout[1].scriptPubKey
+    assert spend_psbt_4.tx.vout[1].scriptPubKey != psbt_manual.tx.vout[1].scriptPubKey
 
 
 def test_coin_selection_changeless(lianad, bitcoind):


### PR DESCRIPTION
This is a fix to ensure the change index in the database is incremented if a new spend is created with a change address derived from the current index, regardless of whether this new spend is broadcast or not.

EDIT: The same fix has been applied to the receive index.