### PR TITLE
gui: add max button for spend recipients

### DIFF
--- a/gui/src/app/state/spend/step.rs
+++ b/gui/src/app/state/spend/step.rs
@@ -192,6 +192,13 @@ impl DefineSpend {
     /// if the user did not select a coin manually
     fn redraft(&mut self, daemon: Arc<dyn Daemon + Sync + Send>) {
         if !self.form_values_are_valid() || self.exists_duplicate() || self.recipients.is_empty() {
+            // The current form details are not valid to draft a spend, so remove any previously
+            // calculated amount as it will no longer be valid and could be misleading, e.g. if
+            // the user removes the amount from one of the recipients.
+            // We can leave any coins selected as they will either be automatically updated
+            // as soon as the form is valid or the user has selected these specific coins and
+            // so we should not touch them.
+            self.amount_left_to_select = None;
             return;
         }
 

--- a/gui/src/app/view/message.rs
+++ b/gui/src/app/view/message.rs
@@ -37,6 +37,7 @@ pub enum CreateSpendMessage {
     FeerateEdited(String),
     SelectPath(usize),
     Generate,
+    SendMaxToRecipient(usize),
 }
 
 #[derive(Debug, Clone)]

--- a/gui/src/app/view/spend/mod.rs
+++ b/gui/src/app/view/spend/mod.rs
@@ -176,7 +176,10 @@ pub fn create_spend_tx<'a>(
                                         Message::CreateSpend(CreateSpendMessage::FeerateEdited(msg))
                                     },
                                 )
-                                .warning("Feerate must be an integer less than or equal to 1000 sats/vbyte")
+                                .warning(
+                                    "Feerate must be an integer less than \
+                                    or equal to 1000 sats/vbyte",
+                                )
                                 .size(20)
                                 .padding(10),
                             )
@@ -253,7 +256,8 @@ pub fn create_spend_tx<'a>(
                             .width(Length::Fixed(100.0)),
                     )
                     .push(
-                        if is_valid && !duplicate
+                        if is_valid
+                            && !duplicate
                             && (is_self_send
                                 || (total_amount < *balance_available
                                     && Some(&Amount::from_sat(0)) == amount_left))

--- a/gui/src/app/view/spend/mod.rs
+++ b/gui/src/app/view/spend/mod.rs
@@ -220,8 +220,14 @@ pub fn create_spend_tx<'a>(
                                         .push(amount_with_size(amount_left, P2_SIZE))
                                         .push(p2_regular("left to select").style(color::GREY_3))
                                 } else {
-                                    Row::new()
-                                        .push(text("Feerate needs to be set.").style(color::GREY_3))
+                                    Row::new().push(
+                                        text(if feerate.value.is_empty() || !feerate.valid {
+                                            "Feerate needs to be set."
+                                        } else {
+                                            "Add recipient details."
+                                        })
+                                        .style(color::GREY_3),
+                                    )
                                 })
                                 .width(Length::Fill),
                         )


### PR DESCRIPTION
This adds the MAX button from #546.

The max amount is calculated within the `redraft` function based on the change output. The recipient's amount is updated directly within this same function in order to avoid another call to `redraft` after updating the amount.

The MAX button only takes effect once when the user clicks it. If further changes are made (e.g. to feerate or other recipients), the value will not update and the user will need to click MAX again.

Currently, the MAX button is always clickable. It would be possible to determine for each recipient whether the MAX button should be clickable for that recipient (feerate is valid and all other recipients are valid and no duplicates), but it's not a trivial change so I'm not sure if it's worth doing as I think the behaviour is quite intuitive.