### PR TITLE
Bump bdk_coin_select to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "bdk_coin_select"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0320167c3655e83f0415d52f39618902e449186ffc7dfb090f922f79675c316"
+checksum = "3c084bf76f0f67546fc814ffa82044144be1bb4618183a15016c162f8b087ad4"
 
 [[package]]
 name = "bech32"
@@ -111,25 +111,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
 name = "bitcoin_hashes"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
-]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -485,7 +470,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.13.0",
  "secp256k1-sys",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ nonblocking_shutdown = []
 miniscript = { version = "11.0", features = ["serde", "compiler", "base64"] }
 
 # Coin selection algorithms for spend transaction creation.
-bdk_coin_select = { version = "0.1.0" }
+bdk_coin_select = "0.3"
 
 # Don't reinvent the wheel
 dirs = "5.0"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -897,10 +897,10 @@ impl DaemonControl {
         if !is_cancel {
             candidate_coins.extend(&confirmed_cands);
         }
-        // The min fee is the fee of the transaction being replaced and its descendants. Coin selection
+        // The replaced fee is the fee of the transaction being replaced and its descendants. Coin selection
         // will ensure that the replacement transaction additionally pays for its own weight as per
         // RBF rule 4.
-        let min_fee = descendant_fees.to_sat();
+        let replaced_fee = descendant_fees.to_sat();
         // This loop can have up to 2 iterations in the case of cancel and otherwise only 1.
         loop {
             match create_spend(
@@ -909,7 +909,7 @@ impl DaemonControl {
                 &mut tx_getter,
                 &destinations,
                 &candidate_coins,
-                SpendTxFees::Rbf(feerate_vb, min_fee),
+                SpendTxFees::Rbf(feerate_vb, replaced_fee),
                 change_address.clone(),
             ) {
                 Ok(CreateSpendRes {


### PR DESCRIPTION
This is to resolve #923.

The `score` method of the `LowestFee` metric has been fixed upstream and so our temporary partial fix from #867 is no longer required.

The `min_fee` parameter of `select_coins_for_spend`, if positive, now ensures that RBF rule 4 is satisfied. Accordingly, it has been renamed to `replaced_fee` and made an `Option`. We could potentially have used the `SpendTxFees` enum as a parameter directly instead of `feerate_vb` and `replaced_fee`, but `feerate_vb` is currently `f32` rather than `u64` and so I kept them as separate parameters.

Thanks to how the `replaced_fee` parameter works, the fee iteration approach used in `rbf_psbt` to ensure the replacement satisfies [RBF rule 4](https://github.com/bitcoin/bitcoin/blob/master/doc/policy/mempool-replacements.md#current-replace-by-fee-policy) is no longer required.

`base_weight` is no longer stored in `CoinSelector` and instead the output weights are stored in `Target`. This means that the `output_weight` of `DrainWeights` no longer needs to take into account a potential change in output count varint as this is now handled by bdk_coin_select.

The min value for change no longer includes the threshold itself and so we have to subtract 1 from our change policy's min value (see https://github.com/bitcoindevkit/coin-select/pull/14#discussion_r1439665103). We already have a [test](https://github.com/wizardsardine/liana/blob/master/src/commands/mod.rs#L1653-#L1654) that fails without this subtraction as it expects a change output of 5000 sats.