### PR TITLE
disable previous button if device processing

### DIFF
--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -750,7 +750,11 @@ pub fn register_descriptor<'a>(
             })
             .spacing(50),
         true,
-        Some(Message::Previous),
+        if !processing {
+        Some(Message::Previous)
+        } else {
+            None
+        }
     )
 }
 


### PR DESCRIPTION
This PR diasable the previous button  at the descriptor registration step if a device is still processing, avoiding issues like #1158.
The other way around can be to reset the state of `self.processing` if user go back, but look less clean to me.

closes #1158 