### PR TITLE
GUI: Add space separator to integer portion of BTC amount rendering

### DIFF
--- a/gui/ui/src/component/amount.rs
+++ b/gui/ui/src/component/amount.rs
@@ -95,6 +95,22 @@ fn split_digits<'a, T: 'a>(mut s: String, size: u16, bold: bool) -> impl Into<El
                 });
         }
     }
+
+    // Reformat the integer portion of the amount with space separation.
+    let (integer, fraction) = match s.split_once('.') {
+        Some((i, f)) => (i, f),
+        None => (s.as_str(), "00 000 000"),
+    };
+    let mut integer = integer
+        .chars()
+        .collect::<Vec<_>>()
+        .rchunks(3)
+        .map(|c| c.iter().collect::<String>())
+        .collect::<Vec<_>>();
+    integer.reverse();
+    let integer = integer.join(" ");
+    s = format!("{integer}.{fraction}");
+
     if bold {
         Row::new().push(text(s).bold().size(size))
     } else {


### PR DESCRIPTION
This PR attempts to address #962, refactoring the amount component to support an internationalized display format and fixing a bug where the integer portion of the decimal didn't support the space separator for BTC values.

I'm attempting to learn Rust, Bitcoin programming, the `iced` GUI library and the Liana stack simultaneously, so this took altogether waaaaay too long, but it ended up being a great onboarding task to start wrapping my head around Rust strings, Strings, slices, vectors, iterators, and rummaging around in the documentation. That said, there are probably plenty of small details or oversights, so pile on the feedback. Here are a few review topics of interest:

* It didn't make sense to me at first that `split_digits()` was responsible for adding GUI rows and formatting details like `bold()` and text size, so I ripped that out in favor of a function that focused on formatting the decimal amount, returning a tuple containing strings for the integer and fraction portions of the number. This resulted in probably removing some embedded `Row` objects. I didn't see a problem with this, but please advise if it was too aggressive.
* I wrote a quick test for the formatting in `amount.rs` which can be run from `gui/ui` using `cargo test --release`. Maybe there is a better place for this? Other test cases that should be added?
* The only thing I could observe between the `amount_with_size()` and `unconfirmed_amount_with_size()` functions was that the former was applying bold formatting to the integer part of the number. I removed a lot of duplicate code between these functions and reduced them to focusing on building the GUI elements, rather than number formatting logic. I hope this is right, but could be missing something as it was rather hard to read.

There is probably a lot of room for improvement. Thanks :)