### PR TITLE
fix receive panel: reset addresses on reload

### DIFF
--- a/gui/src/app/state/receive.rs
+++ b/gui/src/app/state/receive.rs
@@ -40,12 +40,6 @@ pub struct Addresses {
     labels: HashMap<String, String>,
 }
 
-impl Addresses {
-    fn is_empty(&self) -> bool {
-        self.list.is_empty()
-    }
-}
-
 impl Labelled for Addresses {
     fn labelled(&self) -> Vec<LabelItem> {
         self.list
@@ -200,21 +194,17 @@ impl State for ReceivePanel {
         wallet: Arc<Wallet>,
     ) -> Command<Message> {
         self.wallet = wallet;
-        // Fill at least with one address, user will then use the generate button.
-        if self.addresses.is_empty() {
-            let daemon = daemon.clone();
-            Command::perform(
-                async move {
-                    daemon
-                        .get_new_address()
-                        .map(|res| (res.address, res.derivation_index))
-                        .map_err(|e| e.into())
-                },
-                Message::ReceiveAddress,
-            )
-        } else {
-            Command::none()
-        }
+        self.addresses = Addresses::default();
+        let daemon = daemon.clone();
+        Command::perform(
+            async move {
+                daemon
+                    .get_new_address()
+                    .map(|res| (res.address, res.derivation_index))
+                    .map_err(|e| e.into())
+            },
+            Message::ReceiveAddress,
+        )
     }
 }
 


### PR DESCRIPTION
We reintroduce previous behavior:
Reset the list when user leave and come back to the receive panel.

close #1026