### PR TITLE
gui: prevent spend with duplicate addresses

### DIFF
--- a/gui/src/app/view/spend/mod.rs
+++ b/gui/src/app/view/spend/mod.rs
@@ -253,7 +253,7 @@ pub fn create_spend_tx<'a>(
                             .width(Length::Fixed(100.0)),
                     )
                     .push(
-                        if is_valid
+                        if is_valid && !duplicate
                             && (is_self_send
                                 || (total_amount < *balance_available
                                     && Some(&Amount::from_sat(0)) == amount_left))


### PR DESCRIPTION
Currently, if duplicate addresses are entered when creating a new spend, the user can click Next and only the second amount will be used for the draft PSBT.

This change prevents the user clicking Next if there are duplicate addresses and stops the `redraft` function running.