### PR TITLE
gui: filter out logs for `cosmic_text`

### DIFF
--- a/gui/src/logger.rs
+++ b/gui/src/logger.rs
@@ -67,6 +67,7 @@ impl Logger {
                             && !metadata.target().starts_with("winit")
                             && !metadata.target().starts_with("mio")
                             && !metadata.target().starts_with("ledger_transport_hid")
+                            && !metadata.target().starts_with("cosmic_text")
                     })),
             )
             .init();


### PR DESCRIPTION
Logs are litterally flooded by `cosmic_text` logs at DEBUG level, this PR filter out this target