### PR TITLE
gui: add transaction redirection

### DIFF
--- a/gui/src/app/menu.rs
+++ b/gui/src/app/menu.rs
@@ -5,6 +5,7 @@ pub enum Menu {
     Receive,
     PSBTs,
     Transactions,
+    TransactionPreSelected(Txid),
     Settings,
     Coins,
     CreateSpendTx,

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -84,6 +84,7 @@ impl Panels {
             Menu::Receive => &self.receive,
             Menu::PSBTs => &self.psbts,
             Menu::Transactions => &self.transactions,
+            Menu::TransactionPreSelected(_) => &self.transactions,
             Menu::Settings => &self.settings,
             Menu::Coins => &self.coins,
             Menu::CreateSpendTx => &self.create_spend,
@@ -99,6 +100,7 @@ impl Panels {
             Menu::Receive => &mut self.receive,
             Menu::PSBTs => &mut self.psbts,
             Menu::Transactions => &mut self.transactions,
+            Menu::TransactionPreSelected(_) => &mut self.transactions,
             Menu::Settings => &mut self.settings,
             Menu::Coins => &mut self.coins,
             Menu::CreateSpendTx => &mut self.create_spend,
@@ -152,6 +154,17 @@ impl App {
 
     fn set_current_panel(&mut self, menu: Menu) -> Command<Message> {
         match &menu {
+            menu::Menu::TransactionPreSelected(txid) => {
+                if let Ok(Some(tx)) = self
+                    .daemon
+                    .get_history_txs(&[*txid])
+                    .map(|txs| txs.first().cloned())
+                {
+                    self.panels.transactions.preselect(tx);
+                    self.panels.current = menu;
+                    return Command::none();
+                };
+            }
             menu::Menu::PsbtPreSelected(txid) => {
                 // Get preselected spend from DB in case it's not yet in the cache.
                 // We only need this single spend as we will go straight to its view and not show the PSBTs list.

--- a/gui/src/app/view/home.rs
+++ b/gui/src/app/view/home.rs
@@ -315,31 +315,8 @@ pub fn payment_view<'a>(
                     .spacing(5),
             ))
             .push(
-                Column::new()
-                    .spacing(20)
-                    // We do not need to display inputs for external incoming transactions
-                    .push_maybe(if tx.is_external() {
-                        None
-                    } else {
-                        Some(super::psbt::inputs_view(
-                            &tx.coins,
-                            &tx.tx,
-                            &tx.labels,
-                            labels_editing,
-                        ))
-                    })
-                    .push(super::psbt::outputs_view(
-                        &tx.tx,
-                        cache.network,
-                        if tx.is_external() {
-                            None
-                        } else {
-                            Some(tx.change_indexes.clone())
-                        },
-                        &tx.labels,
-                        labels_editing,
-                        tx.is_single_payment().is_some(),
-                    )),
+                button::primary(None, "See transaction details")
+                    .on_press(Message::Menu(Menu::TransactionPreSelected(tx.tx.txid()))),
             )
             .spacing(20),
     )

--- a/gui/src/daemon/mod.rs
+++ b/gui/src/daemon/mod.rs
@@ -184,6 +184,44 @@ pub trait Daemon: Debug {
         Ok(txs)
     }
 
+    fn get_history_txs(
+        &self,
+        txids: &[Txid],
+    ) -> Result<Vec<model::HistoryTransaction>, DaemonError> {
+        let info = self.get_info()?;
+        let coins = self.list_coins()?.coins;
+        let txs = self.list_txs(txids)?.transactions;
+        let mut txs = txs
+            .into_iter()
+            .map(|tx| {
+                let mut tx_coins = Vec::new();
+                let mut change_indexes = Vec::new();
+                for coin in &coins {
+                    if coin.outpoint.txid == tx.tx.txid() {
+                        change_indexes.push(coin.outpoint.vout as usize)
+                    } else if tx
+                        .tx
+                        .input
+                        .iter()
+                        .any(|input| input.previous_output == coin.outpoint)
+                    {
+                        tx_coins.push(coin.clone());
+                    }
+                }
+                model::HistoryTransaction::new(
+                    tx.tx,
+                    tx.height,
+                    tx.time,
+                    tx_coins,
+                    change_indexes,
+                    info.network,
+                )
+            })
+            .collect();
+        load_labels(self, &mut txs)?;
+        Ok(txs)
+    }
+
     fn list_pending_txs(&self) -> Result<Vec<model::HistoryTransaction>, DaemonError> {
         let info = self.get_info()?;
         let coins = self.list_coins()?.coins;


### PR DESCRIPTION
based on #959 
This PR removes the payment section about the transaction inputs outputs for a redirection to the payment transaction (The `See transaction details` button). It makes it easy to fee bump a payment by clicking on it to be redirected to the transaction to rbf

![20240305_18h13m51s_grim](https://github.com/wizardsardine/liana/assets/6933020/bbb21e84-9fb6-4eed-ba93-2c4f6177cb95)

Maybe the UX/UI of the payment should be changed to remove more transaction information, but I fear it makes the panel a little bit empty.