### PR TITLE
WIP: Upgrade rust-miniscript / rust-bitcoin to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "544a7f66f3407c6ed1285525418393891e0f31c2078a2d46aefb44ecef09b1b3"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "backtrace"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +54,16 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+]
+
+[[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
 ]
 
 [[package]]
@@ -70,9 +86,9 @@ checksum = "3c084bf76f0f67546fc814ffa82044144be1bb4618183a15016c162f8b087ad4"
 
 [[package]]
 name = "bech32"
-version = "0.10.0-beta"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bip39"
@@ -87,15 +103,18 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.31.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5973a027b341b462105675962214dfe3c938ad9afd395d84b28602608bdcec7b"
+checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
 dependencies = [
+ "base58ck",
  "base64 0.21.5",
  "bech32",
- "bitcoin-internals",
- "bitcoin_hashes 0.13.0",
- "hex-conservative",
+ "bitcoin-internals 0.3.0",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
  "hex_lit",
  "secp256k1",
  "serde",
@@ -106,7 +125,29 @@ name = "bitcoin-internals"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals 0.3.0",
  "serde",
 ]
 
@@ -122,8 +163,18 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-internals",
- "hex-conservative",
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.1",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.1",
  "serde",
 ]
 
@@ -239,6 +290,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,13 +385,12 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "miniscript"
-version = "11.0.0"
+version = "12.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a23dd3ad145a980e231185d114399f25a0a307d2cd918010ddda6334323df9"
+checksum = "add2d4aee30e4291ce5cffa3a322e441ff4d4bc57b38c8d9bf0e94faa50ab626"
 dependencies = [
  "bech32",
  "bitcoin",
- "bitcoin-internals",
  "serde",
 ]
 
@@ -466,9 +525,9 @@ checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "secp256k1"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
+checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
  "bitcoin_hashes 0.13.0",
  "secp256k1-sys",
@@ -477,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd97a086ec737e30053fd5c46f097465d25bb81dd3608825f65298c4c98be83"
+checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ nonblocking_shutdown = []
 
 [dependencies]
 # For managing transactions (it re-exports the bitcoin crate)
-miniscript = { version = "11.0", features = ["serde", "compiler", "base64"] }
+miniscript = { version = "12.0", features = ["serde", "compiler", "base64"] }
 
 # Coin selection algorithms for spend transaction creation.
 bdk_coin_select = "0.3"

--- a/src/database/sqlite/schema.rs
+++ b/src/database/sqlite/schema.rs
@@ -296,7 +296,7 @@ impl TryFrom<&rusqlite::Row<'_>> for DbSpendTransaction {
 
         let txid: Vec<u8> = row.get(2)?;
         let txid: bitcoin::Txid = encode::deserialize(&txid).expect("We only store valid txids");
-        assert_eq!(txid, psbt.unsigned_tx.txid());
+        assert_eq!(txid, psbt.unsigned_tx.compute_txid());
 
         let updated_at = row.get(3)?;
 

