### PR TITLE
spend: reword warning messages

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1571,7 +1571,14 @@ mod tests {
         );
         assert_eq!(tx.output[0].value.to_sat(), 95_000);
         // change = 100_000 - 95_000 - /* fee without change */ 127 - /* extra fee for change output */ 43 = 4830
-        assert_eq!(warnings, vec!["Change amount of 4830 sats added to fee as it was too small to create a transaction output."]);
+        assert_eq!(
+            warnings,
+            vec![
+                "Dust UTXO. The minimal change output allowed by Liana is 5000 sats. \
+                Instead of creating a change of 4830 sats, it was added to the \
+                transaction fee. Select a larger input to avoid this from happening."
+            ]
+        );
 
         // Increase the target value by the change amount and the warning will disappear.
         *destinations.get_mut(&dummy_addr).unwrap() = 95_000 + 4_830;
@@ -1622,7 +1629,14 @@ mod tests {
             panic!("expect successful spend creation")
         };
         // Message uses "sat" instead of "sats" when value is 1.
-        assert_eq!(warnings, vec!["Change amount of 1 sat added to fee as it was too small to create a transaction output."]);
+        assert_eq!(
+            warnings,
+            vec![
+                "Dust UTXO. The minimal change output allowed by Liana is 5000 sats. \
+                Instead of creating a change of 1 sat, it was added to the \
+                transaction fee. Select a larger input to avoid this from happening."
+            ]
+        );
 
         // Now decrease the target value so that we have enough for a change output.
         *destinations.get_mut(&dummy_addr).unwrap() =
@@ -1651,7 +1665,14 @@ mod tests {
         } else {
             panic!("expect successful spend creation")
         };
-        assert_eq!(warnings, vec!["Change amount of 4999 sats added to fee as it was too small to create a transaction output."]);
+        assert_eq!(
+            warnings,
+            vec![
+                "Dust UTXO. The minimal change output allowed by Liana is 5000 sats. \
+                Instead of creating a change of 4999 sats, it was added to the \
+                transaction fee. Select a larger input to avoid this from happening."
+            ]
+        );
 
         // Now if we mark the coin as spent, we won't create another Spend transaction containing
         // it.

--- a/src/spend.rs
+++ b/src/spend.rs
@@ -551,15 +551,20 @@ impl fmt::Display for CreateSpendWarning {
         match self {
             CreateSpendWarning::ChangeAddedToFee(amt) => write!(
                 f,
-                "Change amount of {} sat{} added to fee as it was too small to create a transaction output.",
+                "Dust UTXO. The minimal change output allowed by Liana is {} sats. \
+                Instead of creating a change of {} sat{}, it was added to the \
+                transaction fee. Select a larger input to avoid this from happening.",
+                DUST_OUTPUT_SATS,
                 amt,
-                if *amt > 1 {"s"} else {""},
+                if *amt > 1 { "s" } else { "" },
             ),
             CreateSpendWarning::AdditionalFeeForAncestors(amt) => write!(
                 f,
-                "An additional fee of {} sat{} has been added to pay for ancestors at the target feerate.",
+                "CPFP: an unconfirmed input was selected. The current transaction fee \
+                was increased by {} sat{} to make the average feerate of both the input \
+                and current transaction equal to the selected feerate.",
                 amt,
-                if *amt > 1 {"s"} else {""},
+                if *amt > 1 { "s" } else { "" },
             ),
         }
     }

