### PR TITLE
gui: record updates to aliases

### DIFF
--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -60,7 +60,7 @@ impl Panels {
             current: Menu::Home,
             home: Home::new(wallet.clone(), &cache.coins),
             coins: CoinsPanel::new(&cache.coins, wallet.main_descriptor.first_timelock_value()),
-            transactions: TransactionsPanel::new(),
+            transactions: TransactionsPanel::new(wallet.clone()),
             psbts: PsbtsPanel::new(wallet.clone()),
             recovery: RecoveryPanel::new(wallet.clone(), &cache.coins, cache.blockheight),
             receive: ReceivePanel::new(data_dir.clone(), wallet.clone()),
@@ -137,7 +137,7 @@ impl App {
             data_dir.clone(),
             internal_bitcoind.as_ref(),
         );
-        let cmd = panels.home.reload(daemon.clone());
+        let cmd = panels.home.reload(daemon.clone(), wallet.clone());
         (
             Self {
                 panels,
@@ -202,7 +202,9 @@ impl App {
             _ => {}
         };
         self.panels.current = menu;
-        self.panels.current_mut().reload(self.daemon.clone())
+        self.panels
+            .current_mut()
+            .reload(self.daemon.clone(), self.wallet.clone())
     }
 
     pub fn subscription(&self) -> Subscription<Message> {

--- a/gui/src/app/state/coins.rs
+++ b/gui/src/app/state/coins.rs
@@ -14,6 +14,7 @@ use crate::{
         message::Message,
         state::{label::LabelsEdited, State},
         view,
+        wallet::Wallet,
     },
     daemon::{
         model::{Coin, LabelItem, Labelled},
@@ -150,7 +151,11 @@ impl State for CoinsPanel {
         Command::none()
     }
 
-    fn reload(&mut self, daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {
+    fn reload(
+        &mut self,
+        daemon: Arc<dyn Daemon + Sync + Send>,
+        _wallet: Arc<Wallet>,
+    ) -> Command<Message> {
         let daemon1 = daemon.clone();
         let daemon2 = daemon.clone();
         Command::batch(vec![

--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -44,7 +44,11 @@ pub trait State {
     fn subscription(&self) -> Subscription<Message> {
         Subscription::none()
     }
-    fn reload(&mut self, _daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {
+    fn reload(
+        &mut self,
+        _daemon: Arc<dyn Daemon + Sync + Send>,
+        _wallet: Arc<Wallet>,
+    ) -> Command<Message> {
         Command::none()
     }
 }
@@ -208,7 +212,7 @@ impl State for Home {
                 };
             }
             Message::View(view::Message::Reload) => {
-                return self.reload(daemon);
+                return self.reload(daemon, self.wallet.clone());
             }
             Message::View(view::Message::Close) => {
                 self.selected_event = None;
@@ -259,8 +263,13 @@ impl State for Home {
         Command::none()
     }
 
-    fn reload(&mut self, daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {
+    fn reload(
+        &mut self,
+        daemon: Arc<dyn Daemon + Sync + Send>,
+        wallet: Arc<Wallet>,
+    ) -> Command<Message> {
         self.selected_event = None;
+        self.wallet = wallet;
         let daemon1 = daemon.clone();
         let daemon2 = daemon.clone();
         let daemon3 = daemon.clone();

--- a/gui/src/app/state/psbts.rs
+++ b/gui/src/app/state/psbts.rs
@@ -75,7 +75,7 @@ impl State for PsbtsPanel {
     ) -> Command<Message> {
         match message {
             Message::View(view::Message::Reload) | Message::View(view::Message::Close) => {
-                return self.reload(daemon);
+                return self.reload(daemon, self.wallet.clone());
             }
             Message::SpendTxs(res) => match res {
                 Err(e) => self.warning = Some(e),
@@ -118,7 +118,12 @@ impl State for PsbtsPanel {
         }
     }
 
-    fn reload(&mut self, daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {
+    fn reload(
+        &mut self,
+        daemon: Arc<dyn Daemon + Sync + Send>,
+        wallet: Arc<Wallet>,
+    ) -> Command<Message> {
+        self.wallet = wallet;
         self.selected_tx = None;
         self.import_tx = None;
         let daemon = daemon.clone();

--- a/gui/src/app/state/recovery.rs
+++ b/gui/src/app/state/recovery.rs
@@ -192,8 +192,13 @@ impl State for RecoveryPanel {
         Command::none()
     }
 
-    fn reload(&mut self, daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {
+    fn reload(
+        &mut self,
+        daemon: Arc<dyn Daemon + Sync + Send>,
+        wallet: Arc<Wallet>,
+    ) -> Command<Message> {
         let daemon = daemon.clone();
+        self.wallet = wallet;
         self.selected_path = None;
         self.warning = None;
         self.feerate = form::Value::default();

--- a/gui/src/app/state/settings/mod.rs
+++ b/gui/src/app/state/settings/mod.rs
@@ -53,25 +53,28 @@ impl State for SettingsState {
                     )
                     .into(),
                 );
+                let wallet = self.wallet.clone();
                 self.setting
                     .as_mut()
-                    .map(|s| s.reload(daemon))
+                    .map(|s| s.reload(daemon, wallet))
                     .unwrap_or_else(Command::none)
             }
             Message::View(view::Message::Settings(view::SettingsMessage::AboutSection)) => {
                 self.setting = Some(AboutSettingsState::default().into());
+                let wallet = self.wallet.clone();
                 self.setting
                     .as_mut()
-                    .map(|s| s.reload(daemon))
+                    .map(|s| s.reload(daemon, wallet))
                     .unwrap_or_else(Command::none)
             }
             Message::View(view::Message::Settings(view::SettingsMessage::EditWalletSettings)) => {
                 self.setting = Some(
                     WalletSettingsState::new(self.data_dir.clone(), self.wallet.clone()).into(),
                 );
+                let wallet = self.wallet.clone();
                 self.setting
                     .as_mut()
-                    .map(|s| s.reload(daemon))
+                    .map(|s| s.reload(daemon, wallet))
                     .unwrap_or_else(Command::none)
             }
             _ => self
@@ -98,8 +101,13 @@ impl State for SettingsState {
         }
     }
 
-    fn reload(&mut self, _daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {
+    fn reload(
+        &mut self,
+        _daemon: Arc<dyn Daemon + Sync + Send>,
+        wallet: Arc<Wallet>,
+    ) -> Command<Message> {
         self.setting = None;
+        self.wallet = wallet;
         Command::none()
     }
 }
@@ -150,7 +158,11 @@ impl State for AboutSettingsState {
         Command::none()
     }
 
-    fn reload(&mut self, daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {
+    fn reload(
+        &mut self,
+        daemon: Arc<dyn Daemon + Sync + Send>,
+        _wallet: Arc<Wallet>,
+    ) -> Command<Message> {
         Command::perform(
             async move { daemon.get_info().map_err(|e| e.into()) },
             Message::Info,

--- a/gui/src/app/state/settings/wallet.rs
+++ b/gui/src/app/state/settings/wallet.rs
@@ -180,7 +180,14 @@ impl State for WalletSettingsState {
         }
     }
 
-    fn reload(&mut self, daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {
+    fn reload(
+        &mut self,
+        daemon: Arc<dyn Daemon + Sync + Send>,
+        wallet: Arc<Wallet>,
+    ) -> Command<Message> {
+        self.descriptor = wallet.main_descriptor.to_string();
+        self.keys_aliases = Self::keys_aliases(&wallet);
+        self.wallet = wallet;
         Command::perform(
             async move { daemon.get_info().map_err(|e| e.into()) },
             Message::Info,

--- a/gui/src/app/state/spend/mod.rs
+++ b/gui/src/app/state/spend/mod.rs
@@ -112,7 +112,11 @@ impl State for CreateSpendPanel {
         Command::none()
     }
 
-    fn reload(&mut self, daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {
+    fn reload(
+        &mut self,
+        daemon: Arc<dyn Daemon + Sync + Send>,
+        _wallet: Arc<Wallet>,
+    ) -> Command<Message> {
         let daemon1 = daemon.clone();
         let daemon2 = daemon.clone();
         Command::batch(vec![

--- a/gui/src/app/state/transactions.rs
+++ b/gui/src/app/state/transactions.rs
@@ -22,6 +22,7 @@ use crate::{
         message::Message,
         state::{label::LabelsEdited, State},
         view,
+        wallet::Wallet,
     },
     daemon::model,
 };
@@ -31,8 +32,8 @@ use crate::daemon::{
     Daemon,
 };
 
-#[derive(Default)]
 pub struct TransactionsPanel {
+    wallet: Arc<Wallet>,
     pending_txs: Vec<HistoryTransaction>,
     txs: Vec<HistoryTransaction>,
     labels_edited: LabelsEdited,
@@ -42,8 +43,9 @@ pub struct TransactionsPanel {
 }
 
 impl TransactionsPanel {
-    pub fn new() -> Self {
+    pub fn new(wallet: Arc<Wallet>) -> Self {
         Self {
+            wallet,
             selected_tx: None,
             txs: Vec::new(),
             pending_txs: Vec::new(),
@@ -120,7 +122,7 @@ impl State for TransactionsPanel {
                 }
             },
             Message::View(view::Message::Reload) | Message::View(view::Message::Close) => {
-                return self.reload(daemon);
+                return self.reload(daemon, self.wallet.clone());
             }
             Message::View(view::Message::Select(i)) => {
                 self.selected_tx = if i < self.pending_txs.len() {
@@ -225,7 +227,11 @@ impl State for TransactionsPanel {
         Command::none()
     }
 
-    fn reload(&mut self, daemon: Arc<dyn Daemon + Sync + Send>) -> Command<Message> {
+    fn reload(
+        &mut self,
+        daemon: Arc<dyn Daemon + Sync + Send>,
+        _wallet: Arc<Wallet>,
+    ) -> Command<Message> {
         self.selected_tx = None;
         let daemon1 = daemon.clone();
         let daemon2 = daemon.clone();

--- a/gui/src/utils/sandbox.rs
+++ b/gui/src/utils/sandbox.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use iced_native::command::Action;
 
 use crate::{
-    app::{cache::Cache, message::Message, state::State},
+    app::{cache::Cache, message::Message, state::State, wallet::Wallet},
     daemon::Daemon,
 };
 
@@ -37,8 +37,13 @@ impl<S: State + Send + 'static> Sandbox<S> {
         self
     }
 
-    pub async fn load(mut self, daemon: Arc<dyn Daemon + Sync + Send>, cache: &Cache) -> Self {
-        let cmd = self.state.reload(daemon.clone());
+    pub async fn load(
+        mut self,
+        daemon: Arc<dyn Daemon + Sync + Send>,
+        cache: &Cache,
+        wallet: Arc<Wallet>,
+    ) -> Self {
+        let cmd = self.state.reload(daemon.clone(), wallet);
         for action in cmd.actions() {
             if let Action::Future(f) = action {
                 let msg = f.await;


### PR DESCRIPTION
This is to fix https://github.com/wizardsardine/liana/issues/1017.

It adds the `wallet` to the `reload` trait method so that changes are recorded.

As part of this change, the `TransactionsPanel` now has a `wallet` field to be used when calling its own `reload` method.