### PR TITLE
Reset hws watch list each step of the installer

### DIFF
--- a/gui/src/hw.rs
+++ b/gui/src/hw.rs
@@ -198,6 +198,10 @@ impl HardwareWallets {
         self.aliases.insert(fg, new_alias);
     }
 
+    pub fn reset_watch_list(&mut self) {
+        self.list = Vec::new();
+    }
+
     pub fn load_aliases(&mut self, aliases: HashMap<Fingerprint, String>) {
         self.aliases = aliases;
     }

--- a/gui/src/installer/mod.rs
+++ b/gui/src/installer/mod.rs
@@ -66,6 +66,7 @@ pub struct Installer {
 
 impl Installer {
     fn previous(&mut self) -> Command<Message> {
+        self.hws.reset_watch_list();
         let network = self.network;
         if self.current > 0 {
             self.current -= 1;
@@ -196,6 +197,7 @@ impl Installer {
     }
 
     fn next(&mut self) -> Command<Message> {
+        self.hws.reset_watch_list();
         let current_step = self
             .steps
             .get_mut(self.current)


### PR DESCRIPTION
Because of flaky connection, we drop the connection list to reconstruct it at each step of the installer

close #1307