### PR TITLE
Change primary and secondary button for consistency

### DIFF
--- a/gui/src/app/view/coins.rs
+++ b/gui/src/app/view/coins.rs
@@ -279,7 +279,7 @@ fn coin_list_view<'a>(
                         } else {
                             Column::new().push(
                                 Row::new().push(Space::with_width(Length::Fill)).push(
-                                    button::primary(Some(icon::arrow_repeat()), "Refresh coin")
+                                    button::secondary(Some(icon::arrow_repeat()), "Refresh coin")
                                         .on_press(Message::Menu(Menu::RefreshCoins(vec![
                                             coin.outpoint,
                                         ]))),

--- a/gui/src/app/view/home.rs
+++ b/gui/src/app/view/home.rs
@@ -87,9 +87,10 @@ pub fn home_view<'a>(
                             .width(Length::Fill),
                         )
                         .push(
-                            button::primary(Some(icon::arrow_repeat()), "Refresh coins").on_press(
-                                Message::Menu(Menu::RefreshCoins(expiring_coins.to_owned())),
-                            ),
+                            button::secondary(Some(icon::arrow_repeat()), "Refresh coins")
+                                .on_press(Message::Menu(Menu::RefreshCoins(
+                                    expiring_coins.to_owned(),
+                                ))),
                         ),
                 )
                 .padding(25)
@@ -322,7 +323,7 @@ pub fn payment_view<'a>(
                     .spacing(5),
             ))
             .push(
-                button::primary(None, "See transaction details")
+                button::secondary(None, "See transaction details")
                     .on_press(Message::Menu(Menu::TransactionPreSelected(tx.tx.txid()))),
             )
             .spacing(20),

--- a/gui/src/app/view/label.rs
+++ b/gui/src/app/view/label.rs
@@ -20,7 +20,7 @@ pub fn label_editable(
                     iced::widget::Text::new(label)
                         .size(size)
                         .shaping(Shaping::Advanced),
-                    button::primary(Some(icon::pencil_icon()), "Edit").on_press(
+                    button::secondary(Some(icon::pencil_icon()), "Edit").on_press(
                         view::Message::Label(
                             labelled,
                             view::message::LabelMessage::Edited(label.to_string())
@@ -34,7 +34,7 @@ pub fn label_editable(
         }
     }
     Container::new(
-        button::primary(Some(icon::pencil_icon()), "Add label").on_press(view::Message::Label(
+        button::secondary(Some(icon::pencil_icon()), "Add label").on_press(view::Message::Label(
             labelled,
             view::message::LabelMessage::Edited(String::default()),
         )),
@@ -54,11 +54,11 @@ pub fn label_editing(
                 .size(size)
                 .padding(10),
             if label.valid {
-                button::primary(None, "Save").on_press(view::message::LabelMessage::Confirm)
+                button::secondary(None, "Save").on_press(view::message::LabelMessage::Confirm)
             } else {
-                button::primary(None, "Save")
+                button::secondary(None, "Save")
             },
-            button::primary(None, "Cancel").on_press(view::message::LabelMessage::Cancel)
+            button::secondary(None, "Cancel").on_press(view::message::LabelMessage::Cancel)
         )
         .spacing(5)
         .align_items(Alignment::Center),

--- a/gui/src/app/view/mod.rs
+++ b/gui/src/app/view/mod.rs
@@ -226,7 +226,7 @@ pub fn modal<'a, T: Into<Element<'a, Message>>, F: Into<Element<'a, Message>>>(
                         Column::new().width(Length::Fill)
                     })
                     .align_items(iced::Alignment::Center)
-                    .push(button::primary(Some(cross_icon()), "Close").on_press(Message::Close)),
+                    .push(button::secondary(Some(cross_icon()), "Close").on_press(Message::Close)),
             )
             .padding(10)
             .style(theme::Container::Background),

--- a/gui/src/app/view/psbt.rs
+++ b/gui/src/app/view/psbt.rs
@@ -129,7 +129,7 @@ pub fn save_action<'a>(warning: Option<&Error>, saved: bool) -> Element<'a, Mess
                         .push(Column::new().width(Length::Fill))
                         .push(button::alert(None, "Ignore").on_press(Message::Close))
                         .push(
-                            button::primary(None, "Save")
+                            button::secondary(None, "Save")
                                 .on_press(Message::Spend(SpendTxMessage::Confirm)),
                         ),
                 ),
@@ -213,7 +213,7 @@ pub fn broadcast_action<'a>(
                 })
                 .push(
                     Row::new().push(Column::new().width(Length::Fill)).push(
-                        button::primary(None, "Broadcast")
+                        button::secondary(None, "Broadcast")
                             .on_press(Message::Spend(SpendTxMessage::Confirm)),
                     ),
                 ),
