### PR TITLE
Deserialize error from create_spend http response

### DIFF
--- a/gui/src/lianalite/client/backend/api.rs
+++ b/gui/src/lianalite/client/backend/api.rs
@@ -284,11 +284,17 @@ pub struct Psbt {
 pub enum DraftPsbtResult {
     Success(DraftPsbt),
     InsufficientFunds(InsufficientFundsInfo),
+    Error(DraftPsbtError),
 }
 
 #[derive(Clone, Deserialize)]
 pub struct InsufficientFundsInfo {
     pub missing: u64,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct DraftPsbtError {
+    pub error: String,
 }
 
 #[derive(Clone, Deserialize)]

--- a/gui/src/lianalite/client/backend/mod.rs
+++ b/gui/src/lianalite/client/backend/mod.rs
@@ -753,6 +753,9 @@ impl Daemon for BackendWalletClient {
             api::DraftPsbtResult::InsufficientFunds(api::InsufficientFundsInfo { missing }) => {
                 Ok(CreateSpendResult::InsufficientFunds { missing })
             }
+            api::DraftPsbtResult::Error(api::DraftPsbtError { error }) => {
+                Err(DaemonError::Unexpected(error))
+            }
         }
     }
 
@@ -789,6 +792,9 @@ impl Daemon for BackendWalletClient {
             }),
             api::DraftPsbtResult::InsufficientFunds(api::InsufficientFundsInfo { missing }) => {
                 Ok(CreateSpendResult::InsufficientFunds { missing })
+            }
+            api::DraftPsbtResult::Error(api::DraftPsbtError { error }) => {
+                Err(DaemonError::Unexpected(error))
             }
         }
     }


### PR DESCRIPTION
Instead of having an unclear and ugly message like:
data did not match any variant of untagged enum DraftPsbtResult