### PR TITLE
Update our state upon broadcasting a transaction

### DIFF
--- a/src/bin/daemon.rs
+++ b/src/bin/daemon.rs
@@ -70,13 +70,16 @@ fn main() {
         process::exit(1);
     });
 
-    let daemon = DaemonHandle::start_default(config).unwrap_or_else(|e| {
+    let handle = DaemonHandle::start_default(config, true).unwrap_or_else(|e| {
         log::error!("Error starting Liana daemon: {}", e);
         process::exit(1);
     });
-    daemon
-        .rpc_server()
-        .expect("JSONRPC server must terminate cleanly");
+    while handle.is_alive() {
+        thread::sleep(time::Duration::from_millis(500));
+    }
+    if let Err(e) = handle.stop() {
+        log::error!("Error stopping Liana daemon: {}", e);
+    }
 
     // We are always logging to stdout, should it be then piped to the log file (if self) or
     // not. So just make sure that all messages were actually written.

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -325,6 +325,17 @@ fn sync_poll_interval() -> time::Duration {
     time::Duration::from_secs(0)
 }
 
+/// Update our state from the Bitcoin backend.
+pub fn poll(
+    bit: &sync::Arc<sync::Mutex<dyn BitcoinInterface>>,
+    db: &sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
+    secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    descs: &[descriptors::SinglePathLianaDesc],
+) {
+    updates(bit, db, descs, secp);
+    rescan_check(bit, db, descs, secp);
+}
+
 /// Main event loop. Repeatedly polls the Bitcoin interface until told to stop through the
 /// `shutdown` atomic.
 pub fn looper(
@@ -378,7 +389,6 @@ pub fn looper(
             }
         }
 
-        updates(&bit, &db, &descs, &secp);
-        rescan_check(&bit, &db, &descs, &secp);
+        poll(&bit, &db, &secp, &descs);
     }
 }

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -4,11 +4,7 @@ use crate::{
     descriptors,
 };
 
-use std::{
-    collections::HashSet,
-    sync::{self, atomic},
-    thread, time,
-};
+use std::{collections::HashSet, sync, time};
 
 use miniscript::bitcoin::{self, secp256k1};
 
@@ -302,8 +298,8 @@ fn rescan_check(
     }
 }
 
