### PR TITLE
gui: update `SettingState.wallet` on `WalletUpdated()` message

### DIFF
--- a/gui/src/app/state/settings/mod.rs
+++ b/gui/src/app/state/settings/mod.rs
@@ -84,6 +84,13 @@ impl State for SettingsState {
                     .map(|s| s.reload(daemon, wallet))
                     .unwrap_or_else(Command::none)
             }
+            Message::WalletUpdated(Ok(wallet)) => {
+                self.wallet = wallet.clone();
+                self.setting
+                    .as_mut()
+                    .map(|s| s.update(daemon, cache, message))
+                    .unwrap_or_else(Command::none)
+            }
             _ => self
                 .setting
                 .as_mut()


### PR DESCRIPTION
This PR fixes #1170.

result Message from `update_key_aliases()` emited [here](https://github.com/wizardsardine/liana/blob/0a7ff2b0ea1b6f4e98946ccc1201a8d1caec8bf5/gui/src/app/state/settings/wallet.rs#L152) was not catch in `SettingState.update()`.