### PR TITLE
[GUI] Consider wallet to be syncing until first poll completes after opening

### DIFF
--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -2624,7 +2624,7 @@ dependencies = [
 [[package]]
 name = "liana"
 version = "7.0.0"
-source = "git+https://github.com/wizardsardine/liana?branch=master#18950c219a9233e584fabb1f5b168e17fa450902"
+source = "git+https://github.com/wizardsardine/liana?branch=master#c2ce025a78891307e1f0d83c52cb983eb098d41d"
 dependencies = [
  "backtrace",
  "bdk_coin_select",

--- a/gui/src/app/cache.rs
+++ b/gui/src/app/cache.rs
@@ -9,6 +9,7 @@ pub struct Cache {
     pub blockheight: i32,
     pub coins: Vec<Coin>,
     pub rescan_progress: Option<f64>,
+    pub last_poll_timestamp: Option<u32>,
 }
 
 /// only used for tests.
@@ -20,6 +21,7 @@ impl std::default::Default for Cache {
             blockheight: 0,
             coins: Vec::new(),
             rescan_progress: None,
+            last_poll_timestamp: None,
         }
     }
 }

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -281,6 +281,7 @@ impl App {
                             network: info.network,
                             blockheight: info.block_height,
                             rescan_progress: info.rescan_progress,
+                            last_poll_timestamp: info.last_poll_timestamp,
                         })
                     },
                     Message::UpdateCache,

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -67,6 +67,7 @@ impl Panels {
                 wallet.clone(),
                 &cache.coins,
                 cache.blockheight,
+                cache.last_poll_timestamp,
                 daemon_backend.clone(),
             ),
             coins: CoinsPanel::new(&cache.coins, wallet.main_descriptor.first_timelock_value()),

--- a/gui/src/app/view/home.rs
+++ b/gui/src/app/view/home.rs
@@ -36,6 +36,7 @@ pub fn home_view<'a>(
     is_last_page: bool,
     processing: bool,
     wallet_is_syncing: bool,
+    blockheight: i32,
 ) -> Element<'a, Message> {
     Column::new()
         .push(h3("Balance"))
@@ -58,14 +59,23 @@ pub fn home_view<'a>(
                     ))
                 })
                 .push_maybe(if wallet_is_syncing {
-                    Some(Row::new().push(text("Syncing").style(color::GREY_2)).push(
-                        spinner::typing_text_carousel(
-                            "...",
-                            true,
-                            Duration::from_millis(2000),
-                            |content| text(content).style(color::GREY_2),
-                        ),
-                    ))
+                    Some(
+                        Row::new()
+                            .push(
+                                text(if blockheight <= 0 {
+                                    "Syncing"
+                                } else {
+                                    "Checking for new transactions"
+                                })
+                                .style(color::GREY_2),
+                            )
+                            .push(spinner::typing_text_carousel(
+                                "...",
+                                true,
+                                Duration::from_millis(2000),
+                                |content| text(content).style(color::GREY_2),
+                            )),
+                    )
                 } else {
                     None
                 })

--- a/gui/src/lianalite/client/backend/mod.rs
+++ b/gui/src/lianalite/client/backend/mod.rs
@@ -584,6 +584,8 @@ impl Daemon for BackendWalletClient {
             sync: 1.0,
             rescan_progress: None,
             timestamp: wallet.created_at as u32,
+            // We can ignore this field for remote backend as the wallet should remain synced.
+            last_poll_timestamp: None,
         })
     }
 

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -380,6 +380,7 @@ pub async fn load_application(
         network: info.network,
         blockheight: info.block_height,
         coins,
+        last_poll_timestamp: info.last_poll_timestamp,
         ..Default::default()
     };
 

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -461,6 +461,7 @@ pub fn create_app_with_remote_backend(
             rescan_progress: None,
             datadir_path: datadir.clone(),
             blockheight: wallet.tip_height.unwrap_or(0),
+            last_poll_timestamp: None, // We ignore this field for remote backend.
         },
         Arc::new(
             Wallet::new(wallet.descriptor)


### PR DESCRIPTION
This PR uses the changes from #1376 to complete #1373.

It builds on the changes from #1370 to consider an existing wallet (that uses a local backend) to be syncing until the first poll completes after opening the GUI, where "existing wallet" means one that has positive height (since a newly created wallet has height 0).

Note that for an external Liana daemon,  this logic is only applied in case the last poll timestamp has already been set when starting the GUI. Otherwise, we can't be sure if this external daemon will ever set this value.