### PR TITLE
Set network in launcher

### DIFF
--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -20,7 +20,10 @@ use tokio::runtime::Handle;
 use tracing::{error, info, warn};
 
 pub use liana::{commands::CoinStatus, config::Config as DaemonConfig, miniscript::bitcoin};
-use liana_ui::widget::Element;
+use liana_ui::{
+    component::network_banner,
+    widget::{Column, Element},
+};
 
 pub use config::Config;
 pub use message::Message;
@@ -318,6 +321,11 @@ impl App {
     }
 
     pub fn view(&self) -> Element<Message> {
-        self.panels.current().view(&self.cache).map(Message::View)
+        let content = self.panels.current().view(&self.cache).map(Message::View);
+        if self.cache.network != bitcoin::Network::Bitcoin {
+            Column::with_children(vec![network_banner(self.cache.network).into(), content]).into()
+        } else {
+            content
+        }
     }
 }

--- a/gui/src/installer/message.rs
+++ b/gui/src/installer/message.rs
@@ -1,7 +1,4 @@
-use liana::miniscript::{
-    bitcoin::{bip32::Fingerprint, Network},
-    DescriptorPublicKey,
-};
+use liana::miniscript::{bitcoin::bip32::Fingerprint, DescriptorPublicKey};
 use std::path::PathBuf;
 
 use super::Error;
