### PR TITLE
installer: Go directly to next step once login

### DIFF
--- a/gui/src/installer/step/backend.rs
+++ b/gui/src/installer/step/backend.rs
@@ -252,6 +252,7 @@ impl Step for RemoteBackendLogin {
                                 email: email.clone(),
                                 remote_backend,
                             };
+                            return Command::perform(async move {}, |_| Message::Next);
                         }
                         Err(e) => {
                             if let Error::Auth(AuthError { http_status, .. }) = e {


### PR DESCRIPTION
Once the user is connected we redirect him to
the next step in the install process, but
we keep the Connected state in case the user
want to edit email after clicking on Previous

As discussed in #1240