-// If the database chain tip is NULL (first startup), initialize it.
-fn maybe_initialize_tip(bit: &impl BitcoinInterface, db: &impl DatabaseInterface) {
+/// If the database chain tip is NULL (first startup), initialize it.
+pub fn maybe_initialize_tip(bit: &impl BitcoinInterface, db: &impl DatabaseInterface) {
     let mut db_conn = db.connection();
 
     if db_conn.chain_tip().is_none() {
@@ -312,7 +308,7 @@ fn maybe_initialize_tip(bit: &impl BitcoinInterface, db: &impl DatabaseInterface
     }
 }
 
-fn sync_poll_interval() -> time::Duration {
+pub fn sync_poll_interval() -> time::Duration {
     // TODO: be smarter, like in revaultd, but more generic too.
     #[cfg(not(test))]
     {
@@ -332,61 +328,4 @@ pub fn poll(
     let mut db_conn = db.connection();
     updates(&mut db_conn, bit, descs, secp);
     rescan_check(&mut db_conn, bit, descs, secp);
-}
-
-/// Main event loop. Repeatedly polls the Bitcoin interface until told to stop through the
-/// `shutdown` atomic.
-pub fn looper(
-    bit: sync::Arc<sync::Mutex<dyn BitcoinInterface>>,
-    db: sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
-    shutdown: sync::Arc<atomic::AtomicBool>,
-    poll_interval: time::Duration,
-    desc: descriptors::LianaDescriptor,
-) {
-    let mut last_poll = None;
-    let mut synced = false;
-    let descs = [
-        desc.receive_descriptor().clone(),
-        desc.change_descriptor().clone(),
-    ];
-    let secp = secp256k1::Secp256k1::verification_only();
-
-    maybe_initialize_tip(&bit, &db);
-
-    while !shutdown.load(atomic::Ordering::Relaxed) || last_poll.is_none() {
-        let now = time::Instant::now();
-
-        if let Some(last_poll) = last_poll {
-            let time_since_poll = now.duration_since(last_poll);
-            let poll_interval = if synced {
-                poll_interval
-            } else {
-                // Until we are synced we poll less often to avoid harassing bitcoind and impeding
-                // the sync. As a function since it's mocked for the tests.
-                sync_poll_interval()
-            };
-            if time_since_poll < poll_interval {
-                thread::sleep(time::Duration::from_millis(500));
-                continue;
-            }
-        }
-        last_poll = Some(now);
-
-        // Don't poll until the Bitcoin backend is fully synced.
-        if !synced {
-            let progress = bit.sync_progress();
-            log::info!(
-                "Block chain synchronization progress: {:.2}% ({} blocks / {} headers)",
-                progress.rounded_up_progress() * 100.0,
-                progress.blocks,
-                progress.headers
-            );
-            synced = progress.is_complete();
-            if !synced {
-                continue;
-            }
-        }
-
-        poll(&bit, &db, &secp, &descs);
-    }
 }

--- a/src/bitcoin/poller/mod.rs
+++ b/src/bitcoin/poller/mod.rs
@@ -1,60 +1,95 @@
 mod looper;
 
-use crate::{
-    bitcoin::{poller::looper::looper, BitcoinInterface},
-    database::DatabaseInterface,
-    descriptors,
-};
+use crate::{bitcoin::BitcoinInterface, database::DatabaseInterface, descriptors};
 
 use std::{
     sync::{self, atomic},
     thread, time,
 };
 
+use miniscript::bitcoin::secp256k1;
+
 /// The Bitcoin poller handler.
 pub struct Poller {
-    handle: thread::JoinHandle<()>,
-    shutdown: sync::Arc<atomic::AtomicBool>,
+    bit: sync::Arc<sync::Mutex<dyn BitcoinInterface>>,
+    db: sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
+    secp: secp256k1::Secp256k1<secp256k1::VerifyOnly>,
+    // The receive and change descriptors (in this order).
+    descs: [descriptors::SinglePathLianaDesc; 2],
 }
 
 impl Poller {
-    pub fn start(
+    pub fn new(
         bit: sync::Arc<sync::Mutex<dyn BitcoinInterface>>,
         db: sync::Arc<sync::Mutex<dyn DatabaseInterface>>,
-        poll_interval: time::Duration,
         desc: descriptors::LianaDescriptor,
     ) -> Poller {
-        let shutdown = sync::Arc::from(atomic::AtomicBool::from(false));
-        let handle = thread::Builder::new()
-            .name("Bitcoin poller".to_string())
-            .spawn({
-                let shutdown = shutdown.clone();
-                move || looper(bit, db, shutdown, poll_interval, desc)
-            })
-            .expect("Must not fail");
+        let secp = secp256k1::Secp256k1::verification_only();
+        let descs = [
+            desc.receive_descriptor().clone(),
+            desc.change_descriptor().clone(),
+        ];
 
-        Poller { shutdown, handle }
+        // On first startup the tip may be NULL. Make sure it's set as the poller relies on it.
+        looper::maybe_initialize_tip(&bit, &db);
+
+        Poller {
+            bit,
+            db,
+            secp,
+            descs,
+        }
     }
 
-    pub fn trigger_stop(&self) {
-        self.shutdown.store(true, atomic::Ordering::Relaxed);
-    }
+    /// Continuously update our state from the Bitcoin backend.
+    /// - `poll_interval`: how frequently to perform an update.
+    /// - `shutdown`: set to true to stop continuously updating and make this function return.
+    ///
+    /// Typically this would run for the whole duration of the program in a thread, and the main
+    /// thread would set the `shutdown` atomic to `true` when shutting down.
+    pub fn poll_forever(
+        &self,
+        poll_interval: time::Duration,
+        shutdown: sync::Arc<atomic::AtomicBool>,
+    ) {
+        let mut last_poll = None;
+        let mut synced = false;
 
-    pub fn stop(self) {
-        self.trigger_stop();
-        self.handle.join().expect("The poller loop must not fail");
-    }
+        while !shutdown.load(atomic::Ordering::Relaxed) || last_poll.is_none() {
+            let now = time::Instant::now();
 
-    #[cfg(feature = "nonblocking_shutdown")]
-    pub fn is_stopped(&self) -> bool {
-        // Doc says "This might return true for a brief moment after the thread’s main function has
-        // returned, but before the thread itself has stopped running.". But it's not an issue for
-        // us, as long as the main poller function has returned we are good.
-        self.handle.is_finished()
-    }
+            if let Some(last_poll) = last_poll {
+                let time_since_poll = now.duration_since(last_poll);
+                let poll_interval = if synced {
+                    poll_interval
+                } else {
+                    // Until we are synced we poll less often to avoid harassing bitcoind and impeding
+                    // the sync. As a function since it's mocked for the tests.
+                    looper::sync_poll_interval()
+                };
+                if time_since_poll < poll_interval {
+                    thread::sleep(time::Duration::from_millis(500));
+                    continue;
+                }
+            }
+            last_poll = Some(now);
 
-    #[cfg(test)]
-    pub fn test_stop(&mut self) {
-        self.shutdown.store(true, atomic::Ordering::Relaxed);
+            // Don't poll until the Bitcoin backend is fully synced.
+            if !synced {
+                let progress = self.bit.sync_progress();
+                log::info!(
+                    "Block chain synchronization progress: {:.2}% ({} blocks / {} headers)",
+                    progress.rounded_up_progress() * 100.0,
+                    progress.blocks,
+                    progress.headers
+                );
+                synced = progress.is_complete();
+                if !synced {
+                    continue;
+                }
+            }
+
+            looper::poll(&self.bit, &self.db, &self.secp, &self.descs);
+        }
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1251,7 +1251,7 @@ mod tests {
     fn getinfo() {
         let ms = DummyLiana::new(DummyBitcoind::new(), DummyDatabase::new());
         // We can query getinfo
-        ms.handle.control.get_info();
+        ms.control().get_info();
         ms.shutdown();
     }
 
@@ -1259,7 +1259,7 @@ mod tests {
     fn getnewaddress() {
         let ms = DummyLiana::new(DummyBitcoind::new(), DummyDatabase::new());
 
-        let control = &ms.handle.control;
+        let control = &ms.control();
         // We can get an address
         let addr = control.get_new_address().address;
         assert_eq!(
@@ -1281,7 +1281,7 @@ mod tests {
     fn listaddresses() {
         let ms = DummyLiana::new(DummyBitcoind::new(), DummyDatabase::new());
 
-        let control = &ms.handle.control;
+        let control = &ms.control();
 
         let list = control.list_addresses(Some(2), Some(5)).unwrap();
 
@@ -1412,7 +1412,7 @@ mod tests {
             ),
         );
         let ms = DummyLiana::new(dummy_bitcoind, DummyDatabase::new());
-        let control = &ms.handle.control;
+        let control = &ms.control();
 
         // Arguments sanity checking
         let dummy_addr =
@@ -1900,7 +1900,7 @@ mod tests {
             .insert(dummy_op_a.txid, (dummy_tx.clone(), None));
         dummy_bitcoind.txs.insert(dummy_op_b.txid, (dummy_tx, None));
         let ms = DummyLiana::new(dummy_bitcoind, DummyDatabase::new());
-        let control = &ms.handle.control;
+        let control = &ms.control();
         let mut db_conn = control.db().lock().unwrap().connection();
 
         // Add two (unconfirmed) coins in DB
@@ -2046,7 +2046,7 @@ mod tests {
         let dummy_txid_a = dummy_psbt_a.unsigned_tx.txid();
         dummy_bitcoind.txs.insert(dummy_txid_a, (dummy_tx_a, None));
         let ms = DummyLiana::new(dummy_bitcoind, DummyDatabase::new());
-        let control = &ms.handle.control;
+        let control = &ms.control();
         let mut db_conn = control.db().lock().unwrap().connection();
         // The spend needs to be in DB before using RBF.
         assert_eq!(
@@ -2284,7 +2284,7 @@ mod tests {
 
         let ms = DummyLiana::new(btc, db);
 
-        let control = &ms.handle.control;
+        let control = &ms.control();
 
         let transactions = control.list_confirmed_transactions(0, 4, 10).transactions;
         assert_eq!(transactions.len(), 4);
@@ -2416,7 +2416,7 @@ mod tests {
 
         let ms = DummyLiana::new(btc, DummyDatabase::new());
 
-        let control = &ms.handle.control;
+        let control = &ms.control();
 
         let transactions = control.list_transactions(&[tx1.txid()]).transactions;
         assert_eq!(transactions.len(), 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ use std::{error, fmt, fs, io, path, sync, thread};
 use miniscript::bitcoin::secp256k1;
 
 #[cfg(not(test))]
-use std::{panic, process};
+use std::panic;
 // A panic in any thread should stop the main thread, and print the panic.
 #[cfg(not(test))]
 fn setup_panic_hook() {
@@ -60,8 +60,6 @@ fn setup_panic_hook() {
             info,
             bt
         );
-
-        process::exit(1);
     }));
 }
 
@@ -309,9 +307,6 @@ impl DaemonHandle {
     /// default Bitcoin interface (`bitcoind` JSONRPC) will be used.
     /// You may specify a custom Database interface through the `db` parameter. If `None`, the
     /// default Database interface (SQLite) will be used.
-    ///
-    /// **Note**: we internally use threads, and set a panic hook. A downstream application must
-    /// not overwrite this panic hook.
     pub fn start(
         config: Config,
         bitcoin: Option<impl BitcoinInterface + 'static>,

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -498,9 +498,14 @@ impl DummyLiana {
             main_descriptor: desc,
         };
 
-        let handle =
-            DaemonHandle::start(config, Some(bitcoin_interface), Some(database), rpc_server)
-                .unwrap();
+        let handle = DaemonHandle::start(
+            config,
+            Some(bitcoin_interface),
+            Some(database),
+            #[cfg(feature = "daemon")]
+            rpc_server,
+        )
+        .unwrap();
         DummyLiana { tmp_dir, handle }
     }
 
@@ -513,6 +518,7 @@ impl DummyLiana {
     }
 
     /// Creates a new DummyLiana interface which also spins up an RPC server.
+    #[cfg(feature = "daemon")]
     pub fn new_server(
         bitcoin_interface: impl BitcoinInterface + 'static,
         database: impl DatabaseInterface + 'static,
@@ -523,6 +529,7 @@ impl DummyLiana {
     pub fn control(&self) -> &DaemonControl {
         match self.handle {
             DaemonHandle::Controller { ref control, .. } => control,
+            #[cfg(feature = "daemon")]
             DaemonHandle::Server { .. } => unreachable!(),
         }
     }


### PR DESCRIPTION
Fixes https://github.com/wizardsardine/liana/issues/887.

This takes a couple commits from #909 but takes the approach from there in another direction: we don't externalize the poller, since only a single instance must be ran. Instead we properly keep track of the (up to) two threads we manage in the `DaemonHandle` and provide a way for a user of the library to check for errors in any of the threads.

This approach allows us to 1) communicate with the poller thread from inside the Liana library/daemon (here we leverage this to tell it to poll) 2) eventually (#909) expose all internal errors from the library to the user instead of panic'ing internally.

See the commit messages for details.