--- a/src/spend.rs
+++ b/src/spend.rs
@@ -543,7 +543,7 @@ pub enum SpendTxFees {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum CreateSpendWarning {
     ChangeAddedToFee(u64),
-    AddtionalFeeForAncestors(u64),
+    AdditionalFeeForAncestors(u64),
 }
 
 impl fmt::Display for CreateSpendWarning {
@@ -555,7 +555,7 @@ impl fmt::Display for CreateSpendWarning {
                 amt,
                 if *amt > 1 {"s"} else {""},
             ),
-            CreateSpendWarning::AddtionalFeeForAncestors(amt) => write!(
+            CreateSpendWarning::AdditionalFeeForAncestors(amt) => write!(
                 f,
                 "An additional fee of {} sat{} has been added to pay for ancestors at the target feerate.",
                 amt,
@@ -737,7 +737,7 @@ pub fn create_spend(
     }
 
     if fee_for_ancestors.to_sat() > 0 {
-        warnings.push(CreateSpendWarning::AddtionalFeeForAncestors(
+        warnings.push(CreateSpendWarning::AdditionalFeeForAncestors(
             fee_for_ancestors.to_sat(),
         ));
     }

--- a/tests/test_framework/signer.py
+++ b/tests/test_framework/signer.py
@@ -93,7 +93,9 @@ def sign_psbt_taproot(psbt, hds):
     psbt_str = psbt.to_base64()
     for hd in hds:
         xprv = hd.get_xpriv()
-        proc = subprocess.run([bin_path, psbt_str, xprv], capture_output=True, check=True)
+        proc = subprocess.run(
+            [bin_path, psbt_str, xprv], capture_output=True, check=True
+        )
         psbt_str = proc.stdout.decode("utf-8")
 
     return PSBT.from_base64(psbt_str)

--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -24,7 +24,9 @@ DEFAULT_BITCOIND_PATH = "bitcoind"
 BITCOIND_PATH = os.getenv("BITCOIND_PATH", DEFAULT_BITCOIND_PATH)
 OLD_LIANAD_PATH = os.getenv("OLD_LIANAD_PATH", None)
 IS_NOT_BITCOIND_24 = bool(int(os.getenv("IS_NOT_BITCOIND_24", True)))
-USE_TAPROOT = bool(int(os.getenv("USE_TAPROOT", False)))  # TODO: switch to True in a couple releases.
+USE_TAPROOT = bool(
+    int(os.getenv("USE_TAPROOT", False))
+)  # TODO: switch to True in a couple releases.
 
 
 COIN = 10**8

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -250,12 +250,15 @@ def test_coinbase_deposit(lianad, bitcoind):
     assert coin["is_change"]
     bitcoind.generate_block(100)
     wait_for_sync()
-    coin = next(c for c in lianad.rpc.listcoins()["coins"] if c["outpoint"] == coin["outpoint"])
+    coin = next(
+        c for c in lianad.rpc.listcoins()["coins"] if c["outpoint"] == coin["outpoint"]
+    )
     assert not coin["is_immature"] and coin["block_height"] is not None
 
 
 @pytest.mark.skipif(
-    OLD_LIANAD_PATH is None or USE_TAPROOT, reason="Need the old lianad binary to create the datadir."
+    OLD_LIANAD_PATH is None or USE_TAPROOT,
+    reason="Need the old lianad binary to create the datadir.",
 )
 def test_migration(lianad_multisig, bitcoind):
     """Test we can start a newer lianad on a datadir created by an older lianad."""

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -141,7 +141,9 @@ def test_coin_marked_spent(lianad, bitcoind):
     assert len(res["warnings"]) == 1
     assert (
         res["warnings"][0]
-        == f"Change amount of {change_amount} sats added to fee as it was too small to create a transaction output."
+        == "Dust UTXO. The minimal change output allowed by Liana is 5000 sats. "
+        f"Instead of creating a change of {change_amount} sats, it was added to the "
+        "transaction fee. Select a larger input to avoid this from happening."
     )
 
     # Spend the third coin to an address of ours, no change
@@ -158,7 +160,9 @@ def test_coin_marked_spent(lianad, bitcoind):
     assert len(res["warnings"]) == 1
     assert (
         res["warnings"][0]
-        == f"Change amount of {change_amount} sats added to fee as it was too small to create a transaction output."
+        == "Dust UTXO. The minimal change output allowed by Liana is 5000 sats. "
+        f"Instead of creating a change of {change_amount} sats, it was added to the "
+        "transaction fee. Select a larger input to avoid this from happening."
     )
 
     # Spend the fourth coin to an address of ours, with change
@@ -194,7 +198,9 @@ def test_coin_marked_spent(lianad, bitcoind):
     assert len(res["warnings"]) == 1
     assert (
         res["warnings"][0]
-        == f"An additional fee of {additional_fee} sats has been added to pay for ancestors at the target feerate."
+        == "CPFP: an unconfirmed input was selected. The current transaction fee "
+        f"was increased by {additional_fee} sats to make the average feerate of "
+        "both the input and current transaction equal to the selected feerate."
     )
 
     # All the spent coins must have been detected as such
@@ -346,7 +352,9 @@ def test_coin_selection(lianad, bitcoind):
     assert len(spend_res_2["warnings"]) == 1
     assert (
         spend_res_2["warnings"][0]
-        == f"An additional fee of {additional_fee} sats has been added to pay for ancestors at the target feerate."
+        == "CPFP: an unconfirmed input was selected. The current transaction fee "
+        f"was increased by {additional_fee} sats to make the average feerate of "
+        "both the input and current transaction equal to the selected feerate."
     )
 
     # Try 3 sat/vb:
@@ -366,7 +374,9 @@ def test_coin_selection(lianad, bitcoind):
     assert len(spend_res_2["warnings"]) == 1
     assert (
         spend_res_2["warnings"][0]
-        == f"An additional fee of {additional_fee} sats has been added to pay for ancestors at the target feerate."
+        == "CPFP: an unconfirmed input was selected. The current transaction fee "
+        f"was increased by {additional_fee} sats to make the average feerate of "
+        "both the input and current transaction equal to the selected feerate."
     )
 
     # 2 sat/vb is same feerate as ancestor and we have no warnings:
@@ -416,7 +426,9 @@ def test_coin_selection(lianad, bitcoind):
     assert len(spend_res_3["warnings"]) == 1
     assert (
         spend_res_3["warnings"][0]
-        == f"An additional fee of {additional_fee} sats has been added to pay for ancestors at the target feerate."
+        == "CPFP: an unconfirmed input was selected. The current transaction fee "
+        f"was increased by {additional_fee} sats to make the average feerate of "
+        "both the input and current transaction equal to the selected feerate."
     )
     spend_psbt_3 = PSBT.from_base64(spend_res_3["psbt"])
     spend_txid_3 = sign_and_broadcast_psbt(lianad, spend_psbt_3)

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -12,9 +12,7 @@ from test_framework.utils import (
 def additional_fees(anc_vsize, anc_fee, target_feerate):
     """The additional fee which must have been computed by lianad."""
     computed_anc_vsize = int(anc_fee / target_feerate)
-    print(f"c  ", computed_anc_vsize)
     extra_vsize = anc_vsize - computed_anc_vsize
-    print("e  ", extra_vsize)
     return extra_vsize * target_feerate
 
 

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -1,6 +1,12 @@
 from fixtures import *
 from test_framework.serializations import PSBT, uint256_from_str
-from test_framework.utils import sign_and_broadcast_psbt, wait_for, COIN, RpcError, USE_TAPROOT
+from test_framework.utils import (
+    sign_and_broadcast_psbt,
+    wait_for,
+    COIN,
+    RpcError,
+    USE_TAPROOT,
+)
 
 
 def test_spend_change(lianad, bitcoind):
@@ -334,7 +340,9 @@ def test_coin_selection(lianad, bitcoind):
         bytes.fromhex(spend_txid_1)[::-1]
     )
     anc_vsize = bitcoind.rpc.getmempoolentry(spend_txid_1)["ancestorsize"]
-    anc_fees = int(bitcoind.rpc.getmempoolentry(spend_txid_1)["fees"]["ancestor"] * COIN)
+    anc_fees = int(
+        bitcoind.rpc.getmempoolentry(spend_txid_1)["fees"]["ancestor"] * COIN
+    )
     additional_fee = additional_fees(anc_vsize, anc_fees, feerate)
     assert len(spend_res_2["warnings"]) == 1
     assert (
@@ -352,7 +360,9 @@ def test_coin_selection(lianad, bitcoind):
         bytes.fromhex(spend_txid_1)[::-1]
     )
     anc_vsize = bitcoind.rpc.getmempoolentry(spend_txid_1)["ancestorsize"]
-    anc_fees = int(bitcoind.rpc.getmempoolentry(spend_txid_1)["fees"]["ancestor"] * COIN)
+    anc_fees = int(
+        bitcoind.rpc.getmempoolentry(spend_txid_1)["fees"]["ancestor"] * COIN
+    )
     additional_fee = additional_fees(anc_vsize, anc_fees, feerate)
     assert len(spend_res_2["warnings"]) == 1
     assert (
@@ -398,8 +408,12 @@ def test_coin_selection(lianad, bitcoind):
     anc_vsize = bitcoind.rpc.getmempoolentry(deposit_2)["ancestorsize"]
     anc_fees = int(bitcoind.rpc.getmempoolentry(deposit_2)["fees"]["ancestor"] * COIN)
     prev_anc_vsize = bitcoind.rpc.getmempoolentry(spend_txid_1)["ancestorsize"]
-    prev_anc_fees = int(bitcoind.rpc.getmempoolentry(spend_txid_1)["fees"]["ancestor"] * COIN)
-    additional_fee = additional_fees(anc_vsize, anc_fees, feerate) + additional_fees(prev_anc_vsize, prev_anc_fees, feerate)
+    prev_anc_fees = int(
+        bitcoind.rpc.getmempoolentry(spend_txid_1)["fees"]["ancestor"] * COIN
+    )
+    additional_fee = additional_fees(anc_vsize, anc_fees, feerate) + additional_fees(
+        prev_anc_vsize, prev_anc_fees, feerate
+    )
     assert len(spend_res_3["warnings"]) == 1
     assert (
         spend_res_3["warnings"][0]


### PR DESCRIPTION
As discussed with @kloaec, this PR rewords the warning messages when creating a spend.

I didn't include the selected feerate value in the updated messages as that would have required more code changes, albeit fairly simple ones, beyond the message wording itself. I can add those here if required or otherwise in a follow-up.

Here's a screenshot showing the new warnings:

![image](https://github.com/wizardsardine/liana/assets/121959000/7bd4ec6b-a878-4b25-950a-a4ea87175a6f)
