### PR TITLE
gui: make max tooltip more legible

### DIFF
--- a/gui/src/app/view/spend/mod.rs
+++ b/gui/src/app/view/spend/mod.rs
@@ -406,8 +406,9 @@ pub fn recipient_view<'a>(
                         checkbox("MAX", is_max_selected, move |_| {
                             CreateSpendMessage::SendMaxToRecipient(index)
                         }),
-                        "Total amount remaining after paying fee and any other recipients",
-                        tooltip::Position::Left,
+                        // Add spaces at end so that text is padded at screen edge.
+                        "Total amount remaining after paying fee and any other recipients     ",
+                        tooltip::Position::Bottom,
                     ))
                     .width(Length::Fill),
             ),


### PR DESCRIPTION
This resolves an issue found by @kloaec. I've changed the tooltip position to `Bottom` instead of `Left` and added some blank spaces so that text is padded at screen edge.

![image](https://github.com/wizardsardine/liana/assets/121959000/871c0ba9-90de-4c3a-b7db-937ce62035c6)

Full screen:
![image](https://github.com/wizardsardine/liana/assets/121959000/1bd90278-fc5d-4586-b486-d96511b1bad6)

