### PR TITLE
Disable edit of defined key in multisig template recovery path

### DIFF
--- a/gui/src/installer/view/editor/mod.rs
+++ b/gui/src/installer/view/editor/mod.rs
@@ -128,6 +128,39 @@ pub fn path(
     .into()
 }
 
+pub fn uneditable_defined_key<'a>(
+    alias: &'a str,
+    color: iced::Color,
+    title: impl Into<Cow<'a, str>>,
+    warning: Option<&'static str>,
+) -> Element<'a, message::DefineKey> {
+    card::simple(
+        Row::new()
+            .spacing(10)
+            .width(Length::Fill)
+            .align_items(Alignment::Center)
+            .push(icon::round_key_icon().size(H3_SIZE).style(color))
+            .push(
+                Column::new()
+                    .width(Length::Fill)
+                    .spacing(5)
+                    .push(
+                        Row::new()
+                            .spacing(10)
+                            .push(p1_regular(title).style(color::GREY_2))
+                            .push(p1_bold(alias)),
+                    )
+                    .push_maybe(warning.map(|w| p2_regular(w).style(color::RED))),
+            )
+            .push_maybe(if warning.is_none() {
+                Some(icon::check_icon().style(color::GREEN))
+            } else {
+                None
+            }),
+    )
+    .into()
+}
+
 pub fn defined_key<'a>(
     alias: &'a str,
     color: iced::Color,

--- a/gui/src/installer/view/editor/template/multisig_security_wallet.rs
+++ b/gui/src/installer/view/editor/template/multisig_security_wallet.rs
@@ -15,7 +15,10 @@ use crate::installer::{
     message::{self, Message},
     step::descriptor::editor::key::Key,
     view::{
-        editor::{define_descriptor_advanced_settings, defined_key, path, undefined_key},
+        editor::{
+            define_descriptor_advanced_settings, defined_key, path, undefined_key,
+            uneditable_defined_key,
+        },
         layout,
     },
 };
@@ -168,21 +171,30 @@ pub fn multisig_security_template<'a>(
                         .enumerate()
                         .map(|(j, recovery_key)| {
                             if let Some(key) = recovery_key {
-                                defined_key(
-                                    &key.name,
-                                    if j < 2 { color::GREEN } else { color::ORANGE },
-                                    if j < 2 {
-                                        format!("Primary key #{}", j + 1)
-                                    } else {
-                                        "Recovery key".to_string()
-                                    },
-                                    if use_taproot && !key.is_compatible_taproot {
-                                        Some("Key is not compatible with Taproot")
-                                    } else {
-                                        None
-                                    },
-                                    true,
-                                )
+                                if j < 2 {
+                                    uneditable_defined_key(
+                                        &key.name,
+                                        color::GREEN,
+                                        format!("Primary key #{}", j + 1),
+                                        if use_taproot && !key.is_compatible_taproot {
+                                            Some("Key is not compatible with Taproot")
+                                        } else {
+                                            None
+                                        },
+                                    )
+                                } else {
+                                    defined_key(
+                                        &key.name,
+                                        color::ORANGE,
+                                        "Recovery key".to_string(),
+                                        if use_taproot && !key.is_compatible_taproot {
+                                            Some("Key is not compatible with Taproot")
+                                        } else {
+                                            None
+                                        },
+                                        true,
+                                    )
+                                }
                             } else {
                                 undefined_key(
                                     if j < 2 { color::GREEN } else { color::ORANGE },


### PR DESCRIPTION
The primary keys shouldn't be editable from the recovery path in the Multisig Savings template but only from the primary path. It could bring to weird behaviors and corner cases.