### PR TITLE
Add minimum feerate to TooLowFeerate error message

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -131,7 +131,7 @@ impl From<SpendCreationError> for CommandError {
 pub enum RbfErrorInfo {
     MissingFeerate,
     SuperfluousFeerate,
-    TooLowFeerate(u64),
+    TooLowFeerate(u64, u64),
     NotSignaling,
 }
 
@@ -144,7 +144,9 @@ impl fmt::Display for RbfErrorInfo {
             Self::SuperfluousFeerate => {
                 write!(f, "A feerate must not be provided if creating a cancel. We'll always use the smallest one which satisfies the RBF rules.")
             }
-            Self::TooLowFeerate(r) => write!(f, "Feerate too low: {}.", r),
+            Self::TooLowFeerate(r, m) => {
+                write!(f, "Feerate {} too low for minimum feerate {}.", r, m)
+            }
             Self::NotSignaling => write!(f, "Replacement candidate does not signal for RBF."),
         }
     }
@@ -803,6 +805,7 @@ impl DaemonControl {
         if feerate_vb < min_feerate_vb {
             return Err(CommandError::RbfError(RbfErrorInfo::TooLowFeerate(
                 feerate_vb,
+                min_feerate_vb,
             )));
         }
         // Get info about prev outputs to determine replacement outputs.

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1093,7 +1093,7 @@ def test_rbfpsbt_bump_fee(lianad, bitcoind):
         )
     )
     # We can now use RBF, but the feerate must be higher than that of the first transaction.
-    with pytest.raises(RpcError, match=f"Feerate too low: 1."):
+    with pytest.raises(RpcError, match=f"Feerate 1 too low for minimum feerate 2."):
         lianad.rpc.rbfpsbt(first_txid, False, 1)
     # Using a higher feerate works.
     lianad.rpc.rbfpsbt(first_txid, False, 2)
@@ -1127,7 +1127,9 @@ def test_rbfpsbt_bump_fee(lianad, bitcoind):
     # If we try to RBF the first transaction again, it will use the first RBF's
     # feerate to set the min feerate, instead of 1 sat/vb of first
     # transaction:
-    with pytest.raises(RpcError, match=f"Feerate too low: {int(rbf_1_feerate)}."):
+    with pytest.raises(
+        RpcError, match=f"Feerate {int(rbf_1_feerate)} too low for minimum feerate 10."
+    ):
         lianad.rpc.rbfpsbt(first_txid, False, int(rbf_1_feerate))
     # Using 1 more for feerate works.
     feerate = int(rbf_1_feerate) + 1


### PR DESCRIPTION
This PR adds the minimum feerate value into the `TooLowFeerate` error message for additional context. Addresses the second bullet point in #853.