### PR TITLE
Add nixGL to gui/shell.nix

### DIFF
--- a/gui/shell.nix
+++ b/gui/shell.nix
@@ -1,18 +1,27 @@
-{ pkgs ? import <nixpkgs> {} }:
+# Nixos 23.11 comes with libc 2.38, this version of libc may not be compatible
+# with some drivers. For now the hack found is to user a community wrapper that
+# detects the requirements and do the link (https://github.com/guibou/nixGL).
+# usage:
+# nixGL cargo run
 
+let
+   nixgl = import (fetchTarball "https://github.com/guibou/nixGL/archive/master.tar.gz") {};
+   pkgs = import <nixpkgs> {};
+in
 pkgs.mkShell rec {
-  buildInputs = with pkgs; [
-    expat
-    fontconfig
-    freetype
-    freetype.dev
-    libGL
-    pkgconfig
-    udev
-    xorg.libX11
-    xorg.libXcursor
-    xorg.libXi
-    xorg.libXrandr
+  buildInputs = [
+    pkgs.expat
+    pkgs.fontconfig
+    pkgs.freetype
+    pkgs.freetype.dev
+    pkgs.libGL
+    pkgs.pkgconfig
+    pkgs.udev
+    pkgs.xorg.libX11
+    pkgs.xorg.libXcursor
+    pkgs.xorg.libXi
+    pkgs.xorg.libXrandr
+    nixgl.auto.nixGLDefault
   ];
 
   LD_LIBRARY_PATH =


### PR DESCRIPTION
Nixos 23.11 comes with libc 2.38, this version of libc may not be compatible with some drivers. For now the hack found is to use a community wrapper that detects the requirements and do the link (https://github.com/guibou/nixGL). usage:
nixGL cargo run