--- a/src/database/sqlite/utils.rs
+++ b/src/database/sqlite/utils.rs
@@ -245,7 +245,7 @@ fn migrate_v4_to_v5(
         )?;
 
         for bitcoin_tx in bitcoin_txs {
-            let txid = &bitcoin_tx.txid()[..].to_vec();
+            let txid = &bitcoin_tx.compute_txid()[..].to_vec();
             let bitcoin_tx_ser = bitcoin::consensus::serialize(bitcoin_tx);
             db_tx.execute(
                 "INSERT INTO transactions (txid, tx) VALUES (?1, ?2);",

--- a/src/descriptors/analysis.rs
+++ b/src/descriptors/analysis.rs
@@ -2,11 +2,11 @@ use miniscript::{
     bitcoin::{
         self, bip32,
         hashes::{sha256, Hash},
-        secp256k1, Sequence,
+        secp256k1,
     },
     descriptor,
     policy::{Concrete as ConcretePolicy, Liftable, Semantic as SemanticPolicy},
-    ScriptContext,
+    RelLockTime, ScriptContext, Threshold,
 };
 
 use std::{
@@ -14,6 +14,7 @@ use std::{
     convert::TryFrom,
     error, fmt,
     str::FromStr,
+    sync,
 };
 
 #[derive(Debug)]
@@ -71,9 +72,10 @@ impl error::Error for LianaPolicyError {}
 fn is_single_key_or_multisig(policy: &SemanticPolicy<descriptor::DescriptorPublicKey>) -> bool {
     match policy {
         SemanticPolicy::Key(..) => true,
-        SemanticPolicy::Threshold(_, subs) => {
-            subs.iter().all(|sub| matches!(sub, SemanticPolicy::Key(_)))
-        }
+        SemanticPolicy::Thresh(thresh) => thresh
+            .data()
+            .iter()
+            .all(|sub| matches!(sub.as_ref(), SemanticPolicy::Key(_))),
         _ => false,
     }
 }
@@ -185,11 +187,14 @@ impl PathInfo {
     ) -> Result<PathInfo, LianaPolicyError> {
         match policy {
             SemanticPolicy::Key(key) => Ok(PathInfo::Single(key)),
-            SemanticPolicy::Threshold(k, subs) => {
-                let keys: Result<_, LianaPolicyError> = subs
+            SemanticPolicy::Thresh(thresh) if thresh.k() > 0 && thresh.n() >= thresh.k() => {
+                // FIXME
+                let k = thresh.k();
+                let keys: Result<_, LianaPolicyError> = thresh
+                    .into_data()
                     .into_iter()
-                    .map(|sub| match sub {
-                        SemanticPolicy::Key(key) => Ok(key),
+                    .map(|sub| match sub.as_ref() {
+                        SemanticPolicy::Key(key) => Ok(key.clone()),
                         _ => Err(LianaPolicyError::IncompatibleDesc),
                     })
                     .collect();
@@ -199,6 +204,8 @@ impl PathInfo {
         }
     }
 
+    // FIXME: Rust-miniscript's introduction of Arc-wrapped sub-policies in Thresh made this code
+    // introduce allocations everywhere.
     /// Get the information about the recovery spending path.
     /// Returns None if the policy does not describe the recovery spending path of a Liana
     /// descriptor (that is, a set of keys after a timelock).
@@ -210,7 +217,7 @@ impl PathInfo {
         // special case n == len(keys) (i.e. it's an N-of-N multisig), it is normalized as
         // `thresh(n+1, older(x), key1, key2, ...)`.
         let (k, subs) = match policy {
-            SemanticPolicy::Threshold(k, subs) => (k, subs),
+            SemanticPolicy::Thresh(thresh) => (thresh.k(), thresh.into_data()),
             _ => return Err(LianaPolicyError::IncompatibleDesc),
         };
         if k == 2 && subs.len() == 2 {
@@ -218,29 +225,29 @@ impl PathInfo {
             // of the same form as a primary path.
             let tl_value = subs
                 .iter()
-                .find_map(|s| match s {
-                    SemanticPolicy::Older(val) => Some(csv_check(val.0)),
+                .find_map(|s| match s.as_ref() {
+                    SemanticPolicy::Older(val) => Some(csv_check(val.to_consensus_u32())),
                     _ => None,
                 })
                 .ok_or(LianaPolicyError::IncompatibleDesc)??;
             let keys_sub = subs
                 .into_iter()
-                .find(is_single_key_or_multisig)
+                .find(|sub| is_single_key_or_multisig(sub.as_ref()))
                 .ok_or(LianaPolicyError::IncompatibleDesc)?;
-            PathInfo::from_primary_path(keys_sub).map(|info| (tl_value, info))
+            PathInfo::from_primary_path(keys_sub.as_ref().clone()).map(|info| (tl_value, info))
         } else if k == subs.len() && subs.len() > 2 {
             // The N-of-N case. All subs but the threshold must be keys (if one had been thresh()
             // of keys it would have been normalized).
             let mut tl_value = None;
             let mut keys = Vec::with_capacity(subs.len());
             for sub in subs {
-                match sub {
-                    SemanticPolicy::Key(key) => keys.push(key),
+                match sub.as_ref() {
+                    SemanticPolicy::Key(key) => keys.push(key.clone()),
                     SemanticPolicy::Older(val) => {
                         if tl_value.is_some() {
                             return Err(LianaPolicyError::IncompatibleDesc);
                         }
-                        tl_value = Some(csv_check(val.0)?);
+                        tl_value = Some(csv_check(val.to_consensus_u32())?);
                     }
                     _ => return Err(LianaPolicyError::IncompatibleDesc),
                 }
@@ -348,16 +355,21 @@ impl PathInfo {
     }
 
     /// Get a Miniscript Policy for this path.
-    pub fn into_ms_policy(self) -> ConcretePolicy<descriptor::DescriptorPublicKey> {
-        match self {
+    pub fn into_ms_policy(
+        self,
+    ) -> Result<ConcretePolicy<descriptor::DescriptorPublicKey>, LianaPolicyError> {
+        Ok(match self {
             PathInfo::Single(key) => ConcretePolicy::Key(key),
-            PathInfo::Multi(thresh, keys) => ConcretePolicy::Threshold(
-                thresh,
-                keys.into_iter()
-                    .map(|key| ConcretePolicy::Key(key).into())
-                    .collect(),
+            PathInfo::Multi(thresh, keys) => ConcretePolicy::Thresh(
+                Threshold::new(
+                    thresh,
+                    keys.into_iter()
+                        .map(|key| sync::Arc::new(ConcretePolicy::Key(key).into()))
+                        .collect(),
+                )
+                .map_err(|e| LianaPolicyError::InvalidPolicy(miniscript::Error::Threshold(e)))?,
             ),
-        }
+        })
     }
 }
 
@@ -570,13 +582,10 @@ impl LianaPolicy {
                     if *desc_int_xpub == unspend_int_xpub {
                         tree_policy
                     } else {
-                        SemanticPolicy::Threshold(
-                            1,
-                            vec![
-                                SemanticPolicy::Key(desc.internal_key().clone()),
-                                tree_policy,
-                            ],
-                        )
+                        SemanticPolicy::Thresh(Threshold::or(
+                            sync::Arc::new(SemanticPolicy::Key(desc.internal_key().clone())),
+                            sync::Arc::new(tree_policy),
+                        ))
                     }
                 } else {
                     // A Liana descriptor must contain a timelocked path.
@@ -593,15 +602,23 @@ impl LianaPolicy {
         // primary path with at least one key, and at least one timelocked recovery path with at
         // least one key.
         let subs = match policy {
-            SemanticPolicy::Threshold(1, subs) => Some(subs),
-            _ => None,
-        }
-        .ok_or(LianaPolicyError::IncompatibleDesc)?;
+            SemanticPolicy::Thresh(thresh) if thresh.is_or() && thresh.n() > 1 => {
+                thresh.into_data()
+            }
+            _ => return Err(LianaPolicyError::IncompatibleDesc),
+        };
 
         // Fetch all spending paths' semantic policies. The primary path is identified as the only
         // one that isn't timelocked.
         let (mut primary_path, mut recovery_paths) = (None::<PathInfo>, BTreeMap::new());
         for sub in subs {
+            // Rust-Miniscript now forces the policy in thresholds to be wrapped into an Arc. Since
+            // we lift the policy from the descriptor right above, there is necessarily a single
+            // reference per Arc, so it's safe to unwrap. This avoids having to clone every single
+            // sub below.
+            let sub =
+                sync::Arc::try_unwrap(sub).expect("Only a single reference, created right above.");
+
             // This is a (multi)key check. It must be the primary path.
             if is_single_key_or_multisig(&sub) {
                 // We only support a single primary path. But it may be that the primary path is a
@@ -610,7 +627,7 @@ impl LianaPolicy {
                 // thresh(2, older(42), pk(C)))`.
                 if let Some(prim_path) = primary_path {
                     if let SemanticPolicy::Key(key) = sub {
-                        primary_path = Some(prim_path.with_added_key(key));
+                        primary_path = Some(prim_path.with_added_key(key.clone()));
                     } else {
                         return Err(LianaPolicyError::IncompatibleDesc);
                     }
@@ -645,7 +662,10 @@ impl LianaPolicy {
         &self.recovery_paths
     }
 
-    fn into_policy(self) -> miniscript::policy::Concrete<descriptor::DescriptorPublicKey> {
+    fn into_policy(
+        self,
+    ) -> Result<miniscript::policy::Concrete<descriptor::DescriptorPublicKey>, LianaPolicyError>
+    {
         let LianaPolicy {
             primary_path,
             recovery_paths,
@@ -653,19 +673,23 @@ impl LianaPolicy {
         } = self;
 
         // Start with the primary spending path. We'll then or() all the recovery paths to it.
-        let primary_keys = primary_path.into_ms_policy();
+        let primary_keys = primary_path.into_ms_policy()?;
 
         // Incrementally create the top-level policy using all recovery paths.
         assert!(!recovery_paths.is_empty());
-        recovery_paths
-            .into_iter()
-            .fold(primary_keys, |tl_policy, (timelock, path_info)| {
-                let timelock = ConcretePolicy::Older(Sequence::from_height(timelock));
-                let keys = path_info.into_ms_policy();
+        Ok(recovery_paths.into_iter().try_fold(
+            primary_keys,
+            |tl_policy, (timelock, path_info)| {
+                let timelock = ConcretePolicy::Older(RelLockTime::from_height(timelock));
+                let keys = path_info.into_ms_policy()?;
                 let recovery_branch = ConcretePolicy::And(vec![keys.into(), timelock.into()]);
                 // We assume the larger the timelock the less likely a branch would be used.
-                ConcretePolicy::Or(vec![(99, tl_policy.into()), (1, recovery_branch.into())])
-            })
+                Ok(ConcretePolicy::Or(vec![
+                    (99, tl_policy.into()),
+                    (1, recovery_branch.into()),
+                ]))
+            },
+        )?)
     }
 
     fn into_multipath_descriptor_fallible(
@@ -689,12 +713,12 @@ impl LianaPolicy {
                         depth: 0,
                         parent_fingerprint: [0; 4].into(),
                         child_number: 0.into(),
-                        network: bitcoin::Network::Regtest,
+                        network: bitcoin::Network::Regtest.into(),
                     },
                     derivation_path: vec![].into(),
                     wildcard: descriptor::Wildcard::None,
                 });
-            let policy = self.into_policy();
+            let policy = self.into_policy()?;
             let desc = policy
                 .clone()
                 .compile_tr(Some(dummy_internal_key.clone()))
@@ -719,7 +743,7 @@ impl LianaPolicy {
             }
         } else {
             let ms = self
-                .into_policy()
+                .into_policy()?
                 .compile::<miniscript::Segwitv0>()
                 .map_err(|e| LianaPolicyError::InvalidPolicy(e.into()))?;
             miniscript::Segwitv0::check_local_validity(&ms).expect("Miniscript must be sane");

--- a/src/descriptors/mod.rs
+++ b/src/descriptors/mod.rs
@@ -199,7 +199,7 @@ impl LianaDescriptor {
     pub fn all_xpubs_net_is(&self, expected_net: bitcoin::Network) -> bool {
         self.multi_desc.for_each_key(|xpub| {
             if let descriptor::DescriptorPublicKey::MultiXPub(xpub) = xpub {
-                xpub.xkey.network == expected_net
+                xpub.xkey.network == expected_net.into()
             } else {
                 false
             }
@@ -286,10 +286,14 @@ impl LianaDescriptor {
             // emtpy witness). But this method is used to account between a completely "nude"
             // transaction (and therefore no Segwit marker nor empty witness in inputs) and a
             // satisfied transaction.
-            self.multi_desc
+            (self
+                .multi_desc
                 .max_weight_to_satisfy()
                 .expect("Always satisfiable")
-                + 1
+                .to_wu()
+                + 1)
+            .try_into()
+            .expect("Sat weight must fit in usize.")
         }
     }
 
@@ -773,7 +777,7 @@ mod tests {
             [(26352, recovery_keys.clone())].iter().cloned().collect(),
         )
         .unwrap();
-        assert_eq!(LianaDescriptor::new(policy).to_string(), "wsh(or_d(multi(3,[aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/0/<0;1>/*,[aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/0/<0;1>/*,[aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/0/<0;1>/*),and_v(v:thresh(2,pkh([aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/1/<0;1>/*),a:pkh([aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/1/<0;1>/*),a:pkh([aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/1/<0;1>/*)),older(26352))))#prj7nktq");
+        assert_eq!(LianaDescriptor::new(policy).to_string(), "wsh(or_i(and_v(v:thresh(2,pkh([aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/1/<0;1>/*),a:pkh([aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/1/<0;1>/*),a:pkh([aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/1/<0;1>/*)),older(26352)),and_v(v:and_v(v:pk([aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/0/<0;1>/*),pk([aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/0/<0;1>/*)),pk([aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/0/<0;1>/*))))#c7nf353n");
 
         // Same under Taproot.
         let policy = LianaPolicy::new(
@@ -781,7 +785,7 @@ mod tests {
             [(26352, recovery_keys)].iter().cloned().collect(),
         )
         .unwrap();
-        assert_eq!(LianaDescriptor::new(policy.clone()).to_string(), "tr(xpub661MyMwAqRbcFERisZuMzFcfg3Ur3dKB17kb8iEG89ZJYMHTWqKQGRdLjTXC6Byr8kjKo6JabFfRCm3ETM4woq7DxUXuUxxRFHfog4Peh41/<0;1>/*,{and_v(v:multi_a(2,[aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/1/<0;1>/*,[aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/1/<0;1>/*,[aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/1/<0;1>/*),older(26352)),multi_a(3,[aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/0/<0;1>/*,[aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/0/<0;1>/*,[aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/0/<0;1>/*)})#tugn7xtx");
+        assert_eq!(LianaDescriptor::new(policy.clone()).to_string(), "tr(xpub661MyMwAqRbcFERisZuMzFcfg3Ur3dKB17kb8iEG89ZJYMHTWqKQGRdLjTXC6Byr8kjKo6JabFfRCm3ETM4woq7DxUXuUxxRFHfog4Peh41/<0;1>/*,{and_v(v:multi_a(2,[aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/1/<0;1>/*,[aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/1/<0;1>/*,[aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/1/<0;1>/*),older(26352)),and_v(v:and_v(v:pk([aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/0/<0;1>/*),pk([aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/0/<0;1>/*)),pk([aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/0/<0;1>/*))})#eey6zfhr");
 
         // Another derivation step before the wildcard is taken into account.
         // desc_b is the very same descriptor as desc_a, except the very first xpub's derivation
@@ -819,7 +823,7 @@ mod tests {
             [(26352, recovery_keys.clone())].iter().cloned().collect(),
         )
         .unwrap();
-        assert_eq!(LianaDescriptor::new(policy).to_string(), "wsh(or_d(multi(3,[aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/<0;1>/*,[aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/<0;1>/*,[aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/<0;1>/*),and_v(v:thresh(2,pkh([aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/<2;3>/*),a:pkh([aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/<2;3>/*),a:pkh([aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/<2;3>/*)),older(26352))))#d2h994td");
+        assert_eq!(LianaDescriptor::new(policy).to_string(), "wsh(or_i(and_v(v:thresh(2,pkh([aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/<2;3>/*),a:pkh([aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/<2;3>/*),a:pkh([aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/<2;3>/*)),older(26352)),and_v(v:and_v(v:pk([aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/<0;1>/*),pk([aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/<0;1>/*)),pk([aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/<0;1>/*))))#tjdnx6vm");
 
         // Same under Taproot.
         let policy = LianaPolicy::new(
@@ -827,7 +831,7 @@ mod tests {
             [(26352, recovery_keys)].iter().cloned().collect(),
         )
         .unwrap();
-        assert_eq!(LianaDescriptor::new(policy.clone()).to_string(), "tr(xpub661MyMwAqRbcFERisZuMzFcfg3Ur3dKB17kb8iEG89ZJYMHTWqKQGRdLjTXC6Byr8kjKo6JabFfRCm3ETM4woq7DxUXuUxxRFHfog4Peh41/<0;1>/*,{and_v(v:multi_a(2,[aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/<2;3>/*,[aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/<2;3>/*,[aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/<2;3>/*),older(26352)),multi_a(3,[aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/<0;1>/*,[aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/<0;1>/*,[aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/<0;1>/*)})#ayju5dfr");
+        assert_eq!(LianaDescriptor::new(policy.clone()).to_string(), "tr(xpub661MyMwAqRbcFERisZuMzFcfg3Ur3dKB17kb8iEG89ZJYMHTWqKQGRdLjTXC6Byr8kjKo6JabFfRCm3ETM4woq7DxUXuUxxRFHfog4Peh41/<0;1>/*,{and_v(v:multi_a(2,[aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/<2;3>/*,[aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/<2;3>/*,[aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/<2;3>/*),older(26352)),and_v(v:and_v(v:pk([aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/<0;1>/*),pk([aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/<0;1>/*)),pk([aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/<0;1>/*))})#d06ehu7c");
 
         // We prevent footguns with timelocks by requiring a u16. Note how the following wouldn't
         // compile:

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -249,9 +249,9 @@ impl HotSigner {
             .as_ref()
             .ok_or(SignerError::IncompletePsbt)?
             .value;
-        let sig_type = sighash::EcdsaSighashType::All;
+        let sighash_type = sighash::EcdsaSighashType::All;
         let sighash = sighash_cache
-            .p2wsh_signature_hash(input_index, witscript, value, sig_type)
+            .p2wsh_signature_hash(input_index, witscript, value, sighash_type)
             .map_err(|_| SignerError::InsanePsbt)?;
         let sighash = secp256k1::Message::from_digest_slice(sighash.as_byte_array())
             .expect("Sighash is always 32 bytes.");
@@ -266,12 +266,12 @@ impl HotSigner {
             if pubkey.inner != *curr_pubkey {
                 return Err(SignerError::InsanePsbt);
             }
-            let sig = secp.sign_ecdsa_low_r(&sighash, &privkey.inner);
+            let signature = secp.sign_ecdsa_low_r(&sighash, &privkey.inner);
             psbt_in.partial_sigs.insert(
                 pubkey,
                 ecdsa::Signature {
-                    sig,
-                    hash_ty: sig_type,
+                    signature,
+                    sighash_type,
                 },
             );
         }
@@ -289,7 +289,7 @@ impl HotSigner {
         psbt_in: &mut PsbtIn,
         input_index: usize,
     ) -> Result<(), SignerError> {
-        let sig_type = sighash::TapSighashType::Default;
+        let sighash_type = sighash::TapSighashType::Default;
         let prevouts = sighash::Prevouts::All(prevouts);
 
         // If the details of the internal key are filled, provide a keypath signature.
@@ -305,14 +305,14 @@ impl HotSigner {
                     }
                     let keypair = keypair.tap_tweak(secp, psbt_in.tap_merkle_root).to_inner();
                     let sighash = sighash_cache
-                        .taproot_key_spend_signature_hash(input_index, &prevouts, sig_type)
+                        .taproot_key_spend_signature_hash(input_index, &prevouts, sighash_type)
                         .map_err(|_| SignerError::InsanePsbt)?;
                     let sighash = secp256k1::Message::from_digest_slice(sighash.as_byte_array())
                         .expect("Sighash is always 32 bytes.");
-                    let sig = secp.sign_schnorr_no_aux_rand(&sighash, &keypair);
+                    let signature = secp.sign_schnorr_no_aux_rand(&sighash, &keypair);
                     let sig = bitcoin::taproot::Signature {
-                        sig,
-                        hash_ty: sig_type,
+                        signature,
+                        sighash_type,
                     };
                     psbt_in.tap_key_sig = Some(sig);
                 }
@@ -334,15 +334,15 @@ impl HotSigner {
                         input_index,
                         &prevouts,
                         *leaf_hash,
-                        sig_type,
+                        sighash_type,
                     )
                     .map_err(|_| SignerError::InsanePsbt)?;
                 let sighash = secp256k1::Message::from_digest_slice(sighash.as_byte_array())
                     .expect("Sighash is always 32 bytes.");
-                let sig = secp.sign_schnorr_no_aux_rand(&sighash, &keypair);
+                let signature = secp.sign_schnorr_no_aux_rand(&sighash, &keypair);
                 let sig = bitcoin::taproot::Signature {
-                    sig,
-                    hash_ty: sig_type,
+                    signature,
+                    sighash_type,
                 };
                 psbt_in.tap_script_sigs.insert((*pubkey, *leaf_hash), sig);
             }
@@ -400,7 +400,7 @@ impl HotSigner {
     /// BIP32 encoding of those keys (xpubs, tpubs, ..) but does not affect any data (whether it is
     /// the keys or the mnemonics).
     pub fn set_network(&mut self, network: bitcoin::Network) {
-        self.master_xpriv.network = network;
+        self.master_xpriv.network = network.into();
     }
 }
 
@@ -565,7 +565,7 @@ mod tests {
                         "bc1qvklensptw5lk7d470ds60pcpsr0psdpgyvwepv",
                     )
                     .unwrap()
-                    .payload()
+                    .assume_checked()
                     .script_pubkey(),
                 }],
             },
@@ -825,7 +825,7 @@ mod tests {
                         "bc1qvklensptw5lk7d470ds60pcpsr0psdpgyvwepv",
                     )
                     .unwrap()
-                    .payload()
+                    .assume_checked()
                     .script_pubkey(),
                 }],
             },

--- a/src/spend.rs
+++ b/src/spend.rs
@@ -157,7 +157,7 @@ fn sanity_check_psbt(
 
     // Check for dust outputs
     for txo in psbt.unsigned_tx.output.iter() {
-        if txo.value < txo.script_pubkey.dust_value() {
+        if txo.value < txo.script_pubkey.minimal_non_dust() {
             return Err(SpendCreationError::SanityCheckFailure(psbt.clone()));
         }
     }

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -355,7 +355,7 @@ impl DatabaseConnection for DummyDatabase {
     }
 
     fn store_spend(&mut self, psbt: &Psbt) {
-        let txid = psbt.unsigned_tx.txid();
+        let txid = psbt.unsigned_tx.compute_txid();
         self.db
             .write()
             .unwrap()
@@ -446,7 +446,11 @@ impl DatabaseConnection for DummyDatabase {
 
     fn new_txs(&mut self, txs: &[bitcoin::Transaction]) {
         for tx in txs {
-            self.db.write().unwrap().txs.insert(tx.txid(), tx.clone());
+            self.db
+                .write()
+                .unwrap()
+                .txs
+                .insert(tx.compute_txid(), tx.clone());
         }
     }
 


### PR DESCRIPTION
I need to go over the changes again, and this introduces a massive performance hit. From quick profiling i think it's from upstream changes in the miniscript policy compiler. 

Running `cargo test descriptors` before:
```
real    0m5.166s
user    0m10.630s
sys     0m0.075s
```
After:
```
real    4m16.438s
user    7m14.968s
sys     0m0.099s
```

Fixes #1224.