### PR TITLE
Remove legacy harware_wallets field from gui config

### DIFF
--- a/gui/src/app/config.rs
+++ b/gui/src/app/config.rs
@@ -1,4 +1,3 @@
-use crate::hw::HardwareWalletConfig;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tracing_subscriber::filter;
@@ -13,9 +12,6 @@ pub struct Config {
     pub log_level: Option<String>,
     /// Use iced debug feature if true.
     pub debug: Option<bool>,
-    /// hardware wallets config.
-    /// LEGACY: Use Settings module instead.
-    pub hardware_wallets: Option<Vec<HardwareWalletConfig>>,
     /// Start internal bitcoind executable.
     #[serde(default)]
     pub start_internal_bitcoind: bool,
@@ -30,7 +26,6 @@ impl Config {
             daemon_rpc_path: None,
             log_level: None,
             debug: None,
-            hardware_wallets: None,
             start_internal_bitcoind,
         }
     }

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -309,11 +309,8 @@ impl App {
     }
 
     pub fn load_wallet(&mut self) -> Result<Arc<Wallet>, Error> {
-        let wallet = Wallet::new(self.wallet.main_descriptor.clone()).load_settings(
-            &self.config,
-            &self.data_dir,
-            self.cache.network,
-        )?;
+        let wallet = Wallet::new(self.wallet.main_descriptor.clone())
+            .load_settings(&self.data_dir, self.cache.network)?;
 
         self.wallet = Arc::new(wallet);
 

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -203,7 +203,6 @@ impl Loader {
                                 load_application(
                                     daemon.clone(),
                                     info,
-                                    self.gui_config.clone(),
                                     self.datadir_path.clone(),
                                     self.network,
                                     self.internal_bitcoind.clone(),
@@ -356,7 +355,6 @@ impl Loader {
 pub async fn load_application(
     daemon: Arc<dyn Daemon + Sync + Send>,
     info: GetInfoResult,
-    gui_config: GUIConfig,
     datadir_path: PathBuf,
     network: bitcoin::Network,
     internal_bitcoind: Option<Bitcoind>,
@@ -369,8 +367,7 @@ pub async fn load_application(
     ),
     Error,
 > {
-    let wallet =
-        Wallet::new(info.descriptors.main).load_settings(&gui_config, &datadir_path, network)?;
+    let wallet = Wallet::new(info.descriptors.main).load_settings(&datadir_path, network)?;
 
     let coins = daemon
         .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])


### PR DESCRIPTION
Ledger hmacs, wallet name and fingerprint labels where moved one year ago in the settings.json file.
Here the commit of the new settings module:
https://github.com/wizardsardine/liana/commit/bf1e9e4b808a7c275766975467e637b883524236

A second commit in v4 checked that settings.json is present otherwise it does the migration from the gui configuration file to the settings file:
https://github.com/wizardsardine/liana/commit/3eeba082483c06318ca7a1f018ce2c5da47f5f32

We remove the legacy field from the config field so the wallet module does not depend on the config module anymore to load hardware wallet information.

Tested on gui.toml config with legacy field hardware_wallets and it does not fail to launch.