@@ -29,7 +26,6 @@ pub enum Message {
     Select(usize),
     UseHotSigner,
     Installed(Result<PathBuf, Error>),
-    Network(Network),
     CreateTaprootDescriptor(bool),
     SelectBitcoindType(SelectBitcoindTypeMsg),
     InternalBitcoind(InternalBitcoindMsg),

--- a/gui/src/installer/message.rs
+++ b/gui/src/installer/message.rs
@@ -20,6 +20,7 @@ pub enum Message {
     Next,
     Skip,
     Previous,
+    BackToLauncher,
     Install,
     Close,
     Reload,

--- a/gui/src/installer/mod.rs
+++ b/gui/src/installer/mod.rs
@@ -73,6 +73,10 @@ impl Installer {
         )
     }
 
+    pub fn destination_path(&self) -> PathBuf {
+        self.context.data_dir.clone()
+    }
+
     pub fn subscription(&self) -> Subscription<Message> {
         if self.current > 0 {
             self.steps

--- a/gui/src/installer/mod.rs
+++ b/gui/src/installer/mod.rs
@@ -29,6 +29,7 @@ use step::{
 };
 
 pub struct Installer {
+    network: bitcoin::Network,
     current: usize,
     steps: Vec<Box<dyn Step>>,
     hws: HardwareWallets,
@@ -61,6 +62,7 @@ impl Installer {
     ) -> (Installer, Command<Message>) {
         (
             Installer {
+                network,
                 current: 0,
                 hws: HardwareWallets::new(destination_path.clone(), network),
                 steps: vec![Welcome::default().into()],
@@ -135,7 +137,7 @@ impl Installer {
             Message::CreateWallet => {
                 self.steps = vec![
                     Welcome::default().into(),
-                    DefineDescriptor::new(self.signer.clone()).into(),
+                    DefineDescriptor::new(self.network, self.signer.clone()).into(),
                     BackupMnemonic::new(self.signer.clone()).into(),
                     BackupDescriptor::default().into(),
                     RegisterDescriptor::new_create_wallet().into(),
@@ -149,8 +151,8 @@ impl Installer {
             Message::ParticipateWallet => {
                 self.steps = vec![
                     Welcome::default().into(),
-                    ParticipateXpub::new(self.signer.clone()).into(),
-                    ImportDescriptor::new(false).into(),
+                    ParticipateXpub::new(self.network, self.signer.clone()).into(),
+                    ImportDescriptor::new(self.network).into(),
                     BackupMnemonic::new(self.signer.clone()).into(),
                     RegisterDescriptor::new_import_wallet().into(),
                     SelectBitcoindTypeStep::new().into(),
@@ -163,7 +165,7 @@ impl Installer {
             Message::ImportWallet => {
                 self.steps = vec![
                     Welcome::default().into(),
-                    ImportDescriptor::new(true).into(),
+                    ImportDescriptor::new(self.network).into(),
                     RecoverMnemonic::default().into(),
                     RegisterDescriptor::new_import_wallet().into(),
                     SelectBitcoindTypeStep::new().into(),

--- a/gui/src/installer/mod.rs
+++ b/gui/src/installer/mod.rs
@@ -5,8 +5,11 @@ mod step;
 mod view;
 
 use iced::{clipboard, Command, Subscription};
-use liana::miniscript::bitcoin;
-use liana_ui::widget::Element;
+use liana::miniscript::bitcoin::{self, Network};
+use liana_ui::{
+    component::network_banner,
+    widget::{Column, Element},
+};
 use tracing::{error, info, warn};
 
 use context::Context;
@@ -252,10 +255,17 @@ impl Installer {
     }
 
     pub fn view(&self) -> Element<Message> {
-        self.steps
+        let content = self
+            .steps
             .get(self.current)
             .expect("There is always a step")
-            .view(&self.hws, self.progress())
+            .view(&self.hws, self.progress());
+
+        if self.network != Network::Bitcoin {
+            Column::with_children(vec![network_banner(self.network).into(), content]).into()
+        } else {
+            content
+        }
     }
 }
 

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -111,6 +111,11 @@ pub fn welcome<'a>() -> Element<'a, Message> {
                                     .padding(20),
                                 ),
                         )
+                        .push(
+                            button::secondary(Some(icon::previous_icon()), "Change network")
+                                .width(Length::Fixed(200.0))
+                                .on_press(Message::BackToLauncher),
+                        )
                         .push(Space::with_height(Length::Fixed(100.0)))
                         .spacing(50)
                         .align_items(Alignment::Center),

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -32,55 +32,6 @@ use crate::{
     },
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Network {
-    Mainnet,
-    Testnet,
-    Regtest,
-    Signet,
-}
-
-impl From<bitcoin::Network> for Network {
-    fn from(n: bitcoin::Network) -> Self {
-        match n {
-            bitcoin::Network::Bitcoin => Network::Mainnet,
-            bitcoin::Network::Testnet => Network::Testnet,
-            bitcoin::Network::Regtest => Network::Regtest,
-            bitcoin::Network::Signet => Network::Signet,
-            _ => Network::Mainnet,
-        }
-    }
-}
-
-impl From<Network> for bitcoin::Network {
-    fn from(network: Network) -> bitcoin::Network {
-        match network {
-            Network::Mainnet => bitcoin::Network::Bitcoin,
-            Network::Testnet => bitcoin::Network::Testnet,
-            Network::Regtest => bitcoin::Network::Regtest,
-            Network::Signet => bitcoin::Network::Signet,
-        }
-    }
-}
-
-impl std::fmt::Display for Network {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::Mainnet => write!(f, "Bitcoin mainnet"),
-            Self::Testnet => write!(f, "Bitcoin testnet"),
-            Self::Regtest => write!(f, "Bitcoin regtest"),
-            Self::Signet => write!(f, "Bitcoin signet"),
-        }
-    }
-}
-
-const NETWORKS: [Network; 4] = [
-    Network::Mainnet,
-    Network::Testnet,
-    Network::Signet,
-    Network::Regtest,
-];
-
 pub fn welcome<'a>() -> Element<'a, Message> {
     Container::new(
         Column::new()
@@ -191,31 +142,7 @@ impl std::fmt::Display for DescriptorKind {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn define_descriptor_advanced_settings<'a>(
-    network: bitcoin::Network,
-    network_valid: bool,
-    use_taproot: bool,
-) -> Element<'a, Message> {
-    let col_network = Column::new()
-        .spacing(10)
-        .push(text("Network").bold())
-        .push(container(
-            pick_list(&NETWORKS[..], Some(Network::from(network)), |net| {
-                Message::Network(net.into())
-            })
-            .style(if network_valid {
-                theme::PickList::Secondary
-            } else {
-                theme::PickList::Invalid
-            })
-            .padding(10),
-        ))
-        .push_maybe(if network_valid {
-            None
-        } else {
-            Some(text("A data directory already exists for this network").style(color::RED))
-        });
-
+pub fn define_descriptor_advanced_settings<'a>(use_taproot: bool) -> Element<'a, Message> {
     let col_wallet = Column::new()
         .spacing(10)
         .push(text("Descriptor type").bold())
@@ -238,12 +165,7 @@ pub fn define_descriptor_advanced_settings<'a>(
             .spacing(20)
             .push(Space::with_height(0))
             .push(separation().width(500))
-            .push(
-                Row::new()
-                    .push(col_network)
-                    .push(Space::with_width(100))
-                    .push(col_wallet),
-            )
+            .push(Row::new().push(col_wallet))
             .push_maybe(if use_taproot {
                 Some(
                     p1_regular("Taproot is only supported by Liana version 5.0 and above")
@@ -259,8 +181,6 @@ pub fn define_descriptor_advanced_settings<'a>(
 #[allow(clippy::too_many_arguments)]
 pub fn define_descriptor<'a>(
     progress: (usize, usize),
-    network: bitcoin::Network,
-    network_valid: bool,
     use_taproot: bool,
     spending_keys: Vec<Element<'a, Message>>,
     spending_threshold: usize,
@@ -329,34 +249,29 @@ pub fn define_descriptor<'a>(
         progress,
         "Create the wallet",
         Column::new()
-            .push(
-                collapse::Collapse::new(
-                    || {
-                        Button::new(
-                            Row::new()
-                                .align_items(Alignment::Center)
-                                .spacing(10)
-                                .push(text("Advanced settings").small().bold())
-                                .push(icon::collapse_icon()),
-                        )
-                        .style(theme::Button::Transparent)
-                    },
-                    || {
-                        Button::new(
-                            Row::new()
-                                .align_items(Alignment::Center)
-                                .spacing(10)
-                                .push(text("Advanced settings").small().bold())
-                                .push(icon::collapsed_icon()),
-                        )
-                        .style(theme::Button::Transparent)
-                    },
-                    move || {
-                        define_descriptor_advanced_settings(network, network_valid, use_taproot)
-                    },
-                )
-                .collapsed(!network_valid),
-            )
+            .push(collapse::Collapse::new(
+                || {
+                    Button::new(
+                        Row::new()
+                            .align_items(Alignment::Center)
+                            .spacing(10)
+                            .push(text("Advanced settings").small().bold())
+                            .push(icon::collapse_icon()),
+                    )
+                    .style(theme::Button::Transparent)
+                },
+                || {
+                    Button::new(
+                        Row::new()
+                            .align_items(Alignment::Center)
+                            .spacing(10)
+                            .push(text("Advanced settings").small().bold())
+                            .push(icon::collapsed_icon()),
+                    )
+                    .style(theme::Button::Transparent)
+                },
+                move || define_descriptor_advanced_settings(use_taproot),
+            ))
             .push(
                 Column::new()
                     .width(Length::Fill)
@@ -384,7 +299,7 @@ pub fn define_descriptor<'a>(
                             ))
                             .width(Length::Fixed(200.0)),
                     )
-                    .push(if !valid || !network_valid {
+                    .push(if !valid {
                         button::primary(None, "Next").width(Length::Fixed(200.0))
                     } else {
                         button::primary(None, "Next")
@@ -455,33 +370,10 @@ pub fn recovery_path_view(
 
 pub fn import_descriptor<'a>(
     progress: (usize, usize),
-    change_network: bool,
-    network: bitcoin::Network,
-    network_valid: bool,
     imported_descriptor: &form::Value<String>,
     wrong_network: bool,
     error: Option<&String>,
 ) -> Element<'a, Message> {
-    let row_network = Row::new()
-        .spacing(10)
-        .align_items(Alignment::Center)
-        .push(text("Network:").bold())
-        .push(Container::new(
-            pick_list(&NETWORKS[..], Some(Network::from(network)), |net| {
-                Message::Network(net.into())
-            })
-            .style(if network_valid {
-                theme::PickList::Simple
-            } else {
-                theme::PickList::Invalid
-            })
-            .padding(10),
-        ))
-        .push_maybe(if network_valid {
-            None
-        } else {
-            Some(text("A data directory already exists for this network").style(color::RED))
-        });
     let col_descriptor = Column::new()
         .push(text("Descriptor:").bold())
         .push(
@@ -501,28 +393,13 @@ pub fn import_descriptor<'a>(
         progress,
         "Import the wallet",
         Column::new()
-            .push(
-                Column::new()
-                    .spacing(20)
-                    .push_maybe(if change_network {
-                        Some(row_network)
-                    } else {
-                        None
-                    })
-                    .push(col_descriptor)
-                    .push_maybe(if change_network {
-                        // only show message when importing a descriptor
-                        Some(text(
-                            "After creating the wallet, \
+            .push(Column::new().spacing(20).push(col_descriptor).push(text(
+                "After creating the wallet, \
                             you will need to perform a rescan of \
                             the blockchain in order to see your \
                             coins and past transactions. This can \
                             be done in Settings > Bitcoin Core.",
-                        ))
-                    } else {
-                        None
-                    }),
-            )
+            )))
             .push(
                 if imported_descriptor.value.is_empty() || !imported_descriptor.valid {
                     button::primary(None, "Next").width(Length::Fixed(200.0))
@@ -684,43 +561,14 @@ pub fn hardware_wallet_xpubs<'a>(
 
 pub fn participate_xpub<'a>(
     progress: (usize, usize),
-    network: bitcoin::Network,
-    network_valid: bool,
     hws: Vec<Element<'a, Message>>,
     signer: Element<'a, Message>,
     shared: bool,
 ) -> Element<'a, Message> {
-    let row_network = Row::new()
-        .spacing(10)
-        .align_items(Alignment::Center)
-        .push(text("Network:").bold())
-        .push(Container::new(
-            pick_list(&NETWORKS[..], Some(Network::from(network)), |net| {
-                Message::Network(net.into())
-            })
-            .style(if network_valid {
-                theme::PickList::Simple
-            } else {
-                theme::PickList::Invalid
-            })
-            .padding(10),
-        ))
-        .push_maybe(if network_valid {
-            None
-        } else {
-            Some(text("A data directory already exists for this network").style(color::RED))
-        });
-
     layout(
         progress,
         "Share your public keys",
         Column::new()
-            .push(
-                Column::new()
-                    .spacing(20)
-                    .width(Length::Fill)
-                    .push(row_network),
-            )
             .push(
                 Column::new()
                     .push(
@@ -739,7 +587,7 @@ pub fn participate_xpub<'a>(
                 checkbox("I have shared my extended public key", shared)
                     .on_toggle(Message::UserActionDone),
             )
-            .push(if shared && network_valid {
+            .push(if shared {
                 button::primary(None, "Next")
                     .width(Length::Fixed(200.0))
                     .on_press(Message::Next)

--- a/gui/src/launcher.rs
+++ b/gui/src/launcher.rs
@@ -237,11 +237,6 @@ impl Launcher {
                                             )
                                             .fold(
                                                 Column::new()
-                                                    .push(
-                                                        text("Open an existing wallet:")
-                                                            .small()
-                                                            .bold(),
-                                                    )
                                                     .spacing(10),
                                                 |col, choice| {
                                                     col.push(
@@ -263,7 +258,7 @@ impl Launcher {
                                                                         _ => theme::Badge::Standard,
                                                                     }),
                                                                 )
-                                                                .push(text(wallet_name(choice))),
+                                                                .push(text(format!("Open wallet on {}", choice))),
                                                         )
                                                         .on_press(ViewMessage::Check(*choice))
                                                         .padding(10)
@@ -317,11 +312,6 @@ impl Launcher {
                                                 })
                                                 .fold(
                                                     Column::new()
-                                                        .push(
-                                                            text("Create a new wallet:")
-                                                                .small()
-                                                                .bold(),
-                                                        )
                                                         .spacing(10),
                                                     |col, choice| {
                                                         col.push(
@@ -340,7 +330,7 @@ impl Launcher {
                                                                     _ => theme::Badge::Standard,
                                                                 }),
                                                             )
-                                                            .push(text(wallet_name(choice))),
+                                                            .push(text(format!("Create wallet on {}", wallet_name(choice)))),
                                                     )
                                                     .on_press(ViewMessage::StartInstall(*choice))
                                                     .padding(10)

--- a/gui/src/launcher.rs
+++ b/gui/src/launcher.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use iced::{
     alignment::Horizontal,
-    widget::{tooltip, Space},
+    widget::{scrollable, tooltip},
     Alignment, Command, Length, Subscription,
 };
 
@@ -28,31 +28,35 @@ fn wallet_name(network: &Network) -> String {
 }
 
 pub struct Launcher {
-    choices: Vec<Network>,
+    // true if installed
+    choices: Vec<(Network, bool)>,
     datadir_path: PathBuf,
     error: Option<String>,
     delete_wallet_modal: Option<DeleteWalletModal>,
+    collapsed: bool,
 }
 
 impl Launcher {
     pub fn new(datadir_path: PathBuf) -> Self {
-        let mut choices = Vec::new();
-        for network in [
-            Network::Bitcoin,
-            Network::Testnet,
-            Network::Signet,
-            Network::Regtest,
-        ] {
-            if datadir_path.join(network.to_string()).exists() {
-                choices.push(network)
-            }
-        }
         Self {
+            choices: [
+                Network::Bitcoin,
+                Network::Testnet,
+                Network::Signet,
+                Network::Regtest,
+            ]
+            .iter()
+            .map(|net| (*net, datadir_path.join(net.to_string()).exists()))
+            .collect(),
             datadir_path,
-            choices,
             error: None,
             delete_wallet_modal: None,
+            collapsed: false,
         }
+    }
+
+    fn is_fresh_install(&self) -> bool {
+        !self.choices.iter().any(|(_, installed)| *installed)
     }
 
     pub fn stop(&mut self) {}
@@ -63,9 +67,15 @@ impl Launcher {
 
     pub fn update(&mut self, message: Message) -> Command<Message> {
         match message {
-            Message::View(ViewMessage::StartInstall) => {
+            Message::View(ViewMessage::ShowUninstalledNetworks) => {
+                self.collapsed = true;
+                Command::none()
+            }
+            Message::View(ViewMessage::StartInstall(net)) => {
                 let datadir_path = self.datadir_path.clone();
-                Command::perform(async move { datadir_path }, Message::Install)
+                Command::perform(async move { (datadir_path, net) }, |(d, n)| {
+                    Message::Install(d, n)
+                })
             }
             Message::View(ViewMessage::Check(network)) => Command::perform(
                 check_network_datadir(self.datadir_path.clone(), network),
@@ -88,11 +98,9 @@ impl Launcher {
             }
             Message::View(ViewMessage::DeleteWallet(DeleteWalletMessage::Deleted)) => {
                 if let Some(modal) = &self.delete_wallet_modal {
-                    let choices = self.choices.clone();
-                    self.choices = choices
-                        .into_iter()
-                        .filter(|c| c != &modal.network)
-                        .collect();
+                    if let Some(choice) = self.choices.iter_mut().find(|c| c.0 == modal.network) {
+                        choice.1 = false;
+                    }
                 }
                 Command::none()
             }
@@ -126,7 +134,7 @@ impl Launcher {
     }
 
     pub fn view(&self) -> Element<Message> {
-        let content = Into::<Element<ViewMessage>>::into(
+        let content = Into::<Element<ViewMessage>>::into(scrollable(
             Column::new()
                 .push(
                     Container::new(image::liana_brand_grey().width(Length::Fixed(200.0)))
@@ -136,17 +144,107 @@ impl Launcher {
                     Container::new(
                         Column::new()
                             .spacing(30)
-                            .push(text("Welcome back").size(50).bold())
+                            .push(if !self.is_fresh_install() {
+                                text("Welcome back").size(50).bold()
+                            } else {
+                                text("Welcome").size(50).bold()
+                            })
                             .push_maybe(self.error.as_ref().map(|e| card::simple(text(e))))
-                            .push(
-                                self.choices
-                                    .iter()
-                                    .fold(
-                                        Column::new()
-                                            .push(text("Select network:").small().bold())
-                                            .spacing(10),
-                                        |col, choice| {
-                                            col.push(
+                            .push(if self.is_fresh_install() {
+                                Column::new()
+                                    .spacing(10)
+                                    .push(
+                                        Button::new(
+                                            Row::new()
+                                                .spacing(20)
+                                                .align_items(Alignment::Center)
+                                                .push(
+                                                    badge::Badge::new(icon::bitcoin_icon())
+                                                        .style(theme::Badge::Bitcoin),
+                                                )
+                                                .push(text(format!(
+                                                    "Create wallet on {}",
+                                                    wallet_name(&Network::Bitcoin)
+                                                ))),
+                                        )
+                                        .on_press(ViewMessage::StartInstall(Network::Bitcoin))
+                                        .padding(10)
+                                        .width(Length::Fixed(400.0))
+                                        .style(theme::Button::Border),
+                                    )
+                                    .push(if !self.collapsed {
+                                        Column::new().push(
+                                            Button::new(
+                                                Row::new()
+                                                    .spacing(20)
+                                                    .align_items(Alignment::Center)
+                                                    .push(badge::Badge::new(icon::plus_icon()))
+                                                    .push(text("Create wallet on another network")),
+                                            )
+                                            .on_press(ViewMessage::ShowUninstalledNetworks)
+                                            .padding(10)
+                                            .width(Length::Fixed(400.0))
+                                            .style(theme::Button::TransparentBorder),
+                                        )
+                                    } else {
+                                        self.choices
+                                            .iter()
+                                            .filter_map(|(net, installed)| {
+                                                if *installed || *net == Network::Bitcoin {
+                                                    None
+                                                } else {
+                                                    Some(net)
+                                                }
+                                            })
+                                            .fold(Column::new().spacing(10), |col, choice| {
+                                                col.push(
+                                                    Button::new(
+                                                        Row::new()
+                                                            .spacing(20)
+                                                            .align_items(Alignment::Center)
+                                                            .push(
+                                                                badge::Badge::new(
+                                                                    icon::bitcoin_icon(),
+                                                                )
+                                                                .style(theme::Badge::Standard),
+                                                            )
+                                                            .push(text(format!(
+                                                                "Create wallet on {}",
+                                                                wallet_name(choice)
+                                                            ))),
+                                                    )
+                                                    .on_press(ViewMessage::StartInstall(*choice))
+                                                    .padding(10)
+                                                    .width(Length::Fixed(400.0))
+                                                    .style(theme::Button::Border),
+                                                )
+                                            })
+                                    })
+                            } else {
+                                Column::new()
+                                    .spacing(10)
+                                    .push(
+                                        self.choices
+                                            .iter()
+                                            .filter_map(
+                                                |(net, installed)| {
+                                                    if *installed {
+                                                        Some(net)
+                                                    } else {
+                                                        None
+                                                    }
+                                                },
+                                            )
+                                            .fold(
+                                                Column::new()
+                                                    .push(
+                                                        text("Open an existing wallet:")
+                                                            .small()
+                                                            .bold(),
+                                                    )
+                                                    .spacing(10),
+                                                |col, choice| {
+                                                    col.push(
                                                 Row::new()
                                                     .spacing(10)
                                                     .push(
@@ -169,7 +267,7 @@ impl Launcher {
                                                         )
                                                         .on_press(ViewMessage::Check(*choice))
                                                         .padding(10)
-                                                        .width(Length::Fill)
+                                                        .width(Length::Fixed(400.0))
                                                         .style(theme::Button::Border),
                                                     )
                                                     .push(tooltip::Tooltip::new(
@@ -187,35 +285,89 @@ impl Launcher {
                                                     ))
                                                     .align_items(Alignment::Center),
                                             )
-                                        },
+                                                },
+                                            ),
                                     )
                                     .push(
-                                        Button::new(
-                                            Row::new()
-                                                .spacing(20)
-                                                .align_items(Alignment::Center)
-                                                .push(badge::Badge::new(icon::plus_icon()))
-                                                .push(text("Install Liana on another network")),
-                                        )
-                                        .on_press(ViewMessage::StartInstall)
-                                        .padding(10)
-                                        .width(Length::Fill)
-                                        .style(theme::Button::TransparentBorder),
-                                    ),
-                            )
-                            .max_width(500)
-                            .align_items(Alignment::Center),
+                                        if !self.collapsed
+                                            && self.choices.iter().any(|(_, installed)| !installed)
+                                        {
+                                            Column::new().push(
+                                                Button::new(
+                                                    Row::new()
+                                                        .spacing(20)
+                                                        .align_items(Alignment::Center)
+                                                        .push(badge::Badge::new(icon::plus_icon()))
+                                                        .push(text("Create a new wallet")),
+                                                )
+                                                .on_press(ViewMessage::ShowUninstalledNetworks)
+                                                .padding(10)
+                                                .width(Length::Fixed(400.0))
+                                                .style(theme::Button::TransparentBorder),
+                                            )
+                                        } else if self.collapsed {
+                                            self.choices
+                                                .iter()
+                                                .filter_map(|(net, installed)| {
+                                                    if *installed {
+                                                        None
+                                                    } else {
+                                                        Some(net)
+                                                    }
+                                                })
+                                                .fold(
+                                                    Column::new()
+                                                        .push(
+                                                            text("Create a new wallet:")
+                                                                .small()
+                                                                .bold(),
+                                                        )
+                                                        .spacing(10),
+                                                    |col, choice| {
+                                                        col.push(
+                                                    Button::new(
+                                                        Row::new()
+                                                            .spacing(20)
+                                                            .align_items(Alignment::Center)
+                                                            .push(
+                                                                badge::Badge::new(
+                                                                    icon::bitcoin_icon(),
+                                                                )
+                                                                .style(match choice {
+                                                                    Network::Bitcoin => {
+                                                                        theme::Badge::Bitcoin
+                                                                    }
+                                                                    _ => theme::Badge::Standard,
+                                                                }),
+                                                            )
+                                                            .push(text(wallet_name(choice))),
+                                                    )
+                                                    .on_press(ViewMessage::StartInstall(*choice))
+                                                    .padding(10)
+                                                    .width(Length::Fixed(400.0))
+                                                    .style(theme::Button::Border),
+                                                )
+                                                    },
+                                                )
+                                        } else {
+                                            Column::new()
+                                        },
+                                    )
+                            })
+                            .align_items(if self.is_fresh_install() {
+                                Alignment::Center
+                            } else {
+                                Alignment::Start
+                            })
+                            .max_width(500),
                     )
                     .width(Length::Fill)
-                    .height(Length::Fill)
-                    .center_x()
-                    .center_y(),
-                )
-                .push(Space::with_height(Length::Fixed(100.0))),
-        )
+                    .center_x(),
+                ),
+        ))
         .map(Message::View);
         if let Some(modal) = &self.delete_wallet_modal {
-            Modal::new(content, modal.view())
+            Modal::new(Container::new(content).height(Length::Fill), modal.view())
                 .on_blur(Some(Message::View(ViewMessage::DeleteWallet(
                     DeleteWalletMessage::CloseModal,
                 ))))
@@ -229,14 +381,15 @@ impl Launcher {
 #[derive(Debug, Clone)]
 pub enum Message {
     View(ViewMessage),
-    Install(PathBuf),
+    Install(PathBuf, Network),
     Checked(Result<Network, String>),
     Run(PathBuf, app::config::Config, Network),
 }
 
 #[derive(Debug, Clone)]
 pub enum ViewMessage {
-    StartInstall,
+    StartInstall(Network),
+    ShowUninstalledNetworks,
     Check(Network),
     DeleteWallet(DeleteWalletMessage),
 }

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -198,13 +198,12 @@ impl Application for GUI {
                 }
             }
             (State::Launcher(l), Message::Launch(msg)) => match *msg {
-                launcher::Message::Install(datadir_path) => {
+                launcher::Message::Install(datadir_path, network) => {
                     self.logger.set_installer_mode(
                         datadir_path.clone(),
                         self.log_level.unwrap_or(LevelFilter::INFO),
                     );
-                    let (install, command) =
-                        Installer::new(datadir_path, bitcoin::Network::Bitcoin);
+                    let (install, command) = Installer::new(datadir_path, network);
                     self.state = State::Installer(Box::new(install));
                     command.map(|msg| Message::Install(Box::new(msg)))
                 }
@@ -364,13 +363,6 @@ impl Config {
                 Err(ConfigError::NotFound) => Ok(Config::Install(datadir_path, network)),
                 Err(e) => Err(format!("Failed to read configuration file: {}", e).into()),
             }
-        } else if !datadir_path.exists()
-            || (!datadir_path.join("bitcoin").exists()
-                && !datadir_path.join("testnet").exists()
-                && !datadir_path.join("signet").exists()
-                && !datadir_path.join("regtest").exists())
-        {
-            Ok(Config::Install(datadir_path, bitcoin::Network::Bitcoin))
         } else {
             Ok(Config::Launcher(datadir_path))
         }

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -246,6 +246,10 @@ impl Application for GUI {
                     );
                     self.state = State::Loader(Box::new(loader));
                     command.map(|msg| Message::Load(Box::new(msg)))
+                } else if let installer::Message::BackToLauncher = *msg {
+                    let launcher = Launcher::new(i.destination_path());
+                    self.state = State::Launcher(Box::new(launcher));
+                    Command::none()
                 } else {
                     i.update(*msg).map(|msg| Message::Install(Box::new(msg)))
                 }

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -199,6 +199,18 @@ impl Application for GUI {
             }
             (State::Launcher(l), Message::Launch(msg)) => match *msg {
                 launcher::Message::Install(datadir_path, network) => {
+                    if !datadir_path.exists() {
+                        // datadir is created right before launching the installer
+                        // so logs can go in <datadir_path>/installer.log
+                        if let Err(e) = create_datadir(&datadir_path) {
+                            error!("Failed to create datadir: {}", e);
+                        } else {
+                            info!(
+                                "Created a fresh data directory at {}",
+                                &datadir_path.to_string_lossy()
+                            );
+                        }
+                    }
                     self.logger.set_installer_mode(
                         datadir_path.clone(),
                         self.log_level.unwrap_or(LevelFilter::INFO),

--- a/gui/ui/src/color.rs
+++ b/gui/ui/src/color.rs
@@ -55,3 +55,9 @@ pub const RED: Color = Color::from_rgb(
 
 pub const ORANGE: Color =
     Color::from_rgb(0xFF as f32 / 255.0, 0xa7 as f32 / 255.0, 0x0 as f32 / 255.0);
+
+pub const BLUE: Color = Color::from_rgb(
+    0x7D as f32 / 255.0,
+    0xD3 as f32 / 255.0,
+    0xFC as f32 / 255.0,
+);

--- a/gui/ui/src/component/mod.rs
+++ b/gui/ui/src/component/mod.rs
@@ -12,14 +12,41 @@ pub mod text;
 pub mod toast;
 pub mod tooltip;
 
+use bitcoin::Network;
 pub use tooltip::tooltip;
 
 use iced::Length;
 
 use crate::{theme, widget::*};
 
+use self::text::Text;
+
 pub fn separation<'a, T: 'a>() -> Container<'a, T> {
-    Container::new(Column::new().push(Text::new(" ")))
+    Container::new(Column::new().push(text::text(" ")))
         .style(theme::Container::Border)
         .height(Length::Fixed(1.0))
+}
+
+pub fn network_banner<'a, T: 'a>(network: Network) -> Container<'a, T> {
+    Container::new(
+        Row::new()
+            .push(super::icon::warning_icon())
+            .push(text::text("THIS IS A "))
+            .push(
+                text::text(match network {
+                    Network::Signet => "SIGNET WALLET",
+                    Network::Testnet => "TESTNET WALLET",
+                    Network::Regtest => "REGTEST WALLET",
+                    _ => unreachable!(),
+                })
+                .bold(),
+            )
+            .push(text::text(", COINS HAVE "))
+            .push(text::text("NO VALUE").bold())
+            .align_items(iced::Alignment::Center),
+    )
+    .padding(5)
+    .width(Length::Fill)
+    .center_x()
+    .style(theme::Container::Banner)
 }

--- a/gui/ui/src/theme.rs
+++ b/gui/ui/src/theme.rs
@@ -91,6 +91,7 @@ pub enum Container {
     Background,
     Foreground,
     Border,
+    Banner,
     Card(Card),
     Badge(Badge),
     Pill(Pill),
@@ -142,6 +143,16 @@ impl container::StyleSheet for Theme {
                     },
                     ..container::Appearance::default()
                 },
+                Container::Banner => container::Appearance {
+                    background: Some(color::WHITE.into()),
+                    border: iced::Border {
+                        color: color::TRANSPARENT,
+                        width: 0.0,
+                        radius: 0.0.into(),
+                    },
+                    text_color: color::LIGHT_BLACK.into(),
+                    ..container::Appearance::default()
+                },
             },
             Theme::Dark => match style {
                 Container::Transparent => container::Appearance {
@@ -180,6 +191,16 @@ impl container::StyleSheet for Theme {
                         width: 0.0,
                         radius: 25.0.into(),
                     },
+                    ..container::Appearance::default()
+                },
+                Container::Banner => container::Appearance {
+                    background: Some(color::BLUE.into()),
+                    border: iced::Border {
+                        color: color::TRANSPARENT,
+                        width: 0.0,
+                        radius: 0.0.into(),
+                    },
+                    text_color: color::LIGHT_BLACK.into(),
                     ..container::Appearance::default()
                 },
             },


### PR DESCRIPTION
This Pull requests introduce three changes:

1. Network can only be chosen with the launcher panel. A drop down showing what network user can install is shown to the user when clicking on install a new network.
2. A previous button is added to the first installer page, so user can be redirected to launcher and the network choices if he has chosen the wrong network. close #306 
3. In order to make it clear for the user which network he is actually using or he is currently installing a blue banner is added on top of the window if the network is different than the bitcoin mainnet.

![20240529_13h01m15s_grim](https://github.com/wizardsardine/liana/assets/6933020/54ec0cb2-f358-404e-8e6c-27737ecbf2ef)
![20240529_13h01m27s_grim](https://github.com/wizardsardine/liana/assets/6933020/39c25b63-83d8-43ef-9b20-70fec8684cee)
![20240529_13h01m02s_grim](https://github.com/wizardsardine/liana/assets/6933020/a96a3062-6608-4d87-b4cf-5ccc59b17b59)
![20240529_13h00m35s_grim](https://github.com/wizardsardine/liana/assets/6933020/73fdd803-bbe8-4ee0-9855-050306ecbc1c)