### PR TITLE
gui: remove used addresses from receive panel

### DIFF
--- a/gui/src/app/message.rs
+++ b/gui/src/app/message.rs
@@ -26,6 +26,7 @@ pub enum Message {
     LoadWallet,
     WalletLoaded(Result<Arc<Wallet>, Error>),
     Info(Result<GetInfoResult, Error>),
+    CheckUsedAddresses,
     ReceiveAddress(Result<(Address, ChildNumber), Error>),
     Coins(Result<Vec<Coin>, Error>),
     Labels(Result<HashMap<String, String>, Error>),


### PR DESCRIPTION
If the receive panel is the current panel, then we check every 10s if  a coin exists that is a deposit to one of the generated address, if it is the case we remove the address from the list. We do also the same when reloading the receive panel (when user come back from an other panel).

It is possible to make it more efficient by using the `list_addresses` method if its response include the address usage status (See #1030).

close #1026