### PR TITLE
build: add Makefile for Rust noobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+all:
+	cargo build

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
-all:
+configure:
+	@which cargo > /dev/null || (echo "Please install Rust 1.70 (or newer) toolchain; e.g. with 'apt install cargo', or using rustup" && exit 1)
+
+all: configure
 	cargo build

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,1 @@
+cargo build


### PR DESCRIPTION
With this minimal wrappers, one could just download&install Rust and after that just type 'make', no need to be knowledgeable about how to build things in Rust ecosystem.