### PR TITLE
poller: unspend expired before new spend

### DIFF
--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -245,8 +245,8 @@ fn updates(
     db_conn.new_unspent_coins(&updated_coins.received);
     db_conn.remove_coins(&updated_coins.expired);
     db_conn.confirm_coins(&updated_coins.confirmed);
-    db_conn.spend_coins(&updated_coins.spending);
     db_conn.unspend_coins(&updated_coins.expired_spending);
+    db_conn.spend_coins(&updated_coins.spending);
     db_conn.confirm_spend(&updated_coins.spent);
     if latest_tip != current_tip {
         db_conn.update_tip(&latest_tip);

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -35,17 +35,33 @@ def wait_for(success, timeout=TIMEOUT, debug_fn=None):
     debug_fn is logged at each call to success, it can be useful for debugging
     when tests fail.
     """
+    wait_for_while_condition_holds(success, lambda: True, timeout, debug_fn)
+
+
+def wait_for_while_condition_holds(success, condition, timeout=TIMEOUT, debug_fn=None):
+    """
+    Run success() either until it returns True, or until the timeout is reached,
+    as long as condition() holds.
+    debug_fn is logged at each call to success, it can be useful for debugging
+    when tests fail.
+    """
     start_time = time.time()
     interval = 0.25
-    while not success() and time.time() < start_time + timeout:
+    while True:
+        if time.time() >= start_time + timeout:
+            raise ValueError("Error waiting for {}", success)
+        if not condition():
+            raise ValueError(
+                "Condition {} not met while waiting for {}", condition, success
+            )
+        if success():
+            return
         if debug_fn is not None:
             logging.info(debug_fn())
         time.sleep(interval)
         interval *= 2
         if interval > 5:
             interval = 5
-    if time.time() > start_time + timeout:
-        raise ValueError("Error waiting for {}", success)
 
 
 def get_txid(hex_tx):


### PR DESCRIPTION
This change ensures that the spend txid of a coin is updated directly to another value in case a conflicting spend is detected.

The previous order caused the spend txid to first be cleared, which would misleadingly make the coin appear as confirmed
rather than spending.

I've added a new utils function for the functional tests that is a slight generalisation of `wait_for` with an additional condition that must always be met while waiting.

`wait_for` now calls this new function with the condition being one that is always true.