### PR TITLE
gui: fix clippy warning

### DIFF
--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -630,7 +630,7 @@ pub fn register_descriptor<'a>(
                         .push(
                             scrollable(
                                 Column::new()
-                                    .push(text(template.to_owned()).small())
+                                    .push(text(template).small())
                                     .push(Space::with_height(Length::Fixed(5.0))),
                             )
                             .direction(


### PR DESCRIPTION
I do not know why but clippy started throwing warning about this line of code