### PR TITLE
gui: add the version in the window title bar

### DIFF
--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -119,8 +119,8 @@ impl Application for GUI {
 
     fn title(&self) -> String {
         match self.state {
-            State::Installer(_) => String::from("Liana Installer"),
-            _ => String::from("Liana"),
+            State::Installer(_) => format!("Liana v{} Installer", VERSION),
+            _ => format!("Liana v{}", VERSION),
         }
     }
 


### PR DESCRIPTION
This PR add the version (major+minor) into the window titlebar, for both installer & wallet.
close #1181 

![image](https://github.com/user-attachments/assets/f4cc883c-dbae-4128-89ea-c9b047e3b1de)

![image](https://github.com/user-attachments/assets/013d5c89-9df1-4883-a014-802b255813b8)
