### PR TITLE
gui: add `listcoins` filters

### DIFF
--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -240,7 +240,7 @@ impl App {
 
                         let info = daemon.get_info()?;
                         // todo: filter coins to only have current coins.
-                        let coins = daemon.list_coins()?;
+                        let coins = daemon.list_coins(&[], &[])?;
                         Ok(Cache {
                             datadir_path,
                             coins: coins.coins,

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use iced::{clipboard, time, Command, Subscription};
 use tracing::{error, info, warn};
 
-pub use liana::{config::Config as DaemonConfig, miniscript::bitcoin};
+pub use liana::{commands::CoinStatus, config::Config as DaemonConfig, miniscript::bitcoin};
 use liana_ui::widget::Element;
 
 pub use config::Config;
@@ -239,8 +239,8 @@ impl App {
                         daemon.is_alive()?;
 
                         let info = daemon.get_info()?;
-                        // todo: filter coins to only have current coins.
-                        let coins = daemon.list_coins(&[], &[])?;
+                        let coins = daemon
+                            .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])?;
                         Ok(Cache {
                             datadir_path,
                             coins: coins.coins,

--- a/gui/src/app/state/coins.rs
+++ b/gui/src/app/state/coins.rs
@@ -162,7 +162,7 @@ impl State for CoinsPanel {
             Command::perform(
                 async move {
                     daemon1
-                        .list_coins()
+                        .list_coins(&[], &[])
                         .map(|res| res.coins)
                         .map_err(|e| e.into())
                 },
@@ -171,7 +171,7 @@ impl State for CoinsPanel {
             Command::perform(
                 async move {
                     let coins = daemon2
-                        .list_coins()
+                        .list_coins(&[], &[])
                         .map(|res| res.coins)
                         .map_err(Error::from)?;
                     let mut targets = HashSet::<LabelItem>::new();

--- a/gui/src/app/state/coins.rs
+++ b/gui/src/app/state/coins.rs
@@ -4,6 +4,7 @@ use std::{cmp::Ordering, collections::HashSet};
 
 use iced::Command;
 
+use liana::commands::CoinStatus;
 use liana_ui::widget::Element;
 
 use crate::{
@@ -162,7 +163,7 @@ impl State for CoinsPanel {
             Command::perform(
                 async move {
                     daemon1
-                        .list_coins(&[], &[])
+                        .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
                         .map(|res| res.coins)
                         .map_err(|e| e.into())
                 },
@@ -171,7 +172,7 @@ impl State for CoinsPanel {
             Command::perform(
                 async move {
                     let coins = daemon2
-                        .list_coins(&[], &[])
+                        .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
                         .map(|res| res.coins)
                         .map_err(Error::from)?;
                     let mut targets = HashSet::<LabelItem>::new();

--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -13,7 +13,10 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use iced::{Command, Subscription};
-use liana::miniscript::bitcoin::{Amount, OutPoint};
+use liana::{
+    commands::CoinStatus,
+    miniscript::bitcoin::{Amount, OutPoint},
+};
 use liana_ui::widget::*;
 
 use super::{cache::Cache, error::Error, menu::Menu, message::Message, view, wallet::Wallet};
@@ -295,7 +298,7 @@ impl State for Home {
             Command::perform(
                 async move {
                     daemon2
-                        .list_coins(&[], &[])
+                        .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
                         .map(|res| res.coins)
                         .map_err(|e| e.into())
                 },

--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -295,7 +295,7 @@ impl State for Home {
             Command::perform(
                 async move {
                     daemon2
-                        .list_coins()
+                        .list_coins(&[], &[])
                         .map(|res| res.coins)
                         .map_err(|e| e.into())
                 },

--- a/gui/src/app/state/psbt.rs
+++ b/gui/src/app/state/psbt.rs
@@ -173,7 +173,7 @@ impl PsbtState {
                         daemon
                             // TODO: filter for the outpoints in `tx.coins` when this is possible:
                             // https://github.com/wizardsardine/liana/issues/677
-                            .list_coins()
+                            .list_coins(&[], &[])
                             .map(|res| {
                                 res.coins
                                     .iter()

--- a/gui/src/app/state/recovery.rs
+++ b/gui/src/app/state/recovery.rs
@@ -4,9 +4,12 @@ use std::sync::Arc;
 
 use iced::Command;
 
-use liana::miniscript::bitcoin::{
-    bip32::{DerivationPath, Fingerprint},
-    secp256k1,
+use liana::{
+    commands::CoinStatus,
+    miniscript::bitcoin::{
+        bip32::{DerivationPath, Fingerprint},
+        secp256k1,
+    },
 };
 use liana_ui::{component::form, widget::Element};
 
@@ -204,7 +207,7 @@ impl State for RecoveryPanel {
         Command::perform(
             async move {
                 daemon
-                    .list_coins(&[], &[])
+                    .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
                     .map(|res| res.coins)
                     .map_err(|e| e.into())
             },

--- a/gui/src/app/state/recovery.rs
+++ b/gui/src/app/state/recovery.rs
@@ -155,7 +155,7 @@ impl State for RecoveryPanel {
                     return Command::perform(
                         async move {
                             let psbt = daemon.create_recovery(address, feerate_vb, sequence)?;
-                            let coins = daemon.list_coins().map(|res| res.coins)?;
+                            let coins = daemon.list_coins(&[], &[]).map(|res| res.coins)?;
                             let coins = coins
                                 .into_iter()
                                 .filter(|coin| {
@@ -207,7 +207,7 @@ impl State for RecoveryPanel {
         Command::perform(
             async move {
                 daemon
-                    .list_coins()
+                    .list_coins(&[], &[])
                     .map(|res| res.coins)
                     .map_err(|e| e.into())
             },

--- a/gui/src/app/state/recovery.rs
+++ b/gui/src/app/state/recovery.rs
@@ -155,16 +155,13 @@ impl State for RecoveryPanel {
                     return Command::perform(
                         async move {
                             let psbt = daemon.create_recovery(address, feerate_vb, sequence)?;
-                            let coins = daemon.list_coins(&[], &[]).map(|res| res.coins)?;
-                            let coins = coins
-                                .into_iter()
-                                .filter(|coin| {
-                                    psbt.unsigned_tx
-                                        .input
-                                        .iter()
-                                        .any(|input| input.previous_output == coin.outpoint)
-                                })
+                            let outpoints: Vec<_> = psbt
+                                .unsigned_tx
+                                .input
+                                .iter()
+                                .map(|txin| txin.previous_output)
                                 .collect();
+                            let coins = daemon.list_coins(&[], &outpoints).map(|res| res.coins)?;
                             Ok(SpendTx::new(
                                 None,
                                 psbt,

--- a/gui/src/app/state/spend/mod.rs
+++ b/gui/src/app/state/spend/mod.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 
 use iced::Command;
 
-use liana::miniscript::bitcoin::{Network, OutPoint};
+use liana::{
+    commands::CoinStatus,
+    miniscript::bitcoin::{Network, OutPoint},
+};
 use liana_ui::widget::Element;
 
 use super::{redirect, State};
@@ -123,7 +126,7 @@ impl State for CreateSpendPanel {
             Command::perform(
                 async move {
                     daemon1
-                        .list_coins(&[], &[])
+                        .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
                         .map(|res| res.coins)
                         .map_err(|e| e.into())
                 },
@@ -132,7 +135,7 @@ impl State for CreateSpendPanel {
             Command::perform(
                 async move {
                     let coins = daemon
-                        .list_coins(&[], &[])
+                        .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
                         .map(|res| res.coins)
                         .map_err(Error::from)?;
                     let mut targets = HashSet::<LabelItem>::new();

--- a/gui/src/app/state/spend/mod.rs
+++ b/gui/src/app/state/spend/mod.rs
@@ -123,7 +123,7 @@ impl State for CreateSpendPanel {
             Command::perform(
                 async move {
                     daemon1
-                        .list_coins()
+                        .list_coins(&[], &[])
                         .map(|res| res.coins)
                         .map_err(|e| e.into())
                 },
@@ -132,7 +132,7 @@ impl State for CreateSpendPanel {
             Command::perform(
                 async move {
                     let coins = daemon
-                        .list_coins()
+                        .list_coins(&[], &[])
                         .map(|res| res.coins)
                         .map_err(Error::from)?;
                     let mut targets = HashSet::<LabelItem>::new();

--- a/gui/src/app/state/transactions.rs
+++ b/gui/src/app/state/transactions.rs
@@ -152,7 +152,7 @@ impl State for TransactionsPanel {
                                 daemon
                                     // TODO: filter for spending coins when this is possible:
                                     // https://github.com/wizardsardine/liana/issues/677
-                                    .list_coins()
+                                    .list_coins(&[], &[])
                                     .map(|res| {
                                         res.coins
                                             .iter()
@@ -271,7 +271,7 @@ impl State for TransactionsPanel {
             Command::perform(
                 async move {
                     daemon2
-                        .list_coins()
+                        .list_coins(&[], &[])
                         .map(|res| res.coins)
                         .map_err(|e| e.into())
                 },

--- a/gui/src/app/state/transactions.rs
+++ b/gui/src/app/state/transactions.rs
@@ -249,7 +249,6 @@ impl State for TransactionsPanel {
         self.selected_tx = None;
         let daemon1 = daemon.clone();
         let daemon2 = daemon.clone();
-        let daemon3 = daemon.clone();
         let now: u32 = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -258,7 +257,7 @@ impl State for TransactionsPanel {
             .unwrap();
         Command::batch(vec![
             Command::perform(
-                async move { daemon3.list_pending_txs().map_err(|e| e.into()) },
+                async move { daemon2.list_pending_txs().map_err(|e| e.into()) },
                 Message::PendingTransactions,
             ),
             Command::perform(
@@ -268,15 +267,6 @@ impl State for TransactionsPanel {
                         .map_err(|e| e.into())
                 },
                 Message::HistoryTransactions,
-            ),
-            Command::perform(
-                async move {
-                    daemon2
-                        .list_coins(&[], &[])
-                        .map(|res| res.coins)
-                        .map_err(|e| e.into())
-                },
-                Message::Coins,
             ),
         ])
     }

--- a/gui/src/daemon/client/mod.rs
+++ b/gui/src/daemon/client/mod.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::iter::FromIterator;
 
-use liana::commands::CreateRecoveryResult;
+use liana::commands::{CoinStatus, CreateRecoveryResult};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -77,8 +77,18 @@ impl<C: Client + Debug> Daemon for Lianad<C> {
         self.call("getnewaddress", Option::<Request>::None)
     }
 
-    fn list_coins(&self) -> Result<ListCoinsResult, DaemonError> {
-        self.call("listcoins", Option::<Request>::None)
+    fn list_coins(
+        &self,
+        statuses: &[CoinStatus],
+        outpoints: &[OutPoint],
+    ) -> Result<ListCoinsResult, DaemonError> {
+        self.call(
+            "listcoins",
+            Some(vec![
+                json!(statuses.iter().map(|s| s.to_arg()).collect::<Vec<&str>>()),
+                json!(outpoints),
+            ]),
+        )
     }
 
     fn list_spend_txs(&self) -> Result<ListSpendResult, DaemonError> {

--- a/gui/src/daemon/embedded.rs
+++ b/gui/src/daemon/embedded.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 
 use super::{model::*, Daemon, DaemonError};
 use liana::{
-    commands::LabelItem,
+    commands::{CoinStatus, LabelItem},
     config::Config,
     miniscript::bitcoin::{address, psbt::Psbt, Address, OutPoint, Txid},
     DaemonControl, DaemonHandle,
@@ -87,8 +87,12 @@ impl Daemon for EmbeddedDaemon {
         self.command(|daemon| Ok(daemon.get_new_address()))
     }
 
-    fn list_coins(&self) -> Result<ListCoinsResult, DaemonError> {
-        self.command(|daemon| Ok(daemon.list_coins(&[], &[])))
+    fn list_coins(
+        &self,
+        statuses: &[CoinStatus],
+        outpoints: &[OutPoint],
+    ) -> Result<ListCoinsResult, DaemonError> {
+        self.command(|daemon| Ok(daemon.list_coins(statuses, outpoints)))
     }
 
     fn list_spend_txs(&self) -> Result<ListSpendResult, DaemonError> {

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -370,7 +370,7 @@ pub async fn load_application(
     let wallet =
         Wallet::new(info.descriptors.main).load_settings(&gui_config, &datadir_path, network)?;
 
-    let coins = daemon.list_coins().map(|res| res.coins)?;
+    let coins = daemon.list_coins(&[], &[]).map(|res| res.coins)?;
 
     let cache = Cache {
         datadir_path,

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -9,6 +9,7 @@ use iced::{Alignment, Command, Length, Subscription};
 use tracing::{debug, info, warn};
 
 use liana::{
+    commands::CoinStatus,
     config::{Config, ConfigError},
     miniscript::bitcoin,
     StartupError,
@@ -370,7 +371,9 @@ pub async fn load_application(
     let wallet =
         Wallet::new(info.descriptors.main).load_settings(&gui_config, &datadir_path, network)?;
 
-    let coins = daemon.list_coins(&[], &[]).map(|res| res.coins)?;
+    let coins = daemon
+        .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
+        .map(|res| res.coins)?;
 
     let cache = Cache {
         datadir_path,


### PR DESCRIPTION
This is to resolve https://github.com/wizardsardine/liana/issues/677.

As well as adding the filters to the daemon interface, I've applied filters in separate commits to different sections of the GUI.

This PR builds on changes from https://github.com/wizardsardine/liana/pull/958 and https://github.com/wizardsardine/liana/pull/965. The latter is required when filtering for pending transactions so that a coin whose spending txid changes (e.g. due to RBF) remains as spending.