### PR TITLE
gui: sort events and txs after push in the list

### DIFF
--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -180,6 +180,7 @@ impl State for Home {
                             self.events.push(event);
                         }
                     }
+                    self.events.sort_by(|a, b| b.time.cmp(&a.time));
                 }
             },
             Message::PendingTransactions(res) => match res {

--- a/gui/src/app/state/transactions.rs
+++ b/gui/src/app/state/transactions.rs
@@ -100,6 +100,7 @@ impl State for TransactionsPanel {
                             self.txs.push(tx);
                         }
                     }
+                    self.txs.sort_by(|a, b| b.time.cmp(&a.time));
                 }
             },
             Message::PendingTransactions(res) => match res {


### PR DESCRIPTION
when a pending tx is confirmed, it is pushed in the HistoryTransaction list at the end. It should be first in the list. We sort now the list in order to make sure it will be always the case.