### PR TITLE
Add hw error details

### DIFF
--- a/gui/src/hw.rs
+++ b/gui/src/hw.rs
@@ -396,14 +396,14 @@ async fn refresh(mut state: State) -> (HardwareWalletMessage, State) {
                 match HardwareWallet::new(id, Arc::new(device), Some(&state.keys_aliases)).await {
                     Ok(hw) => hws.push(hw),
                     Err(e) => {
-                        debug!("{}", e);
+                        debug!(" Error while connecting to Specter: {}", e);
                     }
                 }
             }
         }
         Err(HWIError::DeviceNotFound) => {}
         Err(e) => {
-            debug!("{}", e);
+            debug!("Error while connecting to SpecterSimulator: {}", e);
         }
     }
 
@@ -427,7 +427,7 @@ async fn refresh(mut state: State) -> (HardwareWalletMessage, State) {
                         {
                             Ok(hw) => hws.push(hw),
                             Err(e) => {
-                                debug!("{}", e);
+                                debug!("Error while connecting to Specter {}", e);
                             }
                         }
                     }
@@ -459,7 +459,7 @@ async fn refresh(mut state: State) -> (HardwareWalletMessage, State) {
                             hws.push(hw);
                         }
                         Err(e) => {
-                            warn!("{:?}", e);
+                            warn!(" Error while connecting to Jade: {:?}", e);
                         }
                     }
                 }
@@ -530,7 +530,7 @@ async fn refresh(mut state: State) -> (HardwareWalletMessage, State) {
         }
         Err(HWIError::DeviceNotFound) => {}
         Err(e) => {
-            debug!("{}", e);
+            debug!("Error connecting to LedgerSimulator{}", e);
         }
     }
 
@@ -669,7 +669,7 @@ async fn refresh(mut state: State) -> (HardwareWalletMessage, State) {
             },
             Err(HWIError::DeviceNotFound) => {}
             Err(e) => {
-                debug!("{}", e);
+                debug!("Error getting Ledger master fingerprint: {}", e);
             }
         }
     }


### PR DESCRIPTION
This PR add details about debut logs in gui/hw.rs
An user reported [here](https://github.com/wizardsardine/liana/issues/1082#issuecomment-2156602936) hw related logs w/o using an hw device