### PR TITLE
add coldcard support

### DIFF
--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "async-hwi"
-version = "0.0.21"
+version = "0.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a278b99ded5aa103de53c13496b0fd9266f2218ec7a37c8f7083285bba567fa7"
+checksum = "5b3f27c4ed452a71a415e1198b2ef0b586ef270f3921b6ebbd558311d46806fd"
 dependencies = [
  "async-trait",
  "bitbox-api",
@@ -4205,7 +4205,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f622567e3b4b38154fb8190bcf6b160d7a4301d70595a49195b48c116007a27"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.13.0",
  "secp256k1-sys",
  "serde",
 ]

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 async-trait = "0.1"
-async-hwi = { version = "0.0.21" }
+async-hwi = { version = "0.0.22" }
 liana = { git = "https://github.com/wizardsardine/liana", branch = "master", default-features = false, features = ["nonblocking_shutdown"] }
 liana_ui = { path = "ui" }
 backtrace = "0.3"

--- a/gui/src/hw.rs
+++ b/gui/src/hw.rs
@@ -843,7 +843,7 @@ fn ledger_version_supported(version: Option<&Version>) -> bool {
 
 // Kind and minimal version of devices supporting tapminiscript.
 // We cannot use a lazy_static HashMap yet, because DeviceKind does not implement Hash.
-const DEVICES_COMPATIBLE_WITH_TAPMINISCRIPT: [(DeviceKind, Option<Version>); 3] = [
+const DEVICES_COMPATIBLE_WITH_TAPMINISCRIPT: [(DeviceKind, Option<Version>); 4] = [
     (
         DeviceKind::Ledger,
         Some(Version {
@@ -855,6 +855,15 @@ const DEVICES_COMPATIBLE_WITH_TAPMINISCRIPT: [(DeviceKind, Option<Version>); 3] 
     ),
     (DeviceKind::Specter, None),
     (DeviceKind::SpecterSimulator, None),
+    (
+        DeviceKind::Coldcard,
+        Some(Version {
+            major: 6,
+            minor: 3,
+            patch: 3,
+            prerelease: None,
+        }),
+    ),
 ];
 
 pub fn is_compatible_with_tapminiscript(


### PR DESCRIPTION
This PR add support for taproot w/ coldcard devices
We need to wait [async-hwi PR](https://github.com/wizardsardine/async-hwi/pull/92) to be merged berfore merge this one.

Tested w/ internal key & taptree on Mk4