@@ -234,7 +234,7 @@ pub fn delete_action<'a>(warning: Option<&Error>, deleted: bool) -> Element<'a, 
                 .spacing(20)
                 .align_items(Alignment::Center)
                 .push(text("Successfully deleted this transaction."))
-                .push(button::primary(None, "Go back to PSBTs").on_press(Message::Close)),
+                .push(button::secondary(None, "Go back to PSBTs").on_press(Message::Close)),
         )
         .align_x(iced::alignment::Horizontal::Center)
         .width(Length::Fixed(400.0))
@@ -379,13 +379,13 @@ pub fn spend_overview_view<'a>(
                     .push(Space::with_width(Length::Fill))
                     .push_maybe(if tx.path_ready().is_none() {
                         Some(
-                            button::primary(None, "Sign")
+                            button::secondary(None, "Sign")
                                 .on_press(Message::Spend(SpendTxMessage::Sign))
                                 .width(Length::Fixed(150.0)),
                         )
                     } else {
                         Some(
-                            button::primary(None, "Broadcast")
+                            button::secondary(None, "Broadcast")
                                 .on_press(Message::Spend(SpendTxMessage::Broadcast))
                                 .width(Length::Fixed(150.0)),
                         )
@@ -1147,12 +1147,12 @@ pub fn update_spend_view<'a>(
                         )
                         .push(Row::new().push(Space::with_width(Length::Fill)).push(
                             if updated.valid && !updated.value.is_empty() && !processing {
-                                button::primary(None, "Update")
+                                button::secondary(None, "Update")
                                     .on_press(Message::ImportSpend(ImportSpendMessage::Confirm))
                             } else if processing {
-                                button::primary(None, "Processing...")
+                                button::secondary(None, "Processing...")
                             } else {
-                                button::primary(None, "Update")
+                                button::secondary(None, "Update")
                             },
                         )),
                 ),

--- a/gui/src/app/view/psbt.rs
+++ b/gui/src/app/view/psbt.rs
@@ -1127,7 +1127,7 @@ pub fn update_spend_view<'a>(
                     Row::new()
                         .push(text("PSBT:").bold().width(Length::Fill))
                         .push(
-                            button::border(Some(icon::clipboard_icon()), "Copy")
+                            button::secondary(Some(icon::clipboard_icon()), "Copy")
                                 .on_press(Message::Clipboard(psbt)),
                         )
                         .align_items(Alignment::Center),

--- a/gui/src/app/view/psbt.rs
+++ b/gui/src/app/view/psbt.rs
@@ -126,10 +126,11 @@ pub fn save_action<'a>(warning: Option<&Error>, saved: bool) -> Element<'a, Mess
                 .push(text("Save this transaction"))
                 .push(
                     Row::new()
-                        .push(Column::new().width(Length::Fill))
-                        .push(button::alert(None, "Ignore").on_press(Message::Close))
+                        .spacing(10)
+                        .push(Space::with_width(Length::Fill))
+                        .push(button::secondary(None, "Ignore").on_press(Message::Close))
                         .push(
-                            button::secondary(None, "Save")
+                            button::primary(None, "Save")
                                 .on_press(Message::Spend(SpendTxMessage::Confirm)),
                         ),
                 ),

--- a/gui/src/app/view/psbts.rs
+++ b/gui/src/app/view/psbts.rs
@@ -35,12 +35,12 @@ pub fn import_psbt_view<'a>(
                 )
                 .push(Row::new().push(Space::with_width(Length::Fill)).push(
                     if imported.valid && !imported.value.is_empty() && !processing {
-                        button::primary(None, "Import")
+                        button::secondary(None, "Import")
                             .on_press(Message::ImportSpend(ImportSpendMessage::Confirm))
                     } else if processing {
-                        button::primary(None, "Processing...")
+                        button::secondary(None, "Processing...")
                     } else {
-                        button::primary(None, "Import")
+                        button::secondary(None, "Import")
                     },
                 )),
         ))
@@ -70,7 +70,7 @@ pub fn psbts_view(spend_txs: &[SpendTx]) -> Element<'_, Message> {
                         .on_press(Message::ImportSpend(ImportSpendMessage::Import)),
                 )
                 .push(
-                    button::primary(Some(icon::plus_icon()), "New")
+                    button::secondary(Some(icon::plus_icon()), "New")
                         .on_press(Message::Menu(Menu::CreateSpendTx)),
                 ),
         )

--- a/gui/src/app/view/receive.rs
+++ b/gui/src/app/view/receive.rs
@@ -45,7 +45,7 @@ pub fn receive<'a>(
                 .align_items(Alignment::Center)
                 .push(Container::new(h3("Receive")).width(Length::Fill))
                 .push(
-                    button::primary(Some(icon::plus_icon()), "Generate address")
+                    button::secondary(Some(icon::plus_icon()), "Generate address")
                         .on_press(Message::Next),
                 ),
         )
