### PR TITLE
GUI: change daemon trait to handle async methods

### DIFF
--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -2643,6 +2643,7 @@ name = "liana_gui"
 version = "5.0.0"
 dependencies = [
  "async-hwi",
+ "async-trait",
  "backtrace",
  "base64 0.21.6",
  "bitcoin_hashes 0.12.0",

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -14,6 +14,7 @@ name = "liana-gui"
 path = "src/main.rs"
 
 [dependencies]
+async-trait = "0.1"
 async-hwi = "0.0.16"
 liana = { git = "https://github.com/wizardsardine/liana", branch = "master", default-features = false, features = ["nonblocking_shutdown"] }
 liana_ui = { path = "ui" }

--- a/gui/src/app/state/coins.rs
+++ b/gui/src/app/state/coins.rs
@@ -164,6 +164,7 @@ impl State for CoinsPanel {
                 async move {
                     daemon1
                         .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
+                        .await
                         .map(|res| res.coins)
                         .map_err(|e| e.into())
                 },
@@ -173,6 +174,7 @@ impl State for CoinsPanel {
                 async move {
                     let coins = daemon2
                         .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
+                        .await
                         .map(|res| res.coins)
                         .map_err(Error::from)?;
                     let mut targets = HashSet::<LabelItem>::new();
@@ -181,7 +183,7 @@ impl State for CoinsPanel {
                         targets.insert(LabelItem::Txid(coin.outpoint.txid));
                         targets.insert(LabelItem::Address(coin.address));
                     }
-                    daemon2.get_labels(&targets).map_err(|e| e.into())
+                    daemon2.get_labels(&targets).await.map_err(|e| e.into())
                 },
                 Message::Labels,
             ),

--- a/gui/src/app/state/label.rs
+++ b/gui/src/app/state/label.rs
@@ -66,7 +66,7 @@ impl LabelsEdited {
                     }
                     return Ok(Command::perform(
                         async move {
-                            daemon.update_labels(&updated_labels)?;
+                            daemon.update_labels(&updated_labels).await?;
                             Ok(updated_labels_str)
                         },
                         Message::LabelsUpdated,

--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -230,8 +230,9 @@ impl State for Home {
                     return Command::perform(
                         async move {
                             let mut limit = view::home::HISTORY_EVENT_PAGE_SIZE;
-                            let mut events =
-                                daemon.list_history_txs(0_u32, last_event_date, limit)?;
+                            let mut events = daemon
+                                .list_history_txs(0_u32, last_event_date, limit)
+                                .await?;
 
                             // because gethistory cursor is inclusive and use blocktime
                             // multiple events can occur in the same block.
@@ -253,7 +254,7 @@ impl State for Home {
                             {
                                 // increments of the equivalent of one page more.
                                 limit += view::home::HISTORY_EVENT_PAGE_SIZE;
-                                events = daemon.list_history_txs(0, last_event_date, limit)?;
+                                events = daemon.list_history_txs(0, last_event_date, limit).await?;
                             }
                             Ok(events)
                         },
@@ -284,13 +285,14 @@ impl State for Home {
             .unwrap();
         Command::batch(vec![
             Command::perform(
-                async move { daemon3.list_pending_txs().map_err(|e| e.into()) },
+                async move { daemon3.list_pending_txs().await.map_err(|e| e.into()) },
                 Message::PendingTransactions,
             ),
             Command::perform(
                 async move {
                     daemon1
                         .list_history_txs(0, now, view::home::HISTORY_EVENT_PAGE_SIZE)
+                        .await
                         .map_err(|e| e.into())
                 },
                 Message::HistoryTransactions,
@@ -299,6 +301,7 @@ impl State for Home {
                 async move {
                     daemon2
                         .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
+                        .await
                         .map(|res| res.coins)
                         .map_err(|e| e.into())
                 },

--- a/gui/src/app/state/psbt.rs
+++ b/gui/src/app/state/psbt.rs
@@ -173,6 +173,7 @@ impl PsbtState {
                     async move {
                         daemon
                             .list_coins(&[CoinStatus::Spending], &outpoints)
+                            .await
                             .map(|res| {
                                 res.coins
                                     .iter()
@@ -275,8 +276,8 @@ impl Action for SaveAction {
                 }
                 return Command::perform(
                     async move {
-                        daemon.update_spend_tx(&psbt)?;
-                        daemon.update_labels(&labels).map_err(|e| e.into())
+                        daemon.update_spend_tx(&psbt).await?;
+                        daemon.update_labels(&labels).await.map_err(|e| e.into())
                     },
                     Message::Updated,
                 );
@@ -323,6 +324,7 @@ impl Action for BroadcastAction {
                     async move {
                         daemon
                             .broadcast_spend_tx(&psbt.unsigned_tx.txid())
+                            .await
                             .map_err(|e| e.into())
                     },
                     Message::Updated,
@@ -375,6 +377,7 @@ impl Action for DeleteAction {
                     async move {
                         daemon
                             .delete_spend_tx(&psbt.unsigned_tx.txid())
+                            .await
                             .map_err(|e| e.into())
                     },
                     Message::Updated,
@@ -482,7 +485,7 @@ impl Action for SignAction {
                         merge_signatures(&mut tx.psbt, &psbt);
                         if self.is_saved {
                             return Command::perform(
-                                async move { daemon.update_spend_tx(&psbt).map_err(|e| e.into()) },
+                                async move { daemon.update_spend_tx(&psbt).await.map_err(|e| e.into()) },
                                 Message::Updated,
                             );
                         // If the spend transaction was never saved before, then both the psbt and
@@ -496,8 +499,8 @@ impl Action for SignAction {
                             }
                             return Command::perform(
                                 async move {
-                                    daemon.update_spend_tx(&psbt)?;
-                                    daemon.update_labels(&labels).map_err(|e| e.into())
+                                    daemon.update_spend_tx(&psbt).await?;
+                                    daemon.update_labels(&labels).await.map_err(|e| e.into())
                                 },
                                 Message::Updated,
                             );
@@ -727,7 +730,7 @@ impl Action for UpdateAction {
                     self.error = None;
                     let updated = Psbt::from_str(&self.updated.value).expect("Already checked");
                     return Command::perform(
-                        async move { daemon.update_spend_tx(&updated).map_err(|e| e.into()) },
+                        async move { daemon.update_spend_tx(&updated).await.map_err(|e| e.into()) },
                         Message::Updated,
                     );
                 }

--- a/gui/src/app/state/psbts.rs
+++ b/gui/src/app/state/psbts.rs
@@ -128,7 +128,12 @@ impl State for PsbtsPanel {
         self.import_tx = None;
         let daemon = daemon.clone();
         Command::perform(
-            async move { daemon.list_spend_transactions(None).map_err(|e| e.into()) },
+            async move {
+                daemon
+                    .list_spend_transactions(None)
+                    .await
+                    .map_err(|e| e.into())
+            },
             Message::SpendTxs,
         )
     }
@@ -194,7 +199,12 @@ impl ImportPsbtModal {
                     self.error = None;
                     let imported = Psbt::from_str(&self.imported.value).expect("Already checked");
                     return Command::perform(
-                        async move { daemon.update_spend_tx(&imported).map_err(|e| e.into()) },
+                        async move {
+                            daemon
+                                .update_spend_tx(&imported)
+                                .await
+                                .map_err(|e| e.into())
+                        },
                         Message::Updated,
                     );
                 }

--- a/gui/src/app/state/receive.rs
+++ b/gui/src/app/state/receive.rs
@@ -161,6 +161,7 @@ impl State for ReceivePanel {
                     async move {
                         daemon
                             .get_new_address()
+                            .await
                             .map(|res| (res.address, res.derivation_index))
                             .map_err(|e| e.into())
                     },
@@ -200,6 +201,7 @@ impl State for ReceivePanel {
             async move {
                 daemon
                     .get_new_address()
+                    .await
                     .map(|res| (res.address, res.derivation_index))
                     .map_err(|e| e.into())
             },

--- a/gui/src/app/state/recovery.rs
+++ b/gui/src/app/state/recovery.rs
@@ -157,14 +157,19 @@ impl State for RecoveryPanel {
                     let network = cache.network;
                     return Command::perform(
                         async move {
-                            let psbt = daemon.create_recovery(address, feerate_vb, sequence)?;
+                            let psbt = daemon
+                                .create_recovery(address, feerate_vb, sequence)
+                                .await?;
                             let outpoints: Vec<_> = psbt
                                 .unsigned_tx
                                 .input
                                 .iter()
                                 .map(|txin| txin.previous_output)
                                 .collect();
-                            let coins = daemon.list_coins(&[], &outpoints).map(|res| res.coins)?;
+                            let coins = daemon
+                                .list_coins(&[], &outpoints)
+                                .await
+                                .map(|res| res.coins)?;
                             Ok(SpendTx::new(
                                 None,
                                 psbt,
@@ -208,6 +213,7 @@ impl State for RecoveryPanel {
             async move {
                 daemon
                     .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
+                    .await
                     .map(|res| res.coins)
                     .map_err(|e| e.into())
             },

--- a/gui/src/app/state/settings/bitcoind.rs
+++ b/gui/src/app/state/settings/bitcoind.rs
@@ -420,7 +420,9 @@ impl RescanSetting {
                 info!("Asking deamon to rescan with timestamp: {}", t);
                 return Command::perform(
                     async move {
-                        daemon.start_rescan(t.try_into().expect("t cannot be inferior to 0 otherwise genesis block timestam is chosen")).map_err(|e| e.into())
+                        daemon.start_rescan(t.try_into().expect("t cannot be inferior to 0 otherwise genesis block timestamp is chosen"))
+                            .await
+                            .map_err(|e| e.into())
                     },
                     Message::StartRescan,
                 );

--- a/gui/src/app/state/settings/mod.rs
+++ b/gui/src/app/state/settings/mod.rs
@@ -164,7 +164,7 @@ impl State for AboutSettingsState {
         _wallet: Arc<Wallet>,
     ) -> Command<Message> {
         Command::perform(
-            async move { daemon.get_info().map_err(|e| e.into()) },
+            async move { daemon.get_info().await.map_err(|e| e.into()) },
             Message::Info,
         )
     }

--- a/gui/src/app/state/settings/wallet.rs
+++ b/gui/src/app/state/settings/wallet.rs
@@ -189,7 +189,7 @@ impl State for WalletSettingsState {
         self.keys_aliases = Self::keys_aliases(&wallet);
         self.wallet = wallet;
         Command::perform(
-            async move { daemon.get_info().map_err(|e| e.into()) },
+            async move { daemon.get_info().await.map_err(|e| e.into()) },
             Message::Info,
         )
     }

--- a/gui/src/app/state/spend/mod.rs
+++ b/gui/src/app/state/spend/mod.rs
@@ -127,6 +127,7 @@ impl State for CreateSpendPanel {
                 async move {
                     daemon1
                         .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
+                        .await
                         .map(|res| res.coins)
                         .map_err(|e| e.into())
                 },
@@ -136,6 +137,7 @@ impl State for CreateSpendPanel {
                 async move {
                     let coins = daemon
                         .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
+                        .await
                         .map(|res| res.coins)
                         .map_err(Error::from)?;
                     let mut targets = HashSet::<LabelItem>::new();
@@ -143,7 +145,7 @@ impl State for CreateSpendPanel {
                         targets.insert(LabelItem::OutPoint(coin.outpoint));
                         targets.insert(LabelItem::Txid(coin.outpoint.txid));
                     }
-                    daemon2.get_labels(&targets).map_err(|e| e.into())
+                    daemon2.get_labels(&targets).await.map_err(|e| e.into())
                 },
                 Message::Labels,
             ),


### PR DESCRIPTION
This a preparatory work in order to have a lianalite backend connection to satisfy the Daemon trait.
This PR also allows us to use tokio::sync::Mutex for the embedded daemon which goes great with the iced tokio runtime.