### PR TITLE
Add specter support for tap-miniscript

### DIFF
--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "async-hwi"
-version = "0.0.18"
+version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db4e95bcb10d14662ffcf56bc33330f47947677e5834a7edaa5ec8520562b36"
+checksum = "b0997b52dfde80180dc53e5445f9823a490a9eef8dcc0cef0855ed2890fa3987"
 dependencies = [
  "async-trait",
  "bitbox-api",

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 async-trait = "0.1"
-async-hwi = "0.0.18"
+async-hwi = "0.0.19"
 liana = { git = "https://github.com/wizardsardine/liana", branch = "master", default-features = false, features = ["nonblocking_shutdown"] }
 liana_ui = { path = "ui" }
 backtrace = "0.3"

--- a/gui/src/hw.rs
+++ b/gui/src/hw.rs
@@ -828,15 +828,19 @@ fn ledger_version_supported(version: Option<&Version>) -> bool {
 
 // Kind and minimal version of devices supporting tapminiscript.
 // We cannot use a lazy_static HashMap yet, because DeviceKind does not implement Hash.
-const DEVICES_COMPATIBLE_WITH_TAPMINISCRIPT: [(DeviceKind, Option<Version>); 1] = [(
-    DeviceKind::Ledger,
-    Some(Version {
-        major: 2,
-        minor: 2,
-        patch: 0,
-        prerelease: None,
-    }),
-)];
+const DEVICES_COMPATIBLE_WITH_TAPMINISCRIPT: [(DeviceKind, Option<Version>); 3] = [
+    (
+        DeviceKind::Ledger,
+        Some(Version {
+            major: 2,
+            minor: 2,
+            patch: 0,
+            prerelease: None,
+        }),
+    ),
+    (DeviceKind::Specter, None),
+    (DeviceKind::SpecterSimulator, None),
+];
 
 pub fn is_compatible_with_tapminiscript(
     device_kind: &DeviceKind,


### PR DESCRIPTION
This pr enable specter support for tap-miniscript.
tested:
- descriptor registration
- spend trough internal key path
- spent trough taptree path
