### PR TITLE
Add interrupt method to state trait

### DIFF
--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -157,6 +157,8 @@ impl App {
     }
 
     fn set_current_panel(&mut self, menu: Menu) -> Command<Message> {
+        self.panels.current_mut().interrupt();
+
         match &menu {
             menu::Menu::TransactionPreSelected(txid) => {
                 if let Ok(Some(tx)) = Handle::current().block_on(async {

--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -47,6 +47,7 @@ pub trait State {
     fn subscription(&self) -> Subscription<Message> {
         Subscription::none()
     }
+    fn interrupt(&mut self) {}
     fn reload(
         &mut self,
         _daemon: Arc<dyn Daemon + Sync + Send>,

--- a/gui/src/app/state/psbt.rs
+++ b/gui/src/app/state/psbt.rs
@@ -107,6 +107,10 @@ impl PsbtState {
         }
     }
 
+    pub fn interrupt(&mut self) {
+        self.action = None;
+    }
+
     pub fn subscription(&self) -> Subscription<Message> {
         if let Some(action) = &self.action {
             action.as_ref().subscription()

--- a/gui/src/app/state/psbts.rs
+++ b/gui/src/app/state/psbts.rs
@@ -67,6 +67,10 @@ impl State for PsbtsPanel {
         }
     }
 
+    fn interrupt(&mut self) {
+        self.selected_tx = None;
+    }
+
     fn update(
         &mut self,
         daemon: Arc<dyn Daemon + Sync + Send>,

--- a/gui/src/app/state/spend/mod.rs
+++ b/gui/src/app/state/spend/mod.rs
@@ -81,6 +81,10 @@ impl State for CreateSpendPanel {
         self.steps.get(self.current).unwrap().subscription()
     }
 
+    fn interrupt(&mut self) {
+        self.steps.get_mut(self.current).unwrap().interrupt();
+    }
+
     fn update(
         &mut self,
         daemon: Arc<dyn Daemon + Sync + Send>,

--- a/gui/src/app/state/spend/step.rs
+++ b/gui/src/app/state/spend/step.rs
@@ -61,6 +61,7 @@ pub trait Step {
         message: Message,
     ) -> Command<Message>;
     fn apply(&self, _draft: &mut TransactionDraft) {}
+    fn interrupt(&mut self) {}
     fn load(&mut self, _draft: &TransactionDraft) {}
     fn subscription(&self) -> Subscription<Message> {
         Subscription::none()
@@ -774,6 +775,12 @@ impl Step for SaveSpend {
             psbt::PsbtState::new(self.wallet.clone(), tx, false),
             warnings,
         ));
+    }
+
+    fn interrupt(&mut self) {
+        if let Some((psbt_state, _)) = &mut self.spend {
+            psbt_state.interrupt()
+        }
     }
 
     fn subscription(&self) -> Subscription<Message> {


### PR DESCRIPTION
Before changing panel, the previous state may need to release a hardware connection for example.
In order to achieve this we introduce an interrupt method that is used to drop action state.

close #1162