### PR TITLE
fix recovery panel reload

### DIFF
--- a/gui/src/app/state/recovery.rs
+++ b/gui/src/app/state/recovery.rs
@@ -194,6 +194,11 @@ impl State for RecoveryPanel {
 
     fn reload(&mut self, daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {
         let daemon = daemon.clone();
+        self.selected_path = None;
+        self.warning = None;
+        self.feerate = form::Value::default();
+        self.recipient = form::Value::default();
+        self.generated = None;
         Command::perform(
             async move {
                 daemon


### PR DESCRIPTION
Once a psbt was generated with the recovery panel
it is impossible for user to start again a recovery process He is redirected to the previous generated psbt because of the panel state being not reset.

This commit reset the panel state on reload.