### PR TITLE
fix ci: bump ahash dep and add bitcoind macos arm64 binary hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",

--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1978,7 +1978,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 

--- a/gui/src/bitcoind.rs
+++ b/gui/src/bitcoind.rs
@@ -30,6 +30,9 @@ pub const VERSION: &str = VERSIONS[0];
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
 pub const SHA256SUM: &str = "acb50edd20692a9d023de12da573b64ca0fd9b4e9a2b88d1251020a3022b0f27";
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+pub const SHA256SUM: &str = "8a8e415763b7ffd5988153cf03967d812eca629016dd3b0ddf6da3ab6f4a3621";
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 pub const SHA256SUM: &str = "a5b7d206384a8100058d3f2e2f02123a8e49e83f523499e70e86e121a4897d5b";
 
@@ -39,6 +42,11 @@ pub const SHA256SUM: &str = "7bd0849e47472aeff99a0ea2c0cefd98f5be829e5a2d3b0168b
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
 pub fn download_filename() -> String {
     format!("bitcoin-{}-x86_64-apple-darwin.tar.gz", &VERSION)
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+pub fn download_filename() -> String {
+    format!("bitcoin-{}-arm64-apple-darwin.tar.gz", &VERSION)
 }
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]


### PR DESCRIPTION
- bump ahash dependency to fix macos build
- ci requires now macos aarch64 for the liana-gui tests on macos, sha256sum is added for bitcoind-26.1-arm64-apple-darwin.tar.gz (https://bitcoincore.org/bin/bitcoin-core-26.1/)