### PR TITLE
gui: display unconfirmed changes as confirmed

### DIFF
--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -180,6 +180,8 @@ impl State for Home {
                                 } else {
                                     self.remaining_sequence = Some(seq);
                                 }
+                            } else if coin.is_change {
+                                self.balance += coin.amount;
                             } else {
                                 self.unconfirmed_balance += coin.amount;
                             }


### PR DESCRIPTION
This PR fixes #1375.
It displays all changes as confirmed even if the coin is not in a block.
Note: we assert `is_change` means we control the coin but it's not always true: it just means the coin belongs to the change descriptor, not that the coins is controlled by this wallet. To solve this we need to add as `from_self` field in `Coins` that identify if all input of the funding tx are controlled by this wallet, this will be done in a follow-up.