### PR TITLE
poller: query deposit tx for all coins, including expired

### DIFF
--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -169,14 +169,10 @@ fn add_txs_to_db(
 ) {
     let curr_txids: HashSet<_> = db_conn.list_saved_txids().into_iter().collect();
     let mut new_txids = HashSet::new();
-    // First get all newly received coins that have not expired.
-    new_txids.extend(updated_coins.received.iter().filter_map(|c| {
-        if !updated_coins.expired.contains(&c.outpoint) {
-            Some(c.outpoint.txid)
-        } else {
-            None
-        }
-    }));
+    // Get the transaction for all newly received coins. Note we also query it if the coins
+    // expired, as it's possible for coin to not be in DB already (and therefore not have its
+    // deposit transaction stored there), to be marked as expired *and* newly received. In this
+    new_txids.extend(updated_coins.received.iter().map(|c| c.outpoint.txid));
 
     // Add spend txid for new & existing coins.
     new_txids.extend(updated_coins.spending.iter().map(|(_, txid)| txid));


### PR DESCRIPTION
This fixes a crash whereby we missed the deposit transaction of a received coin because it was also part of the expired coins list.

See the following logs.

```
[8:33 AM](https://mm.revault.dev/revault/pl/a9mazcncaff3fc88yq8oqpipgo)
root@cirrus-ci-task-4780461782728704:/tmp/cirrus-ci-build# tail -n100 /tmp/lianad-tests-o3guj0vh/test_rescan_edge_cases_1/
lianad/log 
b'[1726295509][liana][INFO][thread main] Watchonly wallet created.'
b'[1726295509][liana][INFO][thread main] Loading our watchonly wallet on bitcoind.'
b'[1726295509][liana][INFO][thread main] Watchonly wallet loaded on bitcoind and sanity checked.'
b'[1726295510][liana::database::sqlite][INFO][thread main] Created a fresh database at /tmp/lianad-tests-o3guj0vh/test_rescan_edge_cases_1/lianad/regtest/lianad.sqlite3.'
b'[1726295510][liana::database::sqlite][INFO][thread main] Checking if the database needs upgrading.'
b'[1726295510][liana][INFO][thread main] Database initialized and checked.'
b'[1726295510][liana][INFO][thread Bitcoin Network poller] Bitcoin poller started.'
b'[1726295510][liana::jsonrpc::server][DEBUG][thread Bitcoin Network poller] Binding socket at /tmp/lianad-tests-o3guj0vh/test_rescan_edge_cases_1/lianad/regtest/lianad_rpc'
b'[1726295510][liana][INFO][thread Bitcoin Network poller] JSONRPC server started.'
b'[1726295510][liana::bitcoin::poller][INFO][thread Bitcoin Network poller] Block chain synchronization progress: 100.00% (129 blocks / 129 headers)'
b'[1726295510][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Current coins: {}'
b'[1726295510][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly received coins: []'
b'[1726295510][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly confirmed coins: []'
b'[1726295510][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Expired coins: []'
b'[1726295510][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly spending coins: []'
b'[1726295510][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly spent coins: []'
b'[1726295510][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Missing txids: []'
b"[1726295510][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] New tip: '(129,56fa7e0cc43c7767f68cc230df045a58a2c7cbd8e50d5ed900f39260d6e551fa)'"
b'[1726295510][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Updates done.'
b'[1726295510][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Checking the state of an ongoing rescan if there is any'
b'[1726295510][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] No ongoing rescan.'
b'[1726295511][liana::bitcoin::poller::looper][INFO][thread Bitcoin Network poller] Block chain reorganization detected. Looking for common ancestor.'
b"[1726295511][liana::bitcoin::poller::looper][INFO][thread Bitcoin Network poller] Common ancestor found: '(117,63a3207b98d2f832f9a213c8135243b5d8f7228778aeae4aa23ca6e565bf5b1e)'. Starting rescan from there. Old tip was '(129,56fa7e0cc43c7767f68cc230df045a58a2c7cbd8e50d5ed900f39260d6e551fa)'."
b"[1726295511][liana::bitcoin::poller::looper][INFO][thread Bitcoin Network poller] Tip was rolled back to '(117,63a3207b98d2f832f9a213c8135243b5d8f7228778aeae4aa23ca6e565bf5b1e)'."
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Current coins: {}'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly received coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly confirmed coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Expired coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly spending coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly spent coins: []'
b'[1726295511][liana::bitcoin::poller::looper][INFO][thread Bitcoin Network poller] Chain tip changed while we were updating our state. Starting over.'
b'[1726295511][liana::bitcoin::poller::looper][INFO][thread Bitcoin Network poller] Block chain reorganization detected. Looking for common ancestor.'
b"[1726295511][liana::bitcoin::poller::looper][INFO][thread Bitcoin Network poller] Common ancestor found: '(106,7b2a449b8287d0e29054073110c47164edfc2ab842c43415705e53722acb1e24)'. Starting rescan from there. Old tip was '(117,63a3207b98d2f832f9a213c8135243b5d8f7228778aeae4aa23ca6e565bf5b1e)'."
b"[1726295511][liana::bitcoin::poller::looper][INFO][thread Bitcoin Network poller] Tip was rolled back to '(106,7b2a449b8287d0e29054073110c47164edfc2ab842c43415705e53722acb1e24)'."
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Current coins: {}'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly received coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly confirmed coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Expired coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly spending coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly spent coins: []'
b'[1726295511][liana::bitcoin::poller::looper][INFO][thread Bitcoin Network poller] Chain tip changed while we were updating our state. Starting over.'
b'[1726295511][liana::bitcoin::poller::looper][INFO][thread Bitcoin Network poller] Block chain reorganization detected. Looking for common ancestor.'
b"[1726295511][liana::bitcoin::poller::looper][INFO][thread Bitcoin Network poller] Common ancestor found: '(101,7ad2fc79a78611d1d088ce6638c8324ba496bbd2e26a1d90a2be693b5d613f05)'. Starting rescan from there. Old tip was '(106,7b2a449b8287d0e29054073110c47164edfc2ab842c43415705e53722acb1e24)'."
b"[1726295511][liana::bitcoin::poller::looper][INFO][thread Bitcoin Network poller] Tip was rolled back to '(101,7ad2fc79a78611d1d088ce6638c8324ba496bbd2e26a1d90a2be693b5d613f05)'."
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Current coins: {}'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly received coins: [Coin { outpoint: OutPoint { txid: 0x414ca732f0e59acef1ce6f63bdb6514dd8e0a8519671f38bb59c1b7353f6c00a, vout: 0 }, is_immature: false, block_info: None, amount: Amount(0.35600000 BTC), derivation_index: Normal { index: 2 }, is_change: false, spend_txid: None, spend_block: None }, Coin { outpoint: OutPoint { txid: 0x154afc0fd2190d65f0b5ffd466608c24bd55135666c142ae36b5a2648e0bf44e, vout: 0 }, is_immature: false, block_info: None, amount: Amount(0.35600000 BTC), derivation_index: Normal { index: 1 }, is_change: false, spend_txid: None, spend_block: None }, Coin { outpoint: OutPoint { txid: 0xaf4ef0538cdd46661de66c0175e0d053fbf82d56ff32b04c8699a56ef7f4a2f0, vout: 1 }, is_immature: false, block_info: None, amount: Amount(0.35600000 BTC), derivation_index: Normal { index: 0 }, is_change: false, spend_txid: None, spend_block: None }]'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly confirmed coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Expired coins: [OutPoint { txid: 0x414ca732f0e59acef1ce6f63bdb6514dd8e0a8519671f38bb59c1b7353f6c00a, vout: 0 }, OutPoint { txid: 0x154afc0fd2190d65f0b5ffd466608c24bd55135666c142ae36b5a2648e0bf44e, vout: 0 }]'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly spending coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly spent coins: []'
b'[1726295511][liana::bitcoin::poller::looper][INFO][thread Bitcoin Network poller] Chain tip changed while we were updating our state. Starting over.'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Current coins: {}'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly received coins: [Coin { outpoint: OutPoint { txid: 0x414ca732f0e59acef1ce6f63bdb6514dd8e0a8519671f38bb59c1b7353f6c00a, vout: 0 }, is_immature: false, block_info: None, amount: Amount(0.35600000 BTC), derivation_index: Normal { index: 2 }, is_change: false, spend_txid: None, spend_block: None }, Coin { outpoint: OutPoint { txid: 0x154afc0fd2190d65f0b5ffd466608c24bd55135666c142ae36b5a2648e0bf44e, vout: 0 }, is_immature: false, block_info: None, amount: Amount(0.35600000 BTC), derivation_index: Normal { index: 1 }, is_change: false, spend_txid: None, spend_block: None }, Coin { outpoint: OutPoint { txid: 0xaf4ef0538cdd46661de66c0175e0d053fbf82d56ff32b04c8699a56ef7f4a2f0, vout: 1 }, is_immature: false, block_info: None, amount: Amount(0.35600000 BTC), derivation_index: Normal { index: 0 }, is_change: false, spend_txid: None, spend_block: None }]'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly confirmed coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Expired coins: [OutPoint { txid: 0x414ca732f0e59acef1ce6f63bdb6514dd8e0a8519671f38bb59c1b7353f6c00a, vout: 0 }]'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly spending coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Newly spent coins: []'
b'[1726295511][liana::bitcoin::poller::looper][DEBUG][thread Bitcoin Network poller] Missing txids: [0xaf4ef0538cdd46661de66c0175e0d053fbf82d56ff32b04c8699a56ef7f4a2f0, 0x154afc0fd2190d65f0b5ffd466608c24bd55135666c142ae36b5a2648e0bf44e]'
b'[1726295511][liana][ERROR][thread Bitcoin Network poller] panic occurred at line 465 of file src/database/sqlite/mod.rs: Some("Database must be available: SqliteFailure(Error { code: ConstraintViolation, extended_code: 787 }, Some(\\"FOREIGN KEY constraint failed\\"))")'
b'   0: liana::setup_panic_hook::{{closure}}'
b'   1: std::panicking::rust_panic_with_hook'
b'   2: std::panicking::begin_panic_handler::{{closure}}'
b'   3: std::sys::backtrace::__rust_end_short_backtrace'
b'   4: rust_begin_unwind'
b'   5: core::panicking::panic_fmt'
b'   6: core::result::unwrap_failed'
b'   7: <liana::database::sqlite::SqliteConn as liana::database::DatabaseConnection>::new_unspent_coins'
b'   8: liana::bitcoin::poller::looper::updates'
b'   9: liana::bitcoin::poller::looper::updates'
b'  10: liana::bitcoin::poller::looper::updates'
b'  11: liana::bitcoin::poller::looper::updates'
b'  12: liana::bitcoin::poller::looper::updates'
b'  13: liana::bitcoin::poller::looper::updates'
b'  14: liana::bitcoin::poller::looper::updates'
b'  15: liana::bitcoin::poller::looper::poll'
b'  16: liana::bitcoin::poller::Poller::poll_forever'
b'  17: std::sys::backtrace::__rust_begin_short_backtrace'
b'  18: core::ops::function::FnOnce::call_once{{vtable.shim}}'
b'  19: std::sys::pal::unix::thread::Thread::new::thread_start'
b'  20: <unknown>'
b'  21: <unknown>'
b''
```

This should fix the flaky chain functional tests in ci.