### PR TITLE
gui: fix condition to create draft spend

### DIFF
--- a/gui/src/app/view/spend/mod.rs
+++ b/gui/src/app/view/spend/mod.rs
@@ -112,9 +112,7 @@ pub fn spend_view<'a>(
 #[allow(clippy::too_many_arguments)]
 pub fn create_spend_tx<'a>(
     cache: &'a Cache,
-    balance_available: &'a Amount,
     recipients: Vec<Element<'a, Message>>,
-    total_amount: Amount,
     is_valid: bool,
     duplicate: bool,
     timelock: u16,
@@ -300,9 +298,7 @@ pub fn create_spend_tx<'a>(
                     .push(
                         if is_valid
                             && !duplicate
-                            && (is_self_send
-                                || (total_amount < *balance_available
-                                    && Some(&Amount::from_sat(0)) == amount_left))
+                            && (is_self_send || Some(&Amount::from_sat(0)) == amount_left)
                         {
                             button::primary(None, "Next")
                                 .on_press(Message::CreateSpend(CreateSpendMessage::Generate))


### PR DESCRIPTION
This issue was encountered by @pythcoiner in https://github.com/wizardsardine/liana_manual_testing/blob/master/tests/v5/v5-pre-rc1/pyth.md#comments.

The `balance_available` value was not being refreshed when new coins were received and so it was sometimes not possible to click Next.

It's enough, however, to check the amount left to select is 0, and so both the `balance_available` and `total_amount` fields can be removed.