### PR TITLE
Add a warning in installer if mainnet wallet already exists

### DIFF
--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -329,29 +329,34 @@ pub fn define_descriptor<'a>(
         progress,
         "Create the wallet",
         Column::new()
-            .push(collapse::Collapse::new(
-                || {
-                    Button::new(
-                        Row::new()
-                            .align_items(Alignment::Center)
-                            .spacing(10)
-                            .push(text("Advanced settings").small().bold())
-                            .push(icon::collapse_icon()),
-                    )
-                    .style(theme::Button::Transparent)
-                },
-                || {
-                    Button::new(
-                        Row::new()
-                            .align_items(Alignment::Center)
-                            .spacing(10)
-                            .push(text("Advanced settings").small().bold())
-                            .push(icon::collapsed_icon()),
-                    )
-                    .style(theme::Button::Transparent)
-                },
-                move || define_descriptor_advanced_settings(network, network_valid, use_taproot),
-            ))
+            .push(
+                collapse::Collapse::new(
+                    || {
+                        Button::new(
+                            Row::new()
+                                .align_items(Alignment::Center)
+                                .spacing(10)
+                                .push(text("Advanced settings").small().bold())
+                                .push(icon::collapse_icon()),
+                        )
+                        .style(theme::Button::Transparent)
+                    },
+                    || {
+                        Button::new(
+                            Row::new()
+                                .align_items(Alignment::Center)
+                                .spacing(10)
+                                .push(text("Advanced settings").small().bold())
+                                .push(icon::collapsed_icon()),
+                        )
+                        .style(theme::Button::Transparent)
+                    },
+                    move || {
+                        define_descriptor_advanced_settings(network, network_valid, use_taproot)
+                    },
+                )
+                .collapsed(!network_valid),
+            )
             .push(
                 Column::new()
                     .width(Length::Fill)
@@ -379,7 +384,7 @@ pub fn define_descriptor<'a>(
                             ))
                             .width(Length::Fixed(200.0)),
                     )
-                    .push(if !valid {
+                    .push(if !valid || !network_valid {
                         button::primary(None, "Next").width(Length::Fixed(200.0))
                     } else {
                         button::primary(None, "Next")

--- a/gui/ui/src/component/collapse.rs
+++ b/gui/ui/src/component/collapse.rs
@@ -10,6 +10,7 @@ pub struct Collapse<'a, M, H, F, C> {
     after: F,
     content: C,
     phantom: PhantomData<&'a M>,
+    state: bool,
 }
 
 impl<'a, Message, T, H, F, C, Theme, Renderer> Collapse<'a, Message, H, F, C>
@@ -28,7 +29,13 @@ where
             after,
             content,
             phantom: PhantomData,
+            state: false,
         }
+    }
+
+    pub fn collapsed(mut self, state: bool) -> Self {
+        self.state = state;
+        self
     }
 }
 
@@ -51,18 +58,18 @@ where
     type State = bool;
     type Event = Event<T>;
 
-    fn update(&mut self, state: &mut Self::State, event: Event<T>) -> Option<Message> {
+    fn update(&mut self, _state: &mut Self::State, event: Event<T>) -> Option<Message> {
         match event {
             Event::Internal(e) => Some(e.into()),
             Event::Collapse(s) => {
-                *state = s;
+                self.state = s;
                 None
             }
         }
     }
 
-    fn view(&self, state: &Self::State) -> Element<Self::Event, Theme, Renderer> {
-        if *state {
+    fn view(&self, _state: &Self::State) -> Element<Self::Event, Theme, Renderer> {
+        if self.state {
             column![
                 (self.after)().on_press(Event::Collapse(false)),
                 (self.content)().map(Event::Internal)


### PR DESCRIPTION
this PR fixes #1039, it add a warning in the installer if an wallet already exists on mainnet & grey-out `Next` button if the network  is not valid.

![image](https://github.com/wizardsardine/liana/assets/124568858/87b5017d-f44b-47d2-b3bc-77babc0e7cdf)
