### PR TITLE
installer: add a warning modal if remote address is not loopback

### DIFF
--- a/gui/src/installer/message.rs
+++ b/gui/src/installer/message.rs
@@ -45,6 +45,8 @@ pub enum DefineBitcoind {
     RpcAuthTypeSelected(RpcAuthType),
     PingBitcoindResult(Result<(), Error>),
     PingBitcoind,
+    DisplayModal(bool),
+    PingAndCloseModal,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR add a warning modal if user try to connect to a non-loopback address & use RPCAuth:

![image](https://github.com/wizardsardine/liana/assets/124568858/5232ded3-412c-4950-802d-ea41417127e2)

It also add a check on address + RPC user/password: 
`Check connection` button is greyed out until address is valid + user and password are filled (if RPCAuth selected)

Closes #1059 

 - [x] better check of valid address, atm `::1:<port>` fail but should not (IPV6 loopback)