### PR TITLE
fix wrong datadir in app cache using remote backend

### DIFF
--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -480,7 +480,7 @@ pub fn create_app_with_remote_backend(
             network: bitcoin::Network::Signet,
             coins: Vec::new(),
             rescan_progress: None,
-            datadir_path: default_datadir().unwrap(),
+            datadir_path: datadir.clone(),
             blockheight: wallet.tip_height.unwrap_or(0),
         },
         Arc::new(


### PR DESCRIPTION
Detected after Manuel failed to have in cache the correct the refresh token. It was not correctly stored after 1h in the settings file because of the wrong datadir.