### PR TITLE
gui: clear RBF modal if selected transaction changes

### DIFF
--- a/gui/src/app/state/transactions.rs
+++ b/gui/src/app/state/transactions.rs
@@ -127,6 +127,14 @@ impl State for TransactionsPanel {
                 } else {
                     self.txs.get(i - self.pending_txs.len()).cloned()
                 };
+                // Clear modal if it's for a different tx.
+                if let Some(modal) = &self.create_rbf_modal {
+                    if Some(modal.tx.tx.txid())
+                        != self.selected_tx.as_ref().map(|selected| selected.tx.txid())
+                    {
+                        self.create_rbf_modal = None;
+                    }
+                }
             }
             Message::View(view::Message::CreateRbf(view::CreateRbfMessage::Cancel)) => {
                 self.create_rbf_modal = None;


### PR DESCRIPTION
As a follow-up to #959, this clears the RBF modal if the selected transaction changes. e.g. after going to the replacement transaction from the RBF modal and then returning to the Transactions panel and selecting a different transaction.