### PR TITLE
ci: bump bitcoind version in functional tests to 26.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,7 +51,7 @@ task:
       echo "49df6e444515d457ea0b885d66f521f2a26ca92ccf73d5296082e633544253bf bitcoin-24.0.1-x86_64-linux-gnu.tar.gz" | sha256sum -c
       tar -xzf bitcoin-24.0.1-x86_64-linux-gnu.tar.gz
       export BITCOIND_PATH=bitcoin-24.0.1/bin/bitcoind
-      export IS_BITCOIND_25=0
+      export IS_NOT_BITCOIND_24=0
     else
       # Download the bitcoind binary
       curl -O https://bitcoincore.org/bin/bitcoin-core-26.0/bitcoin-26.0-x86_64-linux-gnu.tar.gz

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -54,10 +54,10 @@ task:
       export IS_BITCOIND_25=0
     else
       # Download the bitcoind binary
-      curl -O https://bitcoincore.org/bin/bitcoin-core-25.1/bitcoin-25.1-x86_64-linux-gnu.tar.gz
-      echo "a978c407b497a727f0444156e397b50491ce862d1f906fef9b521415b3611c8b bitcoin-25.1-x86_64-linux-gnu.tar.gz" | sha256sum -c
-      tar -xzf bitcoin-25.1-x86_64-linux-gnu.tar.gz
-      export BITCOIND_PATH=bitcoin-25.1/bin/bitcoind
+      curl -O https://bitcoincore.org/bin/bitcoin-core-26.0/bitcoin-26.0-x86_64-linux-gnu.tar.gz
+      echo "23e5ab226d9e01ffaadef5ffabe8868d0db23db952b90b0593652993680bb8ab bitcoin-26.0-x86_64-linux-gnu.tar.gz" | sha256sum -c
+      tar -xzf bitcoin-26.0-x86_64-linux-gnu.tar.gz
+      export BITCOIND_PATH=bitcoin-26.0/bin/bitcoind
     fi
 
     # The misc tests have a backward compat test that need the path to a previous version of Liana.

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -23,7 +23,7 @@ LIANAD_PATH = os.getenv("LIANAD_PATH", DEFAULT_MS_PATH)
 DEFAULT_BITCOIND_PATH = "bitcoind"
 BITCOIND_PATH = os.getenv("BITCOIND_PATH", DEFAULT_BITCOIND_PATH)
 OLD_LIANAD_PATH = os.getenv("OLD_LIANAD_PATH", None)
-IS_BITCOIND_25 = bool(int(os.getenv("IS_BITCOIND_25", True)))
+IS_NOT_BITCOIND_24 = bool(int(os.getenv("IS_NOT_BITCOIND_24", True)))
 
 
 COIN = 10**8

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -13,7 +13,7 @@ from test_framework.utils import (
     LIANAD_PATH,
     COIN,
     TIMEOUT,
-    IS_BITCOIND_25,
+    IS_NOT_BITCOIND_24,
 )
 
 from threading import Thread
@@ -275,7 +275,7 @@ def test_migration(lianad_multisig, bitcoind):
 
 
 @pytest.mark.skipif(
-    not IS_BITCOIND_25, reason="Need 'generateblock' with 'submit=False'"
+    not IS_NOT_BITCOIND_24, reason="Need 'generateblock' with 'submit=False'"
 )
 def test_bitcoind_submit_block(bitcoind):
     block_count = bitcoind.rpc.getblockcount()
@@ -297,7 +297,7 @@ def bitcoind_wait_new_block(bitcoind):
 
 
 @pytest.mark.skipif(
-    not IS_BITCOIND_25, reason="Need 'generateblock' with 'submit=False'"
+    not IS_NOT_BITCOIND_24, reason="Need 'generateblock' with 'submit=False'"
 )
 def test_retry_on_workqueue_exceeded(lianad, bitcoind, executor):
     """Make sure we retry requests to bitcoind if it is temporarily overloaded."""


### PR DESCRIPTION
I thought there was some hacks i do in the functional tests i needed to update but apparently i was mistaken.