### PR TITLE
Get timestamp of last completed poll of the blockchain

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -53,15 +53,16 @@ This command does not take any parameter for now.
 
 #### Response
 
-| Field                | Type          | Description                                                                                  |
-| -------------------- | ------------- | -------------------------------------------------------------------------------------------- |
-| `version`            | string        | Version following the [SimVer](http://www.simver.org/) format                                |
-| `network`            | string        | Answer can be `mainnet`, `testnet`, `regtest`                                                |
-| `block_height`       | integer       | The block height we are synced at.                                                           |
-| `sync`               | float         | The synchronization progress as percentage (`0 < sync < 1`)                                  |
-| `descriptors`        | object        | Object with the name of the descriptor as key and the descriptor string as value             |
-| `rescan_progress`    | float or null | Progress of an ongoing rescan as a percentage (between 0 and 1) if there is any              |
-| `timestamp`          | integer       | Unix timestamp of wallet creation date                                                       |
+| Field                | Type            | Description                                                                                  |
+| -------------------- | --------------- | -------------------------------------------------------------------------------------------- |
+| `version`            | string          | Version following the [SimVer](http://www.simver.org/) format                                |
+| `network`            | string          | Answer can be `mainnet`, `testnet`, `regtest`                                                |
+| `block_height`       | integer         | The block height we are synced at.                                                           |
+| `sync`               | float           | The synchronization progress as percentage (`0 < sync < 1`)                                  |
+| `descriptors`        | object          | Object with the name of the descriptor as key and the descriptor string as value             |
+| `rescan_progress`    | float or null   | Progress of an ongoing rescan as a percentage (between 0 and 1) if there is any              |
+| `timestamp`          | integer         | Unix timestamp of wallet creation date                                                       |
+| `last_poll_timestamp`| integer or null | Unix timestamp of last poll (if any) of the blockchain                                       |
 
 ### `getnewaddress`
 

--- a/src/bitcoin/poller/looper.rs
+++ b/src/bitcoin/poller/looper.rs
@@ -4,7 +4,7 @@ use crate::{
     descriptors,
 };
 
-use std::{collections::HashSet, sync, thread, time};
+use std::{collections::HashSet, convert::TryInto, sync, thread, time};
 
 use miniscript::bitcoin::{self, secp256k1};
 
@@ -401,4 +401,11 @@ pub fn poll(
     let mut db_conn = db.connection();
     updates(&mut db_conn, bit, descs, secp);
     rescan_check(&mut db_conn, bit, descs, secp);
+    let now: u32 = time::SystemTime::now()
+        .duration_since(time::UNIX_EPOCH)
+        .expect("current system time must be later than epoch")
+        .as_secs()
+        .try_into()
+        .expect("system clock year is earlier than 2106");
+    db_conn.set_last_poll(now);
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -309,10 +309,10 @@ impl DaemonControl {
     /// Get information about the current state of the daemon
     pub fn get_info(&self) -> GetInfoResult {
         let mut db_conn = self.db.connection();
-
         let block_height = db_conn.chain_tip().map(|tip| tip.height).unwrap_or(0);
-        let rescan_progress = db_conn
-            .rescan_timestamp()
+        let wallet = db_conn.wallet();
+        let rescan_progress = wallet
+            .rescan_timestamp
             .map(|_| self.bitcoin.rescan_progress().unwrap_or(1.0));
         GetInfoResult {
             version: VERSION.to_string(),
@@ -323,8 +323,8 @@ impl DaemonControl {
                 main: self.config.main_descriptor.clone(),
             },
             rescan_progress,
-            timestamp: db_conn.timestamp(),
-            last_poll_timestamp: db_conn.last_poll_timestamp(),
+            timestamp: wallet.timestamp,
+            last_poll_timestamp: wallet.last_poll_timestamp,
         }
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -324,6 +324,7 @@ impl DaemonControl {
             },
             rescan_progress,
             timestamp: db_conn.timestamp(),
+            last_poll_timestamp: db_conn.last_poll_timestamp(),
         }
     }
 
@@ -1127,6 +1128,8 @@ pub struct GetInfoResult {
     pub rescan_progress: Option<f64>,
     /// Timestamp at wallet creation date
     pub timestamp: u32,
+    /// Timestamp of last poll, if any.
+    pub last_poll_timestamp: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -81,6 +81,14 @@ pub trait DatabaseConnection {
     /// Mark the rescan as complete.
     fn complete_rescan(&mut self);
 
+    /// Get the timestamp at which the last poll of the blockchain completed, if any,
+    /// as the number of seconds since the UNIX epoch.
+    fn last_poll_timestamp(&mut self) -> Option<u32>;
+
+    /// Set the timestamp at which the last poll of the blockchain completed,
+    /// where `timestamp` should be given as the number of seconds since the UNIX epoch.
+    fn set_last_poll(&mut self, timestamp: u32);
+
     /// Get the derivation index for this address, as well as whether this address is change.
     fn derivation_index_by_address(
         &mut self,
@@ -218,6 +226,15 @@ impl DatabaseConnection for SqliteConn {
 
     fn complete_rescan(&mut self) {
         self.complete_wallet_rescan()
+    }
+
+    fn last_poll_timestamp(&mut self) -> Option<u32> {
+        self.db_wallet().last_poll_timestamp
+    }
+
+    fn set_last_poll(&mut self, timestamp: u32) {
+        self.set_wallet_last_poll_timestamp(timestamp)
+            .expect("database must be available")
     }
 
     fn coins(

--- a/src/database/sqlite/schema.rs
+++ b/src/database/sqlite/schema.rs
@@ -30,7 +30,8 @@ CREATE TABLE wallets (
     main_descriptor TEXT NOT NULL,
     deposit_derivation_index INTEGER NOT NULL,
     change_derivation_index INTEGER NOT NULL,
-    rescan_timestamp INTEGER
+    rescan_timestamp INTEGER,
+    last_poll_timestamp INTEGER
 );
 
 /* Our (U)TxOs.
@@ -140,6 +141,7 @@ pub struct DbWallet {
     pub deposit_derivation_index: bip32::ChildNumber,
     pub change_derivation_index: bip32::ChildNumber,
     pub rescan_timestamp: Option<u32>,
+    pub last_poll_timestamp: Option<u32>,
 }
 
 impl TryFrom<&rusqlite::Row<'_>> for DbWallet {
@@ -159,6 +161,7 @@ impl TryFrom<&rusqlite::Row<'_>> for DbWallet {
         let change_derivation_index = bip32::ChildNumber::from(der_idx);
 
         let rescan_timestamp = row.get(5)?;
+        let last_poll_timestamp = row.get(6)?;
 
         Ok(DbWallet {
             id,
@@ -167,6 +170,7 @@ impl TryFrom<&rusqlite::Row<'_>> for DbWallet {
             deposit_derivation_index,
             change_derivation_index,
             rescan_timestamp,
+            last_poll_timestamp,
         })
     }
 }

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -149,6 +149,7 @@ struct DummyDbState {
     txs: HashMap<bitcoin::Txid, bitcoin::Transaction>,
     spend_txs: HashMap<bitcoin::Txid, (Psbt, Option<u32>)>,
     timestamp: u32,
+    last_poll_timestamp: Option<u32>,
 }
 
 pub struct DummyDatabase {
@@ -181,6 +182,7 @@ impl DummyDatabase {
                 txs: HashMap::new(),
                 spend_txs: HashMap::new(),
                 timestamp: now,
+                last_poll_timestamp: None,
             })),
         }
     }
@@ -409,6 +411,14 @@ impl DatabaseConnection for DummyDatabase {
 
     fn complete_rescan(&mut self) {
         todo!()
+    }
+
+    fn last_poll_timestamp(&mut self) -> Option<u32> {
+        self.db.read().unwrap().last_poll_timestamp
+    }
+
+    fn set_last_poll(&mut self, timestamp: u32) {
+        self.db.write().unwrap().last_poll_timestamp = Some(timestamp);
     }
 
     fn update_labels(&mut self, _items: &HashMap<LabelItem, Option<String>>) {

--- a/src/testutils.rs
+++ b/src/testutils.rs
@@ -1,7 +1,9 @@
 use crate::{
     bitcoin::{BitcoinInterface, Block, BlockChainTip, MempoolEntry, SyncProgress, UTxO},
     config::{BitcoinConfig, Config},
-    database::{BlockInfo, Coin, CoinStatus, DatabaseConnection, DatabaseInterface, LabelItem},
+    database::{
+        BlockInfo, Coin, CoinStatus, DatabaseConnection, DatabaseInterface, LabelItem, Wallet,
+    },
     descriptors, DaemonControl, DaemonHandle,
 };
 
@@ -149,6 +151,7 @@ struct DummyDbState {
     txs: HashMap<bitcoin::Txid, bitcoin::Transaction>,
     spend_txs: HashMap<bitcoin::Txid, (Psbt, Option<u32>)>,
     timestamp: u32,
+    rescan_timestamp: Option<u32>,
     last_poll_timestamp: Option<u32>,
 }
 
@@ -182,6 +185,7 @@ impl DummyDatabase {
                 txs: HashMap::new(),
                 spend_txs: HashMap::new(),
                 timestamp: now,
+                rescan_timestamp: None,
                 last_poll_timestamp: None,
             })),
         }
@@ -201,6 +205,17 @@ impl DatabaseConnection for DummyDatabase {
 
     fn chain_tip(&mut self) -> Option<BlockChainTip> {
         self.db.read().unwrap().curr_tip
+    }
+
+    fn wallet(&mut self) -> Wallet {
+        let db_wallet = self.db.read().unwrap();
+        Wallet {
+            timestamp: db_wallet.timestamp,
+            receive_index: db_wallet.deposit_index,
+            change_index: db_wallet.change_index,
+            rescan_timestamp: db_wallet.rescan_timestamp,
+            last_poll_timestamp: db_wallet.last_poll_timestamp,
+        }
     }
 
     fn timestamp(&mut self) -> u32 {
@@ -402,7 +417,7 @@ impl DatabaseConnection for DummyDatabase {
     }
 
     fn rescan_timestamp(&mut self) -> Option<u32> {
-        None
+        self.db.read().unwrap().rescan_timestamp
     }
 
     fn set_rescan(&mut self, _: u32) {

--- a/tests/test_framework/lianad.py
+++ b/tests/test_framework/lianad.py
@@ -38,6 +38,7 @@ class Lianad(TailableProc):
         self.prefix = os.path.split(datadir)[-1]
 
         self.signer = signer
+        self._poll_interval_secs = 1
         self.multi_desc = multi_desc
         self.receive_desc, self.change_desc = multi_desc.singlepath_descriptors()
 
@@ -56,8 +57,13 @@ class Lianad(TailableProc):
 
             f.write("[bitcoin_config]\n")
             f.write('network = "regtest"\n')
-            f.write("poll_interval_secs = 1\n")
+            f.write(f"poll_interval_secs = {self._poll_interval_secs}\n")
         bitcoin_backend.append_to_lianad_conf(self.conf_file)
+
+    @property
+    def poll_interval_secs(self):
+        """Return the poll interval in seconds as defined in the config file."""
+        return self._poll_interval_secs
 
     def finalize_psbt(self, psbt):
         """Create a valid witness for all inputs in the PSBT.

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -31,6 +31,11 @@ def test_getinfo(lianad):
     assert res["sync"] == 1.0
     assert "main" in res["descriptors"]
     assert res["rescan_progress"] is None
+    last_poll_timestamp = res["last_poll_timestamp"]
+    assert last_poll_timestamp is not None
+    time.sleep(lianad.poll_interval_secs + 1)
+    res = lianad.rpc.getinfo()
+    assert res["last_poll_timestamp"] > last_poll_timestamp
 
 
 def test_getaddress(lianad):


### PR DESCRIPTION
This is a first step towards #1373.

The timestamp of the last completed poll of the blockchain will be stored in the database, and this value will be made available via the `getinfo` command.