### PR TITLE
Add compression algo flag to dpkg command for arch build

### DIFF
--- a/contrib/release/release.sh
+++ b/contrib/release/release.sh
@@ -47,7 +47,7 @@ TARGET_DIR="$BUILD_DIR" ./contrib/reproducible/docker/docker-build.sh
     cp "$BUILD_DIR/release/lianad" "$BUILD_DIR/release/liana-cli" "$BUILD_DIR/gui/release/liana-gui" ../README.md ./package/usr/bin/
     DIRNAME="liana_$VERSION-1_amd64"
     mv ./package "$DIRNAME"
-    dpkg-deb --build "$DIRNAME"
+    dpkg-deb -Zxz --build "$DIRNAME"
     mv "$DIRNAME.deb" "$RELEASE_DIR"
 )
 


### PR DESCRIPTION
Arch package failed to be extracted during pacman update because of the default zstd algo