### PR TITLE
Fix RemoteBackend::Undefined panic because of skipped step

### DIFF
--- a/gui/src/installer/mod.rs
+++ b/gui/src/installer/mod.rs
@@ -102,9 +102,14 @@ impl Installer {
         let context = Context::new(
             network,
             destination_path.clone(),
-            remote_backend
-                .map(RemoteBackend::WithoutWallet)
-                .unwrap_or(RemoteBackend::Undefined),
+            remote_backend.map(RemoteBackend::WithoutWallet).unwrap_or(
+                if matches!(network, Network::Bitcoin | Network::Signet) {
+                    RemoteBackend::Undefined
+                } else {
+                    // The step for choosing the backend will be skipped.
+                    RemoteBackend::None
+                },
+            ),
         );
         let mut installer = Installer {
             network,


### PR DESCRIPTION
Because Testnet and regtest do not ask user the choice of backend the install panic as the RemoteBackend enum stays to undefined

close #1264