### PR TITLE
gui: remove descriptor backup in installer when participating in new wallet

### DIFF
--- a/gui/src/installer/mod.rs
+++ b/gui/src/installer/mod.rs
@@ -155,7 +155,6 @@ impl Installer {
                     ParticipateXpub::new(self.signer.clone()).into(),
                     ImportDescriptor::new(false).into(),
                     BackupMnemonic::new(self.signer.clone()).into(),
-                    BackupDescriptor::default().into(),
                     RegisterDescriptor::new_import_wallet().into(),
                     SelectBitcoindTypeStep::new().into(),
                     InternalBitcoindStep::new(&self.context.data_dir).into(),

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -720,7 +720,7 @@ pub fn participate_xpub<'a>(
                 shared,
                 Message::UserActionDone,
             ))
-            .push(if shared {
+            .push(if shared && network_valid {
                 button::primary(None, "Next")
                     .width(Length::Fixed(200.0))
                     .on_press(Message::Next)


### PR DESCRIPTION
This fixes #791 which is regarding the "Participate in new wallet" steps.

The previous step requires the descriptor and so no need to back it up.

I also fixed an issue where it was possible to click Next with an invalid network selected.