@@ -112,12 +112,15 @@ pub fn receive<'a>(
                                     .push(
                                         Row::new()
                                             .push(
-                                                button::primary(None, "Verify on hardware device")
-                                                    .on_press(Message::Select(i)),
+                                                button::secondary(
+                                                    None,
+                                                    "Verify on hardware device",
+                                                )
+                                                .on_press(Message::Select(i)),
                                             )
                                             .push(Space::with_width(Length::Fill))
                                             .push(
-                                                button::primary(None, "Show QR Code")
+                                                button::secondary(None, "Show QR Code")
                                                     .on_press(Message::ShowQrCode(i)),
                                             ),
                                     )

--- a/gui/src/app/view/recovery.rs
+++ b/gui/src/app/view/recovery.rs
@@ -118,11 +118,11 @@ pub fn recovery<'a>(
                                 && !address.value.is_empty()
                                 && selected_path.is_some()
                             {
-                                button::primary(None, "Next")
+                                button::secondary(None, "Next")
                                     .on_press(Message::Next)
                                     .width(Length::Fixed(200.0))
                             } else {
-                                button::primary(None, "Next").width(Length::Fixed(200.0))
+                                button::secondary(None, "Next").width(Length::Fixed(200.0))
                             },
                         )
                         .spacing(20)

--- a/gui/src/app/view/settings.rs
+++ b/gui/src/app/view/settings.rs
@@ -284,7 +284,7 @@ pub fn remote_backend_section<'a>(
                                     None
                                 })
                                 .push(Space::with_width(Length::Fill))
