### PR TITLE
[GUI] Don't treat wallets using bitcoind as syncing

### DIFF
--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -63,7 +63,12 @@ impl Panels {
     ) -> Panels {
         Self {
             current: Menu::Home,
-            home: Home::new(wallet.clone(), &cache.coins, cache.blockheight),
+            home: Home::new(
+                wallet.clone(),
+                &cache.coins,
+                cache.blockheight,
+                daemon_backend.clone(),
+            ),
             coins: CoinsPanel::new(&cache.coins, wallet.main_descriptor.first_timelock_value()),
             transactions: TransactionsPanel::new(wallet.clone()),
             psbts: PsbtsPanel::new(wallet.clone()),

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -242,7 +242,7 @@ impl App {
 
     pub fn stop(&mut self) {
         info!("Close requested");
-        if self.daemon.backend() == DaemonBackend::EmbeddedLianad {
+        if self.daemon.backend().is_embedded() {
             if let Err(e) = Handle::current().block_on(async { self.daemon.stop().await }) {
                 error!("{}", e);
             } else {

--- a/gui/src/app/state/settings/mod.rs
+++ b/gui/src/app/state/settings/mod.rs
@@ -62,7 +62,7 @@ impl State for SettingsState {
                     BitcoindSettingsState::new(
                         daemon.config().cloned(),
                         cache,
-                        daemon.backend() != DaemonBackend::EmbeddedLianad,
+                        !daemon.backend().is_embedded(),
                         self.internal_bitcoind,
                     )
                     .into(),

--- a/gui/src/daemon/embedded.rs
+++ b/gui/src/daemon/embedded.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use tokio::sync::Mutex;
 
-use super::{model::*, Daemon, DaemonBackend, DaemonError};
+use super::{model::*, node, Daemon, DaemonBackend, DaemonError};
 use async_trait::async_trait;
 use liana::{
     commands::{CoinStatus, LabelItem},
@@ -51,7 +51,12 @@ impl std::fmt::Debug for EmbeddedDaemon {
 #[async_trait]
 impl Daemon for EmbeddedDaemon {
     fn backend(&self) -> DaemonBackend {
-        DaemonBackend::EmbeddedLianad
+        let node_type = self
+            .config
+            .bitcoin_backend
+            .as_ref()
+            .map(node::NodeType::from);
+        DaemonBackend::EmbeddedLianad(node_type)
     }
 
     fn config(&self) -> Option<&Config> {

--- a/gui/src/daemon/mod.rs
+++ b/gui/src/daemon/mod.rs
@@ -20,7 +20,7 @@ use liana::{
     StartupError,
 };
 
-use crate::hw::HardwareWalletConfig;
+use crate::{hw::HardwareWalletConfig, node};
 
 #[derive(Debug)]
 pub enum DaemonError {
@@ -62,9 +62,15 @@ impl std::fmt::Display for DaemonError {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DaemonBackend {
-    EmbeddedLianad,
+    EmbeddedLianad(Option<node::NodeType>),
     ExternalLianad,
     RemoteBackend,
+}
+
+impl DaemonBackend {
+    pub fn is_embedded(&self) -> bool {
+        matches!(self, DaemonBackend::EmbeddedLianad(_))
+    }
 }
 
 #[async_trait]

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -22,7 +22,6 @@ use liana_ui::{
     widget::*,
 };
 
-use crate::daemon::DaemonBackend;
 use crate::{
     app::{
         cache::Cache,
@@ -227,7 +226,7 @@ impl Loader {
     pub fn stop(&mut self) {
         info!("Close requested");
         if let Step::Syncing { daemon, .. } = &mut self.step {
-            if daemon.backend() == DaemonBackend::EmbeddedLianad {
+            if daemon.backend().is_embedded() {
                 info!("Stopping internal daemon...");
                 if let Err(e) = Handle::current().block_on(async { daemon.stop().await }) {
                     warn!("Internal daemon failed to stop: {}", e);

--- a/gui/src/node/mod.rs
+++ b/gui/src/node/mod.rs
@@ -1,3 +1,5 @@
+use liana::config::BitcoinBackend;
+
 pub mod bitcoind;
 pub mod electrum;
 
@@ -5,4 +7,13 @@ pub mod electrum;
 pub enum NodeType {
     Bitcoind,
     Electrum,
+}
+
+impl From<&BitcoinBackend> for NodeType {
+    fn from(bitcoin_backend: &BitcoinBackend) -> Self {
+        match bitcoin_backend {
+            BitcoinBackend::Bitcoind(_) => Self::Bitcoind,
+            BitcoinBackend::Electrum(_) => Self::Electrum,
+        }
+    }
 }


### PR DESCRIPTION
This is a follow-up to #1370.

If the user has imported a descriptor and is using bitcoind as a local node, then they will need to perform a rescan in order 
to see past transactions. Treating the wallet as syncing in this case could mislead the user that a rescan is being performed. Therefore, it's better to keep the past behaviour here to avoid further confusion.