### PR TITLE
gui(intsaller): ping electrum backend both with tcp & ssl

### DIFF
--- a/contrib/loop_test.sh
+++ b/contrib/loop_test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+iteration=0
+
+while true; do
+    iteration=$((iteration+1))
+
+    pytest -vvvv --log-cli-level=DEBUG $1
+
+    if [ $? -ne 0 ]; then
+        echo "Test failed on iteration $iteration!"
+        break
+    fi
+done

--- a/gui/src/installer/message.rs
+++ b/gui/src/installer/message.rs
@@ -87,8 +87,25 @@ pub enum DefineNode {
     NodeTypeSelected(NodeType),
     DefineBitcoind(DefineBitcoind),
     DefineElectrum(DefineElectrum),
-    PingResult((NodeType, Result<(), Error>)),
+    PingResult((PingType, Result<(), Error>)),
     Ping,
+}
+
+#[derive(Debug, Clone)]
+pub enum PingType {
+    Bitcoind,
+    ElectrumTcp,
+    ElectrumSsl,
+}
+
+impl PingType {
+    pub fn node_type(&self) -> NodeType {
+        match &self {
+            PingType::Bitcoind => NodeType::Bitcoind,
+            PingType::ElectrumTcp => NodeType::Electrum,
+            PingType::ElectrumSsl => NodeType::Electrum,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/gui/src/installer/step/node/electrum.rs
+++ b/gui/src/installer/step/node/electrum.rs
@@ -69,8 +69,8 @@ impl DefineElectrum {
         false
     }
 
-    pub fn view(&self) -> Element<Message> {
-        view::define_electrum(&self.address)
+    pub fn view(&self, is_running: bool) -> Element<Message> {
+        view::define_electrum(&self.address, is_running)
     }
 
     pub fn ping(&self) -> Result<(), Error> {
@@ -82,5 +82,27 @@ impl DefineElectrum {
             .raw_call("server.ping", [])
             .map_err(|e| Error::Electrum(e.to_string()))?;
         Ok(())
+    }
+
+    pub fn is_ssl(&self) -> bool {
+        self.address.value.starts_with("ssl://")
+    }
+
+    pub fn force_ssl(mut self) -> Self {
+        if self.address.value.starts_with("tcp://") {
+            self.address.value = self.address.value.replacen("tcp://", "ssl://", 1);
+        } else if !self.address.value.starts_with("ssl://") {
+            self.address.value = format!("ssl://{}", self.address.value);
+        }
+        self
+    }
+
+    pub fn force_tcp(mut self) -> Self {
+        if self.address.value.starts_with("ssl://") {
+            self.address.value = self.address.value.replacen("ssl://", "tcp://", 1);
+        } else if !self.address.value.starts_with("tcp://") {
+            self.address.value = format!("tcp://{}", self.address.value);
+        }
+        self
     }
 }

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -1370,7 +1370,10 @@ pub fn define_bitcoind<'a>(
         .into()
 }
 
-pub fn define_electrum<'a>(address: &form::Value<String>) -> Element<'a, Message> {
+pub fn define_electrum<'a>(
+    address: &form::Value<String>,
+    is_running: bool,
+) -> Element<'a, Message> {
     let col_address = Column::new()
         .push(text("Address:").bold())
         .push(
@@ -1385,6 +1388,16 @@ pub fn define_electrum<'a>(address: &form::Value<String>) -> Element<'a, Message
             )
             .size(text::P1_SIZE)
             .padding(10),
+        )
+        .push_maybe(
+            if is_running && address.valid && !address.value.starts_with("ssl://") {
+                Some(
+                    text::caption("Warning, you're going to use a non SSL connection!")
+                        .style(color::ORANGE),
+                )
+            } else {
+                None
+            },
         )
         .spacing(10);
 

--- a/loop_test.sh
+++ b/loop_test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+iteration=0
+
+while true; do
+    iteration=$((iteration+1))
+
+    pytest -vvvv --log-cli-level=DEBUG $1
+
+    if [ $? -ne 0 ]; then
+        echo "Test failed on iteration $iteration!"
+        break
+    fi
+done


### PR DESCRIPTION
This PR add a double ping (both tcp & ssl) when defining an electrum server address.
After ping if the prefix is not ssl we display a warning to the user:
![image](https://github.com/user-attachments/assets/8d75dced-8ddb-471c-b5ce-01d607093b29)