-                                .push(button::primary(None, "Send invitation").on_press_maybe(
+                                .push(button::secondary(None, "Send invitation").on_press_maybe(
                                     if !processing && email_form.valid {
                                         Some(Message::Settings(
                                             SettingsMessage::RemoteBackendSettings(
@@ -413,7 +413,7 @@ pub fn bitcoind_edit<'a>(
         );
 
     let mut cancel_button = button::transparent(None, " Cancel ").padding(5);
-    let mut confirm_button = button::primary(None, " Save ").padding(5);
+    let mut confirm_button = button::secondary(None, " Save ").padding(5);
     if !processing {
         cancel_button = cancel_button.on_press(SettingsEditMessage::Cancel);
         confirm_button = confirm_button.on_press(SettingsEditMessage::Confirm);
@@ -599,7 +599,7 @@ pub fn electrum_edit<'a>(
     );
 
     let mut cancel_button = button::transparent(None, " Cancel ").padding(5);
-    let mut confirm_button = button::primary(None, " Save ").padding(5);
+    let mut confirm_button = button::secondary(None, " Save ").padding(5);
     if !processing {
         cancel_button = cancel_button.on_press(SettingsEditMessage::Cancel);
         confirm_button = confirm_button.on_press(SettingsEditMessage::Confirm);
@@ -843,18 +843,18 @@ pub fn rescan<'a>(
                                     && is_ok_and(&u32::from_str(&day.value), |&v| v > 0 && v <= 31))
                             {
                                 Row::new().push(Column::new().width(Length::Fill)).push(
-                                    button::primary(None, "Start rescan")
+                                    button::secondary(None, "Start rescan")
                                         .on_press(SettingsEditMessage::Confirm)
                                         .width(Length::Shrink),
                                 )
                             } else if processing {
                                 Row::new().push(Column::new().width(Length::Fill)).push(
-                                    button::primary(None, "Starting rescan...")
+                                    button::secondary(None, "Starting rescan...")
                                         .width(Length::Shrink),
                                 )
                             } else {
                                 Row::new().push(Column::new().width(Length::Fill)).push(
-                                    button::primary(None, "Start rescan").width(Length::Shrink),
+                                    button::secondary(None, "Start rescan").width(Length::Shrink),
                                 )
                             },
                         ),
@@ -929,7 +929,7 @@ pub fn wallet_settings<'a>(
                                         .on_press(Message::Clipboard(descriptor.to_string())),
                                 )
                                 .push(
-                                    button::primary(
+                                    button::secondary(
                                         Some(icon::chip_icon()),
                                         "Register on hardware device",
                                     )
@@ -988,10 +988,10 @@ pub fn wallet_settings<'a>(
                                     None
                                 })
                                 .push(if !processing {
-                                    button::primary(None, "Update")
+                                    button::secondary(None, "Update")
                                         .on_press(Message::Settings(SettingsMessage::Save))
                                 } else {
-                                    button::primary(None, "Updating")
+                                    button::secondary(None, "Updating")
                                 }),
                         )
                         .spacing(10),

--- a/gui/src/app/view/spend/mod.rs
+++ b/gui/src/app/view/spend/mod.rs
@@ -290,7 +290,7 @@ pub fn create_spend_tx<'a>(
                     .align_items(Alignment::Center)
                     .push(Space::with_width(Length::Fill))
                     .push(
-                        button::primary(None, "Clear")
+                        button::secondary(None, "Clear")
                             .on_press(Message::CreateSpend(CreateSpendMessage::Clear))
                             .width(Length::Fixed(100.0)),
                     )
@@ -299,11 +299,11 @@ pub fn create_spend_tx<'a>(
                             && !duplicate
                             && (is_self_send || Some(&Amount::from_sat(0)) == amount_left)
                         {
-                            button::primary(None, "Next")
+                            button::secondary(None, "Next")
                                 .on_press(Message::CreateSpend(CreateSpendMessage::Generate))
                                 .width(Length::Fixed(100.0))
                         } else {
-                            button::primary(None, "Next").width(Length::Fixed(100.0))
+                            button::secondary(None, "Next").width(Length::Fixed(100.0))
                         },
                     ),
             )

--- a/gui/src/app/view/transactions.rs
+++ b/gui/src/app/view/transactions.rs
@@ -174,7 +174,7 @@ pub fn create_rbf_modal<'a>(
     replacement_txid: Option<Txid>,
     warning: Option<&'a Error>,
 ) -> Element<'a, Message> {
-    let mut confirm_button = button::primary(None, "Confirm").width(Length::Fixed(200.0));
+    let mut confirm_button = button::secondary(None, "Confirm").width(Length::Fixed(200.0));
     if feerate.valid || is_cancel {
         confirm_button =
             confirm_button.on_press(Message::CreateRbf(super::CreateRbfMessage::Confirm));
@@ -280,7 +280,7 @@ pub fn create_rbf_modal<'a>(
             }))
             .push_maybe(replacement_txid.map(|id| {
                 Row::new().push(
-                    button::primary(None, "Go to replacement")
+                    button::secondary(None, "Go to replacement")
                         .width(Length::Fixed(200.0))
                         .on_press(Message::Menu(Menu::PsbtPreSelected(id))),
                 )
@@ -360,13 +360,13 @@ pub fn tx_view<'a>(
                 Some(
                     Row::new()
                         .push(
-                            button::primary(None, "Bump fee")
+                            button::secondary(None, "Bump fee")
                                 .width(Length::Fixed(200.0))
                                 .on_press(Message::CreateRbf(super::CreateRbfMessage::New(false))),
                         )
                         .push(
                             tooltip::Tooltip::new(
-                                button::primary(None, "Cancel transaction")
+                                button::secondary(None, "Cancel transaction")
                                 .width(Length::Fixed(200.0))
                                 .on_press(Message::CreateRbf(super::CreateRbfMessage::New(true))),
                                 "Best effort attempt at double spending an unconfirmed outgoing transaction",

--- a/gui/src/installer/view.rs
+++ b/gui/src/installer/view.rs
@@ -223,9 +223,9 @@ pub fn define_descriptor<'a>(
                             .width(Length::Fixed(200.0)),
                     )
                     .push(if !valid {
-                        button::primary(None, "Next").width(Length::Fixed(200.0))
+                        button::secondary(None, "Next").width(Length::Fixed(200.0))
                     } else {
-                        button::primary(None, "Next")
+                        button::secondary(None, "Next")
                             .width(Length::Fixed(200.0))
                             .on_press(Message::Next)
                     }),
@@ -359,7 +359,7 @@ pub fn import_wallet_or_descriptor<'a>(
                         )
                         .push(
                             Row::new().push(Space::with_width(Length::Fill)).push(
-                                button::primary(None, "Accept")
+                                button::secondary(None, "Accept")
                                     .width(Length::Fixed(200.0))
                                     .on_press(Message::ImportRemoteWallet(
                                         message::ImportRemoteWallet::AcceptInvitation,
@@ -392,7 +392,7 @@ pub fn import_wallet_or_descriptor<'a>(
                             )
                             .push(
                                 Row::new().push(Space::with_width(Length::Fill)).push(
-                                    button::primary(None, "Next")
+                                    button::secondary(None, "Next")
                                         .width(Length::Fixed(200.0))
                                         .on_press_maybe(if !invitation.value.is_empty() {
                                             Some(Message::ImportRemoteWallet(
@@ -462,7 +462,7 @@ pub fn import_wallet_or_descriptor<'a>(
                         )
                         .push(
                             Row::new().push(Space::with_width(Length::Fill)).push(
-                                button::primary(None, "Next")
+                                button::secondary(None, "Next")
                                     .width(Length::Fixed(200.0))
                                     .on_press_maybe(
                                         if imported_descriptor.value.is_empty()
@@ -536,9 +536,9 @@ pub fn import_descriptor<'a>(
             )))
             .push(
                 if imported_descriptor.value.is_empty() || !imported_descriptor.valid {
-                    button::primary(None, "Next").width(Length::Fixed(200.0))
+                    button::secondary(None, "Next").width(Length::Fixed(200.0))
                 } else {
-                    button::primary(None, "Next")
+                    button::secondary(None, "Next")
                         .width(Length::Fixed(200.0))
                         .on_press(Message::Next)
                 },
@@ -908,11 +908,11 @@ pub fn register_descriptor<'a>(
                 done,
             ).on_toggle(Message::UserActionDone)))
             .push(if !created_desc || (done && !processing) {
-                button::primary(None, "Next")
+                button::secondary(None, "Next")
                     .on_press(Message::Next)
                     .width(Length::Fixed(200.0))
             } else {
-                button::primary(None, "Next").width(Length::Fixed(200.0))
+                button::secondary(None, "Next").width(Length::Fixed(200.0))
             })
             .spacing(50),
         true,
@@ -999,11 +999,11 @@ pub fn backup_descriptor<'a>(
                 checkbox("I have backed up my descriptor", done).on_toggle(Message::UserActionDone),
             )
             .push(if done {
-                button::primary(None, "Next")
+                button::secondary(None, "Next")
                     .on_press(Message::Next)
                     .width(Length::Fixed(200.0))
             } else {
-                button::primary(None, "Next").width(Length::Fixed(200.0))
+                button::secondary(None, "Next").width(Length::Fixed(200.0))
             })
             .spacing(50),
         true,
@@ -1244,11 +1244,11 @@ pub fn define_bitcoin_node<'a>(
                         .width(Length::Fixed(200.0)),
                 ))
                 .push(if is_running.map(|res| res.is_ok()).unwrap_or(false) {
-                    button::primary(None, "Next")
+                    button::secondary(None, "Next")
                         .on_press(Message::Next)
                         .width(Length::Fixed(200.0))
                 } else {
-                    button::primary(None, "Next").width(Length::Fixed(200.0))
+                    button::secondary(None, "Next").width(Length::Fixed(200.0))
                 }),
         )
         .spacing(50);
@@ -1475,7 +1475,7 @@ pub fn select_bitcoind_type<'a>(progress: (usize, usize)) -> Element<'a, Message
                                 .width(Length::Fixed(300.0))
                                 .align_items(Alignment::Center)
                                 .push(
-                                    button::primary(None, "Select")
+                                    button::secondary(None, "Select")
                                         .width(Length::Fixed(300.0))
                                         .on_press(Message::SelectBitcoindType(
                                             message::SelectBitcoindTypeMsg::UseExternal(true),
@@ -1491,7 +1491,7 @@ pub fn select_bitcoind_type<'a>(progress: (usize, usize)) -> Element<'a, Message
                                 .width(Length::Fixed(300.0))
                                 .align_items(Alignment::Center)
                                 .push(
-                                    button::primary(None, "Select")
+                                    button::secondary(None, "Select")
                                         .width(Length::Fixed(300.0))
                                         .on_press(Message::SelectBitcoindType(
                                             message::SelectBitcoindTypeMsg::UseExternal(false),
@@ -1515,7 +1515,7 @@ pub fn start_internal_bitcoind<'a>(
     install_state: Option<&InstallState>,
 ) -> Element<'a, Message> {
     let version = crate::node::bitcoind::VERSION;
-    let mut next_button = button::primary(None, "Next").width(Length::Fixed(200.0));
+    let mut next_button = button::secondary(None, "Next").width(Length::Fixed(200.0));
     if let Some(Ok(_)) = started {
         next_button = next_button.on_press(Message::Next);
     };
@@ -1975,7 +1975,7 @@ pub fn edit_key_modal<'a>(
                 .push(
                     if form_xpub.valid && !form_xpub.value.is_empty() && !form_name.value.is_empty() && !duplicate_master_fg
                     {
-                        button::primary(None, "Apply")
+                        button::secondary(None, "Apply")
                             .on_press(Message::DefineDescriptor(
                                 message::DefineDescriptor::KeyModal(
                                     message::ImportKeyModal::ConfirmXpub,
@@ -1983,7 +1983,7 @@ pub fn edit_key_modal<'a>(
                             ))
                             .width(Length::Fixed(200.0))
                     } else {
-                        button::primary(None, "Apply").width(Length::Fixed(100.0))
+                        button::secondary(None, "Apply").width(Length::Fixed(100.0))
                     },
                 )
                 .align_items(Alignment::Center),
@@ -2069,13 +2069,13 @@ pub fn edit_sequence_modal<'a>(sequence: &form::Value<String>) -> Element<'a, Me
     }
 
     card::simple(col.push(if sequence.valid {
-        button::primary(None, "Apply")
+        button::secondary(None, "Apply")
             .on_press(Message::DefineDescriptor(
                 message::DefineDescriptor::SequenceModal(message::SequenceModal::ConfirmSequence),
             ))
             .width(Length::Fixed(200.0))
     } else {
-        button::primary(None, "Apply").width(Length::Fixed(200.0))
+        button::secondary(None, "Apply").width(Length::Fixed(200.0))
     }))
     .width(Length::Fixed(800.0))
     .into()
@@ -2226,11 +2226,11 @@ pub fn backup_mnemonic<'a>(
             )
             .push(checkbox("I have backed up my mnemonic", done).on_toggle(Message::UserActionDone))
             .push(if done {
-                button::primary(None, "Next")
+                button::secondary(None, "Next")
                     .on_press(Message::Next)
                     .width(Length::Fixed(200.0))
             } else {
-                button::primary(None, "Next").width(Length::Fixed(200.0))
+                button::secondary(None, "Next").width(Length::Fixed(200.0))
             })
             .spacing(50),
         true,
@@ -2315,7 +2315,7 @@ pub fn recover_mnemonic<'a>(
                             .width(Length::Fixed(200.0)),
                     )
                     .push(
-                        button::primary(None, "Skip")
+                        button::secondary(None, "Skip")
                             .on_press(Message::Skip)
                             .width(Length::Fixed(200.0)),
                     )
@@ -2329,9 +2329,9 @@ pub fn recover_mnemonic<'a>(
                     )
                     .push(
                         if words.iter().any(|(_, valid)| !valid) || error.is_some() {
-                            button::primary(None, "Next").width(Length::Fixed(200.0))
+                            button::secondary(None, "Next").width(Length::Fixed(200.0))
                         } else {
-                            button::primary(None, "Next")
+                            button::secondary(None, "Next")
                                 .on_press(Message::Next)
                                 .width(Length::Fixed(200.0))
                         },
@@ -2372,7 +2372,7 @@ pub fn choose_backend(progress: (usize, usize)) -> Element<'static, Message> {
                     .spacing(20)
                     .push(
                         Container::new(
-                            button::primary(None, "Select")
+                            button::secondary(None, "Select")
                                 .on_press(Message::SelectBackend(
                                     message::SelectBackend::ContinueWithLocalWallet(true),
                                 ))
@@ -2382,7 +2382,7 @@ pub fn choose_backend(progress: (usize, usize)) -> Element<'static, Message> {
                     )
                     .push(
                         Container::new(
-                            button::primary(None, "Select")
+                            button::secondary(None, "Select")
                                 .on_press(Message::SelectBackend(
                                     message::SelectBackend::ContinueWithLocalWallet(false),
                                 ))
@@ -2440,7 +2440,7 @@ pub fn connection_step_enter_email<'a>(
             .warning("Email is not valid"),
         )
         .push(
-            button::primary(None, "Next")
+            button::secondary(None, "Next")
                 .on_press_maybe(if processing || !email.valid {
                     None
                 } else {
@@ -2476,11 +2476,11 @@ pub fn connection_step_enter_otp<'a>(
             Row::new()
                 .spacing(10)
                 .push(
-                    button::primary(Some(icon::previous_icon()), "Change Email")
+                    button::secondary(Some(icon::previous_icon()), "Change Email")
                         .on_press(Message::SelectBackend(message::SelectBackend::EditEmail)),
                 )
                 .push(
-                    button::primary(None, "Resend token").on_press_maybe(if processing {
+                    button::secondary(None, "Resend token").on_press_maybe(if processing {
                         None
                     } else {
                         Some(Message::SelectBackend(message::SelectBackend::RequestOTP))
@@ -2505,11 +2505,11 @@ pub fn connection_step_connected<'a>(
             Row::new()
                 .spacing(10)
                 .push(
-                    button::primary(Some(icon::previous_icon()), "Change Email")
+                    button::secondary(Some(icon::previous_icon()), "Change Email")
                         .on_press(Message::SelectBackend(message::SelectBackend::EditEmail)),
                 )
                 .push(
-                    button::primary(None, "Continue").on_press_maybe(if processing {
+                    button::secondary(None, "Continue").on_press_maybe(if processing {
                         None
                     } else {
                         Some(Message::Next)

--- a/gui/src/launcher.rs
+++ b/gui/src/launcher.rs
@@ -388,7 +388,7 @@ impl DeleteWalletModal {
         Command::none()
     }
     fn view(&self) -> Element<Message> {
-        let mut confirm_button = button::primary(None, "Delete wallet")
+        let mut confirm_button = button::secondary(None, "Delete wallet")
             .width(Length::Fixed(200.0))
             .style(theme::Button::Destructive);
         if self.warning.is_none() {

--- a/gui/src/launcher.rs
+++ b/gui/src/launcher.rs
@@ -179,7 +179,7 @@ impl Launcher {
                                 Some(self.network),
                                 ViewMessage::SelectNetwork,
                             )
-                            .style(theme::PickList::Simple)
+                            .style(theme::PickList::default())
                             .padding(10),
                         )
                         .align_items(Alignment::Center)

--- a/gui/src/lianalite/login.rs
+++ b/gui/src/lianalite/login.rs
@@ -401,7 +401,7 @@ impl LianaLiteLogin {
                                                 .padding(10)
                                                 .warning("Email is not valid"),
                                             )
-                                            .push(button::primary(None, "Next").on_press_maybe(
+                                            .push(button::secondary(None, "Next").on_press_maybe(
                                                 if self.processing {
                                                     None
                                                 } else {
@@ -427,14 +427,14 @@ impl LianaLiteLogin {
                                                 Row::new()
                                                     .spacing(10)
                                                     .push(
-                                                        button::primary(
+                                                        button::secondary(
                                                             Some(icon::previous_icon()),
                                                             "Change email",
                                                         )
                                                         .on_press(ViewMessage::EditEmail),
                                                     )
                                                     .push(
-                                                        button::primary(None, "Resend token")
+                                                        button::secondary(None, "Resend token")
                                                             .on_press_maybe(if self.processing {
                                                                 None
                                                             } else {

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -450,7 +450,7 @@ pub fn view(step: &Step) -> Element<ViewMessage> {
                     Row::new()
                         .spacing(10)
                         .push(
-                            button::border(None, "Use another Bitcoin network")
+                            button::secondary(None, "Use another Bitcoin network")
                                 .on_press(ViewMessage::SwitchNetwork),
                         )
                         .push(

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -454,7 +454,7 @@ pub fn view(step: &Step) -> Element<ViewMessage> {
                                 .on_press(ViewMessage::SwitchNetwork),
                         )
                         .push(
-                            button::primary(None, "Retry")
+                            button::secondary(None, "Retry")
                                 .width(Length::Fixed(200.0))
                                 .on_press(ViewMessage::Retry),
                         ),

--- a/gui/ui/src/theme.rs
+++ b/gui/ui/src/theme.rs
@@ -547,7 +547,7 @@ impl pick_list::StyleSheet for Theme {
         pick_list::Appearance {
             placeholder_color: color::GREY_6,
             handle_color: color::GREY_7,
-            background: color::TRANSPARENT.into(),
+            background: color::GREY_6.into(),
             border: iced::Border {
                 color: color::GREY_7,
                 width: 1.0,
@@ -561,7 +561,7 @@ impl pick_list::StyleSheet for Theme {
         pick_list::Appearance {
             placeholder_color: color::GREY_6,
             handle_color: color::GREEN,
-            background: color::TRANSPARENT.into(),
+            background: color::GREY_6.into(),
             border: iced::Border {
                 color: color::GREEN,
                 width: 1.0,
@@ -642,7 +642,7 @@ impl button::StyleSheet for Theme {
                 Button::Secondary | Button::SecondaryDestructive | Button::Border => {
                     button::Appearance {
                         shadow_offset: iced::Vector::default(),
-                        background: Some(iced::Color::TRANSPARENT.into()),
+                        background: Some(color::GREY_6.into()),
                         text_color: color::GREY_2,
                         border: iced::Border {
                             color: color::GREY_7,
@@ -654,7 +654,7 @@ impl button::StyleSheet for Theme {
                 }
                 Button::Destructive => button::Appearance {
                     shadow_offset: iced::Vector::default(),
-                    background: Some(iced::Color::TRANSPARENT.into()),
+                    background: Some(color::GREY_6.into()),
                     text_color: color::RED,
                     border: iced::Border {
                         color: color::RED,
@@ -733,7 +733,7 @@ impl button::StyleSheet for Theme {
                 },
                 Button::Secondary => button::Appearance {
                     shadow_offset: iced::Vector::default(),
-                    background: Some(iced::Color::TRANSPARENT.into()),
+                    background: Some(color::GREY_6.into()),
                     text_color: color::GREEN,
                     border: iced::Border {
                         color: color::GREEN,
@@ -766,7 +766,7 @@ impl button::StyleSheet for Theme {
                 },
                 Button::TransparentBorder | Button::Border => button::Appearance {
                     shadow_offset: iced::Vector::default(),
-                    background: Some(iced::Color::TRANSPARENT.into()),
+                    background: Some(color::GREY_6.into()),
                     text_color: color::WHITE,
                     border: iced::Border {
                         color: color::GREEN,
@@ -787,6 +787,19 @@ impl button::StyleSheet for Theme {
                     ..button::Appearance::default()
                 },
             },
+        }
+    }
+    fn disabled(&self, style: &Self::Style) -> button::Appearance {
+        let active = self.active(style);
+
+        button::Appearance {
+            shadow_offset: iced::Vector::default(),
+            background: Some(color::TRANSPARENT.into()),
+            text_color: iced::Color {
+                a: active.text_color.a * 0.5,
+                ..active.text_color
+            },
+            ..active
         }
     }
 }

--- a/gui/ui/src/theme.rs
+++ b/gui/ui/src/theme.rs
@@ -538,54 +538,37 @@ impl scrollable::StyleSheet for Theme {
 #[derive(Default, Clone)]
 pub enum PickList {
     #[default]
-    Simple,
-    Invalid,
     Secondary,
 }
 impl pick_list::StyleSheet for Theme {
     type Style = PickList;
 
-    fn active(&self, style: &Self::Style) -> pick_list::Appearance {
-        match style {
-            PickList::Simple => pick_list::Appearance {
-                placeholder_color: color::GREY_6,
-                handle_color: color::GREY_6,
-                background: color::GREEN.into(),
-                border: iced::Border {
-                    color: color::GREY_7,
-                    width: 1.0,
-                    radius: 25.0.into(),
-                },
-                text_color: iced::Color::BLACK,
+    fn active(&self, _style: &Self::Style) -> pick_list::Appearance {
+        pick_list::Appearance {
+            placeholder_color: color::GREY_6,
+            handle_color: color::GREY_7,
+            background: color::TRANSPARENT.into(),
+            border: iced::Border {
+                color: color::GREY_7,
+                width: 1.0,
+                radius: 25.0.into(),
             },
-            PickList::Invalid => pick_list::Appearance {
-                placeholder_color: color::GREY_6,
-                handle_color: color::GREY_6,
-                background: color::GREY_6.into(),
-                border: iced::Border {
-                    color: color::RED,
-                    width: 1.0,
-                    radius: 25.0.into(),
-                },
-                text_color: color::RED,
-            },
-            PickList::Secondary => pick_list::Appearance {
-                placeholder_color: color::GREY_6,
-                handle_color: color::GREY_6,
-                background: color::GREY_6.into(),
-                border: iced::Border {
-                    color: color::GREY_7,
-                    width: 1.0,
-                    radius: 25.0.into(),
-                },
-                text_color: color::GREY_2,
-            },
+            text_color: color::GREY_2,
         }
     }
 
-    fn hovered(&self, style: &Self::Style) -> pick_list::Appearance {
-        let active = self.active(style);
-        pick_list::Appearance { ..active }
+    fn hovered(&self, _style: &Self::Style) -> pick_list::Appearance {
+        pick_list::Appearance {
+            placeholder_color: color::GREY_6,
+            handle_color: color::GREEN,
+            background: color::TRANSPARENT.into(),
+            border: iced::Border {
+                color: color::GREEN,
+                width: 1.0,
+                radius: 25.0.into(),
+            },
+            text_color: color::GREEN,
+        }
     }
 }
 

--- a/gui/ui/src/theme.rs
+++ b/gui/ui/src/theme.rs
@@ -647,10 +647,10 @@ impl button::StyleSheet for Theme {
             Theme::Dark => match style {
                 Button::Primary => button::Appearance {
                     shadow_offset: iced::Vector::default(),
-                    background: Some(iced::Color::TRANSPARENT.into()),
-                    text_color: color::GREY_2,
+                    background: Some(color::GREEN.into()),
+                    text_color: color::LIGHT_BLACK,
                     border: iced::Border {
-                        color: color::GREY_7,
+                        color: color::GREEN,
                         width: 1.0,
                         radius: 25.0.into(),
                     },
@@ -750,11 +750,11 @@ impl button::StyleSheet for Theme {
                 },
                 Button::Secondary => button::Appearance {
                     shadow_offset: iced::Vector::default(),
-                    background: Some(color::GREEN.into()),
-                    text_color: color::LIGHT_BLACK,
+                    background: Some(iced::Color::TRANSPARENT.into()),
+                    text_color: color::GREEN,
                     border: iced::Border {
-                        color: color::TRANSPARENT,
-                        width: 0.0,
+                        color: color::GREEN,
+                        width: 1.0,
                         radius: 25.0.into(),
                     },
                     ..button::Appearance::default()


### PR DESCRIPTION
close #1380

We removed all the primary buttons, they will be introduced back in the GUI incrementally to follow a one primary button per page policy

The secondary button is border grey then border and text green on hover, whereas primary button will have its background green to be a call to action to the user.
The background of the secondary button is changed for a light grey in order to be consistent with items list selection.

![20241014_12h47m01s_grim](https://github.com/user-attachments/assets/d18feeba-1ea8-424e-b735-1c37ab9dbaa4)
![20241014_12h47m24s_grim](https://github.com/user-attachments/assets/ecdd69e5-674e-40a4-a784-466bccf84cfa)
![20241014_12h47m42s_grim](https://github.com/user-attachments/assets/c622f4f0-8935-4bcf-8f91-6ad87e1fb8df)
