### PR TITLE
gui: add help text for electrum address

### DIFF
--- a/gui/src/app/view/settings.rs
+++ b/gui/src/app/view/settings.rs
@@ -30,7 +30,10 @@ use crate::{
         view::{hw, warning::warn},
     },
     hw::HardwareWallet,
-    node::bitcoind::{RpcAuthType, RpcAuthValues},
+    node::{
+        bitcoind::{RpcAuthType, RpcAuthValues},
+        electrum,
+    },
 };
 
 pub fn list(cache: &Cache, is_remote_backend: bool) -> Element<Message> {
@@ -591,6 +594,7 @@ pub fn electrum_edit<'a>(
                 .size(P1_SIZE)
                 .padding(5),
             )
+            .push(text(electrum::ADDRESS_NOTES).size(P2_SIZE))
             .spacing(5),
     );
 

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -1382,6 +1382,7 @@ pub fn define_electrum<'a>(address: &form::Value<String>) -> Element<'a, Message
             .size(text::P1_SIZE)
             .padding(10),
         )
+        .push(text(electrum::ADDRESS_NOTES).size(text::P2_SIZE))
         .spacing(10);
 
     Column::new().push(col_address).spacing(50).into()

--- a/gui/src/node/electrum.rs
+++ b/gui/src/node/electrum.rs
@@ -5,6 +5,10 @@ pub enum ConfigField {
     Address,
 }
 
+pub const ADDRESS_NOTES: &str = "Note: include \"ssl://\" as a prefix \
+    for SSL connections. Be aware that self-signed \
+    SSL certificates are currently not supported.";
+
 impl fmt::Display for ConfigField {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {


### PR DESCRIPTION
This adds a short text explanation about SSL usage in Electrum addresses to both the installer and settings page.

This is a modified version of #1342.