### PR TITLE
lib: expose random module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod database;
 pub mod descriptors;
 #[cfg(feature = "daemon")]
 mod jsonrpc;
-mod random;
+pub mod random;
 pub mod signer;
 pub mod spend;
 #[cfg(test)]


### PR DESCRIPTION
This is motivated by #929. The GUI will need to generate a salt and password for RPC user/password authentication to the managed bitcoind, and can use this module to get random bytes.