### PR TITLE
gui: hint at rescan when importing wallet

### DIFF
--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -414,7 +414,19 @@ pub fn import_descriptor<'a>(
                     } else {
                         None
                     })
-                    .push(col_descriptor),
+                    .push(col_descriptor)
+                    .push_maybe(if change_network {
+                        // only show message when importing a descriptor
+                        Some(text(
+                            "After creating the wallet, \
+                            you will need to perform a rescan of \
+                            the blockchain in order to see your \
+                            coins and past transactions. This can \
+                            be done in Settings > Bitcoin Core.",
+                        ))
+                    } else {
+                        None
+                    }),
             )
             .push(
                 if imported_descriptor.value.is_empty() || !imported_descriptor.valid {


### PR DESCRIPTION
This is to resolve #866.

I've added the message to the first step where the user enters the descriptor:

![image](https://github.com/wizardsardine/liana/assets/121959000/122c0476-79b5-4b0d-a711-73312a94dc01)
