### PR TITLE
gui: disable replacement fee input if tx is already replaced

### DIFF
--- a/liana-gui/src/app/view/transactions.rs
+++ b/liana-gui/src/app/view/transactions.rs
@@ -257,13 +257,17 @@ pub fn create_rbf_modal<'a>(
                         .push(Container::new(p1_bold("Feerate")).padding(10))
                         .spacing(10)
                         .push(
-                            form::Form::new_trimmed("", feerate, move |msg| {
-                                Message::CreateRbf(CreateRbfMessage::FeerateEdited(msg))
-                            })
-                            .warning(
-                                "Feerate must be greater than previous value and \
-                                less than or equal to 1000 sats/vbyte",
-                            )
+                            if replacement_txid.is_none() {
+                                form::Form::new_trimmed("", feerate, move |msg| {
+                                    Message::CreateRbf(CreateRbfMessage::FeerateEdited(msg))
+                                })
+                                .warning(
+                                    "Feerate must be greater than previous value and \
+                                    less than or equal to 1000 sats/vbyte",
+                                )
+                            } else {
+                                form::Form::new_disabled("", feerate)
+                            }
                             .size(P1_SIZE)
                             .padding(10),
                         )

--- a/liana-ui/src/component/form.rs
+++ b/liana-ui/src/component/form.rs
@@ -46,6 +46,19 @@ where
         }
     }
 
+    /// Creates a new [`Form`] that has a disabled input.
+    ///
+    /// It expects:
+    /// - a placeholder
+    /// - the current value
+    pub fn new_disabled(placeholder: &str, value: &Value<String>) -> Self {
+        Self {
+            input: text_input::TextInput::new(placeholder, &value.value),
+            warning: None,
+            valid: value.valid,
+        }
+    }
+
     /// Creates a new [`Form`] that trims input values before applying the `on_change` function.
     ///
     /// It expects:


### PR DESCRIPTION
this PR disable input on feerate TextInput if the tx already have been replaced, it's fine to do so because we still can RBF the new replacing tx.

![image](https://github.com/user-attachments/assets/c5ad2ed3-50f0-41e0-924b-261896174900)

close #1138 
