### PR TITLE
gui(settings): fix daemon reload handling for electrum

### DIFF
--- a/gui/src/app/state/settings/bitcoind.rs
+++ b/gui/src/app/state/settings/bitcoind.rs
@@ -129,6 +129,9 @@ impl State for BitcoindSettingsState {
                     if let Some(settings) = &mut self.node_settings {
                         settings.edited(false);
                     }
+                    if let Some(settings) = &mut self.electrum_settings {
+                        settings.edited(false);
+                    }
                 }
             },
             Message::Info(res) => match res {


### PR DESCRIPTION
In case of error reloading daemon for Electrum, set edited to false (same handling as for bitcoind).