### PR TITLE
[GUI] Move qr code to modal

### DIFF
--- a/gui/src/app/state/receive.rs
+++ b/gui/src/app/state/receive.rs
@@ -27,6 +27,12 @@ use crate::daemon::{
     Daemon,
 };
 
+pub enum Modal {
+    VerifyAddress(VerifyAddressModal),
+    ShowQrCode(ShowQrCodeModal),
+    None,
+}
+
 #[derive(Debug, Default)]
 pub struct Addresses {
     list: Vec<Address>,
@@ -51,8 +57,7 @@ pub struct ReceivePanel {
     wallet: Arc<Wallet>,
     addresses: Addresses,
     labels_edited: LabelsEdited,
-    qr_code: Option<qr_code::State>,
-    modal: Option<VerifyAddressModal>,
+    modal: Modal,
     warning: Option<Error>,
 }
 
@@ -63,8 +68,7 @@ impl ReceivePanel {
             wallet,
             addresses: Addresses::default(),
             labels_edited: LabelsEdited::default(),
-            qr_code: None,
-            modal: None,
+            modal: Modal::None,
             warning: None,
         }
     }
@@ -78,22 +82,24 @@ impl State for ReceivePanel {
             self.warning.as_ref(),
             view::receive::receive(
                 &self.addresses.list,
-                self.qr_code.as_ref(),
                 &self.addresses.labels,
                 self.labels_edited.cache(),
             ),
         );
-        if let Some(m) = &self.modal {
-            modal::Modal::new(content, m.view())
+
+        match &self.modal {
+            Modal::VerifyAddress(m) => modal::Modal::new(content, m.view())
                 .on_blur(Some(view::Message::Close))
-                .into()
-        } else {
-            content
+                .into(),
+            Modal::ShowQrCode(m) => modal::Modal::new(content, m.view())
+                .on_blur(Some(view::Message::Close))
+                .into(),
+            Modal::None => content,
         }
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        if let Some(modal) = &self.modal {
+        if let Modal::VerifyAddress(modal) = &self.modal {
             modal.subscription()
         } else {
             Subscription::none()
@@ -124,11 +130,6 @@ impl State for ReceivePanel {
                 match res {
                     Ok((address, derivation_index)) => {
                         self.warning = None;
-                        self.qr_code = qr_code::State::new(format!(
-                            "bitcoin:{}?index={}",
-                            address, derivation_index
-                        ))
-                        .ok();
                         self.addresses.list.push(address);
                         self.addresses.derivation_indexes.push(derivation_index);
                     }
@@ -137,11 +138,11 @@ impl State for ReceivePanel {
                 Command::none()
             }
             Message::View(view::Message::Close) => {
-                self.modal = None;
+                self.modal = Modal::None;
                 Command::none()
             }
             Message::View(view::Message::Select(i)) => {
-                self.modal = Some(VerifyAddressModal::new(
+                self.modal = Modal::VerifyAddress(VerifyAddressModal::new(
                     self.data_dir.clone(),
                     self.wallet.clone(),
                     cache.network,
@@ -154,12 +155,20 @@ impl State for ReceivePanel {
                 ));
                 Command::none()
             }
+            Message::View(view::Message::ShowQrCode(i)) => {
+                let address = self.addresses.list.get(i).expect("Must be present").clone();
+                let qr_code = qr_code::State::new(format!("bitcoin:{}?index={}", address, i)).ok();
+                self.modal = Modal::ShowQrCode(ShowQrCodeModal::new(qr_code.unwrap()));
+                Command::none()
+            }
             Message::View(view::Message::Next) => self.load(daemon),
-            _ => self
-                .modal
-                .as_mut()
-                .map(|m| m.update(daemon, cache, message))
-                .unwrap_or_else(Command::none),
+            _ => {
+                if let Modal::VerifyAddress(ref mut m) = self.modal {
+                    m.update(daemon, cache, message)
+                } else {
+                    Command::none()
+                }
+            }
         }
     }
 
@@ -265,6 +274,20 @@ impl VerifyAddressModal {
             }
             _ => Command::none(),
         }
+    }
+}
+
+pub struct ShowQrCodeModal {
+    qr_code: qr_code::State,
+}
+
+impl ShowQrCodeModal {
+    pub fn new(qr: qr_code::State) -> Self {
+        Self { qr_code: qr }
+    }
+
+    fn view(&self) -> Element<view::Message> {
+        view::receive::qr_modal(&self.qr_code)
     }
 }
 

--- a/gui/src/app/view/message.rs
+++ b/gui/src/app/view/message.rs
@@ -18,6 +18,7 @@ pub enum Message {
     Previous,
     SelectHardwareWallet(usize),
     CreateRbf(CreateRbfMessage),
+    ShowQrCode(usize),
 }
 
 #[derive(Debug, Clone)]

--- a/gui/src/app/view/receive.rs
+++ b/gui/src/app/view/receive.rs
@@ -37,7 +37,6 @@ use super::message::Message;
 
 pub fn receive<'a>(
     addresses: &'a [bitcoin::Address],
-    qr: Option<&'a qr_code::State>,
     labels: &'a HashMap<String, String>,
     labels_editing: &'a HashMap<String, form::Value<String>>,
 ) -> Element<'a, Message> {
@@ -111,22 +110,23 @@ pub fn receive<'a>(
                                             .align_items(Alignment::Center),
                                     )
                                     .push(
-                                        button::primary(None, "Verify on hardware device")
-                                            .on_press(Message::Select(i)),
+                                        Row::new()
+                                            .push(
+                                                button::primary(None, "Verify on hardware device")
+                                                    .on_press(Message::Select(i)),
+                                            )
+                                            .push(Space::with_width(Length::Fill))
+                                            .push(
+                                                button::primary(None, "Show QR Code")
+                                                    .on_press(Message::ShowQrCode(i)),
+                                            ),
                                     )
                                     .spacing(10),
                             )
                             .padding(20),
                         )
                     },
-                ))
-                .push(if let Some(qr) = qr {
-                    Container::new(QRCode::new(qr).cell_size(5))
-                        .padding(10)
-                        .style(theme::Container::QrCode)
-                } else {
-                    Container::new(Space::with_width(Length::Fill)).width(Length::Fixed(200.0))
-                }),
+                )),
         )
         .spacing(20)
         .into()
@@ -212,5 +212,17 @@ pub fn verify_address_modal<'a>(
         ))
         .width(Length::Fill)
         .max_width(750)
+        .into()
+}
+
+pub fn qr_modal(qr: &qr_code::State) -> Element<Message> {
+    Column::new()
+        .push(
+            Container::new(QRCode::new(qr).cell_size(8))
+                .padding(10)
+                .style(theme::Container::QrCode),
+        )
+        .width(Length::Fill)
+        .max_width(400)
         .into()
 }


### PR DESCRIPTION
fix #949:
- Remove Qr code from view
- Add a button `Show QR Code` that display the QRCode in a new modal
- Increased size of Qr Code as we now have more room

![image](https://github.com/wizardsardine/liana/assets/124568858/446793c8-1cee-496b-a818-032a4dda547c)

![image](https://github.com/wizardsardine/liana/assets/124568858/0b918e2d-e48d-4b07-adb3-c58f97de42f0)



