### PR TITLE
bump clippy rust toolchain to 1.76.0 for gui + fix new clippy warnings 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: 1.75.0
+            toolchain: 1.76.0
             components: rustfmt, clippy
             override: true
       - name: rustfmt

--- a/gui/src/app/view/home.rs
+++ b/gui/src/app/view/home.rs
@@ -28,9 +28,9 @@ pub fn home_view<'a>(
     balance: &'a bitcoin::Amount,
     unconfirmed_balance: &'a bitcoin::Amount,
     remaining_sequence: &Option<u32>,
-    expiring_coins: &Vec<bitcoin::OutPoint>,
+    expiring_coins: &[bitcoin::OutPoint],
     pending_events: &'a [HistoryTransaction],
-    events: &'a Vec<HistoryTransaction>,
+    events: &'a [HistoryTransaction],
 ) -> Element<'a, Message> {
     Column::new()
         .push(h3("Balance"))
@@ -88,7 +88,7 @@ pub fn home_view<'a>(
                         )
                         .push(
                             button::primary(Some(icon::arrow_repeat()), "Refresh coins").on_press(
-                                Message::Menu(Menu::RefreshCoins(expiring_coins.clone())),
+                                Message::Menu(Menu::RefreshCoins(expiring_coins.to_owned())),
                             ),
                         ),
                 )

--- a/gui/src/app/view/spend/mod.rs
+++ b/gui/src/app/view/spend/mod.rs
@@ -33,7 +33,7 @@ use crate::{
 pub fn spend_view<'a>(
     cache: &'a Cache,
     tx: &'a SpendTx,
-    spend_warnings: &'a Vec<String>,
+    spend_warnings: &'a [String],
     saved: bool,
     desc_info: &'a LianaPolicy,
     key_aliases: &'a HashMap<Fingerprint, String>,

--- a/gui/src/app/view/transactions.rs
+++ b/gui/src/app/view/transactions.rs
@@ -26,7 +26,7 @@ pub const HISTORY_EVENT_PAGE_SIZE: u64 = 20;
 pub fn transactions_view<'a>(
     cache: &'a Cache,
     pending_txs: &'a [HistoryTransaction],
-    txs: &'a Vec<HistoryTransaction>,
+    txs: &'a [HistoryTransaction],
     warning: Option<&'a Error>,
 ) -> Element<'a, Message> {
     dashboard(

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -444,7 +444,7 @@ pub fn import_descriptor<'a>(
     )
 }
 
-pub fn signer_xpubs(xpubs: &Vec<String>) -> Element<Message> {
+pub fn signer_xpubs(xpubs: &[String]) -> Element<Message> {
     Container::new(
         Column::new()
             .push(
@@ -1710,7 +1710,7 @@ pub fn recover_mnemonic<'a>(
     progress: (usize, usize),
     words: &'a [(String, bool); 12],
     current: usize,
-    suggestions: &'a Vec<String>,
+    suggestions: &'a [String],
     recover: bool,
     error: Option<&'a String>,
 ) -> Element<'a, Message> {


### PR DESCRIPTION
bump rust toolchain to 1.76.0 for gui + fix new clippy warnings introduced by 1.76.0