### PR TITLE
Add default hint for hardware wallet errors

### DIFF
--- a/gui/src/app/error.rs
+++ b/gui/src/app/error.rs
@@ -51,7 +51,7 @@ impl std::fmt::Display for Error {
                 DaemonError::CoinSelectionError => write!(f, "{}", e),
             },
             Self::Unexpected(e) => write!(f, "Unexpected error: {}", e),
-            Self::HardwareWallet(e) => write!(f, "{}", e),
+            Self::HardwareWallet(e) => write!(f, "error: {}\nPlease check if the device is still connected and unlocked with the correct firmware open for the current network and no other application is accessing the device.", e),
             Self::Desc(e) => write!(f, "Liana descriptor error: {}", e),
         }
     }


### PR DESCRIPTION
Signing fails if another process has an open connection with a Ledger for example. Async-hwi needs to have a more detailed error api in order to handle graciously errors, but for now we provide a hint to what to check for the user

close #381 
![20240312_17h00m03s_grim](https://github.com/wizardsardine/liana/assets/6933020/6e5aff8c-d46f-4a44-a5e6-68d40e4d297c)
