### PR TITLE
Simplify UI of Welcome screen

### DIFF
--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -74,45 +74,43 @@ pub fn welcome<'a>() -> Element<'a, Message> {
                                 .spacing(20)
                                 .push(
                                     Container::new(
-                                        Column::new()
-                                            .spacing(20)
-                                            .align_items(Alignment::Center)
-                                            .push(
-                                                image::create_new_wallet_icon()
-                                                    .width(Length::Fixed(100.0)),
-                                            )
-                                            .push(
-                                                p1_regular("Create a new wallet")
-                                                    .style(color::GREY_3),
-                                            )
-                                            .push(
-                                                button::secondary(None, "Select")
-                                                    .width(Length::Fixed(200.0))
-                                                    .on_press(Message::CreateWallet),
-                                            )
-                                            .align_items(Alignment::Center),
+                                        Button::new(
+                                            Column::new()
+                                                .spacing(20)
+                                                .align_items(Alignment::Center)
+                                                .push(
+                                                    image::create_new_wallet_icon()
+                                                        .width(Length::Fixed(100.0)),
+                                                )
+                                                .push(
+                                                    p1_regular("Create a new wallet")
+                                                        .style(color::GREY_3),
+                                                )
+                                                .align_items(Alignment::Center),
+                                        )
+                                        .padding(20)
+                                        .on_press(Message::CreateWallet)
                                     )
                                     .padding(20),
                                 )
                                 .push(
                                     Container::new(
-                                        Column::new()
-                                            .spacing(20)
-                                            .align_items(Alignment::Center)
-                                            .push(
-                                                image::restore_wallet_icon()
-                                                    .width(Length::Fixed(100.0)),
-                                            )
-                                            .push(
-                                                p1_regular("Add an existing wallet")
-                                                    .style(color::GREY_3),
-                                            )
-                                            .push(
-                                                button::secondary(None, "Select")
-                                                    .width(Length::Fixed(200.0))
-                                                    .on_press(Message::ImportWallet),
-                                            )
-                                            .align_items(Alignment::Center),
+                                        Button::new(
+                                            Column::new()
+                                                .spacing(20)
+                                                .align_items(Alignment::Center)
+                                                .push(
+                                                    image::restore_wallet_icon()
+                                                        .width(Length::Fixed(100.0)),
+                                                )
+                                                .push(
+                                                    p1_regular("Add an existing wallet")
+                                                        .style(color::GREY_3),
+                                                )
+                                                .align_items(Alignment::Center),
+                                        )
+                                        .padding(20)
+                                        .on_press(Message::ImportWallet)
                                     )
                                     .padding(20),
                                 ),

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -89,7 +89,7 @@ pub fn welcome<'a>() -> Element<'a, Message> {
                                                 .align_items(Alignment::Center),
                                         )
                                         .padding(20)
-                                        .on_press(Message::CreateWallet)
+                                        .on_press(Message::CreateWallet),
                                     )
                                     .padding(20),
                                 )
@@ -110,7 +110,7 @@ pub fn welcome<'a>() -> Element<'a, Message> {
                                                 .align_items(Alignment::Center),
                                         )
                                         .padding(20)
-                                        .on_press(Message::ImportWallet)
+                                        .on_press(Message::ImportWallet),
                                     )
                                     .padding(20),
                                 ),


### PR DESCRIPTION
In the welcome screen, Liana has this:

![image](https://github.com/user-attachments/assets/120aff20-0563-43ff-94ca-9dc8349213b7)

Each option has a text that implies an action, and then a button with the action text "Select". The UI can be changed and simplified so it only reflects the two actions that can be chosen. The end result would be this one:

![image](https://github.com/user-attachments/assets/7b292944-fec9-4d12-8eb6-22a647ef294c)

And when putting the mouse over the button:

![image](https://github.com/user-attachments/assets/4283cce6-6605-491a-a325-590e4717df53)
