### PR TITLE
[GUI] Limit amount to 8 decimal digits

### DIFF
--- a/gui/src/app/view/spend/mod.rs
+++ b/gui/src/app/view/spend/mod.rs
@@ -319,9 +319,9 @@ pub fn create_spend_tx<'a>(
 
 pub fn recipient_view<'a>(
     index: usize,
-    address: &form::Value<String>,
-    amount: &form::Value<String>,
-    label: &form::Value<String>,
+    address: &'a form::Value<String>,
+    amount: &'a form::Value<String>,
+    label: &'a form::Value<String>,
     is_max_selected: bool,
 ) -> Element<'a, CreateSpendMessage> {
     Container::new(
@@ -395,7 +395,7 @@ pub fn recipient_view<'a>(
                         None
                     })
                     .push_maybe(if !is_max_selected {
-                        Some(form::Form::new_trimmed("0.001 (in BTC)", amount, move |msg| {
+                        Some(form::Form::new_amount_btc("0.001 (in BTC)", amount, move |msg| {
                             CreateSpendMessage::RecipientEdited(index, "amount", msg)
                         })
                         .warning(

--- a/gui/ui/src/component/form.rs
+++ b/gui/ui/src/component/form.rs
@@ -1,3 +1,4 @@
+use bitcoin::Denomination;
 use iced::{widget::text_input, Length};
 
 use crate::{color, component::text, theme, util::Collection, widget::*};
@@ -57,6 +58,29 @@ where
         Self {
             input: text_input::TextInput::new(placeholder, &value.value)
                 .on_input(move |s| on_change(s.trim().to_string())),
+            warning: None,
+            valid: value.valid,
+        }
+    }
+
+    /// Creates a new [`Form`] that restrict input values to valid btc amount before applying the
+    /// `on_change` function.
+    /// It expects:
+    /// - a placeholder
+    /// - the current value
+    /// - a function that produces a message when the [`Form`] changes
+    pub fn new_amount_btc<F>(placeholder: &str, value: &'a Value<String>, on_change: F) -> Self
+    where
+        F: 'static + Fn(String) -> Message,
+    {
+        Self {
+            input: text_input::TextInput::new(placeholder, &value.value).on_input(move |s| {
+                if bitcoin::Amount::from_str_in(&s, Denomination::Bitcoin).is_ok() || s.is_empty() {
+                    on_change(s)
+                } else {
+                    on_change(value.value.clone())
+                }
+            }),
             warning: None,
             valid: value.valid,
         }


### PR DESCRIPTION
This PR replace #977 and fixes #798 
I've followed jp1ac4 advice and create a `Form::new_amount_btc()` method that act like `Form::new_trimmed()` ~w/ few more (filtering) features:~
~- allow only input of "0123456789,." characters~
~- "," is replaced by "."~
~- only one "." separator~
~- maximum 8 digit after separator~

~these features works for keyboard input or paste~

~i've tryied to add a "0" in case the String start with a "." but this make the cursor have a bad location and i do not find a way to control the cursor location w/ iced, so i revert this feature~

