### PR TITLE
electrum: common ancestor is before first changed block

### DIFF
--- a/src/bitcoin/electrum/mod.rs
+++ b/src/bitcoin/electrum/mod.rs
@@ -212,7 +212,12 @@ impl Electrum {
                         None
                     } else {
                         log::info!("Block chain reorganization detected.");
-                        Some(self.bdk_wallet.find_block_at_or_before_height(height))
+                        // We can assume height is positive as genesis block will not have changed.
+                        Some(
+                            self.bdk_wallet
+                                .find_block_before_height(height)
+                                .expect("height of first change is greater than 0"),
+                        )
                     };
                 }
                 Some((_, None)) => continue,

--- a/src/bitcoin/electrum/wallet.rs
+++ b/src/bitcoin/electrum/wallet.rs
@@ -295,17 +295,20 @@ impl BdkWallet {
         })
     }
 
-    /// Find the first block in the local chain whose height is less than or equal to this.
-    pub fn find_block_at_or_before_height(&self, height: u32) -> BlockChainTip {
+    /// Find the highest block in the local chain whose height is below `height`.
+    ///
+    /// As the local chain will always contain the genesis block, this returns
+    /// `None` only if `height` is 0.
+    pub fn find_block_before_height(&self, height: u32) -> Option<BlockChainTip> {
         for cp in self.local_chain.iter_checkpoints() {
-            if cp.height() <= height {
-                return BlockChainTip {
+            if cp.height() < height {
+                return Some(BlockChainTip {
                     height: height_i32_from_u32(cp.height()),
                     hash: cp.hash(),
-                };
+                });
             }
         }
-        unreachable!("There must be at least the genesis block.")
+        None
     }
 
     /// Apply an update to the local chain.


### PR DESCRIPTION
The common ancestor is the highest block that is strictly lower than the first change.

When finding the point of change, we can take the first height with any change (including an invalidated block) rather than the first height with a new block, which avoids a loop. The height found in both cases (loop vs no loop) should be almost always the same as we apply the update to our local chain before finding the common ancestor, but perhaps in a test if there's a reorg down to 0 and the chain update only contains invalidated blocks and no new blocks, then checking for the first invalidated block would be better as there would be no new blocks to find and the reorg would be undetected.