### PR TITLE
Use different msg for reloading or extending history tx list

### DIFF
--- a/gui/src/app/message.rs
+++ b/gui/src/app/message.rs
@@ -39,6 +39,7 @@ pub enum Message {
     Verified(Fingerprint, Result<(), Error>),
     StartRescan(Result<(), Error>),
     HardwareWallets(HardwareWalletMessage),
+    HistoryTransactionsExtension(Result<Vec<HistoryTransaction>, Error>),
     HistoryTransactions(Result<Vec<HistoryTransaction>, Error>),
     PendingTransactions(Result<Vec<HistoryTransaction>, Error>),
     LabelsUpdated(Result<HashMap<String, Option<String>>, Error>),

--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -183,6 +183,13 @@ impl State for Home {
                 Err(e) => self.warning = Some(e),
                 Ok(events) => {
                     self.warning = None;
+                    self.events = events;
+                }
+            },
+            Message::HistoryTransactionsExtension(res) => match res {
+                Err(e) => self.warning = Some(e),
+                Ok(events) => {
+                    self.warning = None;
                     for event in events {
                         if !self.events.iter().any(|other| other.tx == event.tx) {
                             self.events.push(event);
@@ -259,7 +266,7 @@ impl State for Home {
                             }
                             Ok(events)
                         },
-                        Message::HistoryTransactions,
+                        Message::HistoryTransactionsExtension,
                     );
                 }
             }


### PR DESCRIPTION
After reorg last payments were not removed as the reloading message was handle as an extension of the list.

close #1260