### PR TITLE
bump gui msrv to 1.71.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.70.0
+          - 1.71.1
           - nightly
         os:
           - ubuntu-latest

--- a/contrib/reproducible/docker/macos.Dockerfile
+++ b/contrib/reproducible/docker/macos.Dockerfile
@@ -24,26 +24,26 @@ RUN apt update && apt satisfy -y \
                     "curl (>=7.74, <=7.74)"
 
 # Download the cargo binary and compiled stdlib from the distributed releases to make sure to build with
-# the very same toolchain. We use 1.70.0 because it is unfortunately the MSRV of the GUI.
-RUN curl -O "https://static.rust-lang.org/dist/rust-1.70.0-x86_64-unknown-linux-gnu.tar.gz" && \
-    echo "8499c0b034dd881cd9a880c44021632422a28dc23d7a81ca0a97b04652245982 rust-1.70.0-x86_64-unknown-linux-gnu.tar.gz" | sha256sum -c && \
-    tar -xzf rust-1.70.0-x86_64-unknown-linux-gnu.tar.gz && \
-    curl -O "https://static.rust-lang.org/dist/rust-1.70.0-x86_64-apple-darwin.tar.gz" && \
-    echo "e5819fdbfc7f1a4d5d82cb4c3b7662250748450b45a585433bfb75648bc45547 rust-1.70.0-x86_64-apple-darwin.tar.gz" | sha256sum -c  && \
-    tar -xzf rust-1.70.0-x86_64-apple-darwin.tar.gz && \
+# the very same toolchain. We use 1.71.1 because it is unfortunately the MSRV of the GUI.
+RUN curl -O "https://static.rust-lang.org/dist/rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz" && \
+    echo "34778d1cda674990dfc0537bc600066046ae9cb5d65a07809f7e7da31d4689c4 rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz" | sha256sum -c && \
+    tar -xzf rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz && \
+    curl -O "https://static.rust-lang.org/dist/rust-1.71.1-x86_64-apple-darwin.tar.gz" && \
+    echo "916056603da88336aba68bbeab49711cc8fdb9cfb46a49b04850c0c09761f58c rust-1.71.1-x86_64-apple-darwin.tar.gz" | sha256sum -c  && \
+    tar -xzf rust-1.71.1-x86_64-apple-darwin.tar.gz && \
     rm -r *.tar.gz
 
 # NOTE: we were previously caching dependencies here (through `cargo vendor`). It's a tradeoff between the image size
 # and not needing internet access when running the image to build the software.
 
 # For some reason, we can't just set the RUSTFLAGS environment variable to add `-L` for compiling dependencies.
-# This doesn't work: RUSTFLAGS="-L/liana/rust-1.70.0-x86_64-apple-darwin/rust-std-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/"
+# This doesn't work: RUSTFLAGS="-L/liana/rust-1.71.1-x86_64-apple-darwin/rust-std-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/"
 # As a workaround, we use a wrapped `rustc` binary that always links against the macOS stdlib we just downloaded.
 # Some issues that seem to be related:
 # https://github.com/rust-lang/rust/issues/40717
 # https://github.com/rust-lang/rust/issues/48409
 RUN echo "#!/bin/sh" > rustc_wrapper.sh && \
-    echo "/liana/rust-1.70.0-x86_64-unknown-linux-gnu/rustc/bin/rustc \"\$@\" -L/liana/rust-1.70.0-x86_64-apple-darwin/rust-std-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/ -L/liana/rust-1.70.0-x86_64-unknown-linux-gnu/rust-std-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/" >> rustc_wrapper.sh && \
+    echo "/liana/rust-1.71.1-x86_64-unknown-linux-gnu/rustc/bin/rustc \"\$@\" -L/liana/rust-1.71.1-x86_64-apple-darwin/rust-std-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/ -L/liana/rust-1.71.1-x86_64-unknown-linux-gnu/rust-std-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/" >> rustc_wrapper.sh && \
     chmod +x rustc_wrapper.sh
 ENV RUSTC="/liana/rustc_wrapper.sh"
 

--- a/contrib/reproducible/docker/macos_cmd.sh
+++ b/contrib/reproducible/docker/macos_cmd.sh
@@ -27,7 +27,7 @@ DARLING_DMG_REVISION=241238313a47d3cf6427ac5a75b7a0311a3a4cb4 \
 cd ..
 
 # Finally build the projects using the toolchain just created.
-alias cargo="/liana/rust-1.70.0-x86_64-unknown-linux-gnu/cargo/bin/cargo"
+alias cargo="/liana/rust-1.71.1-x86_64-unknown-linux-gnu/cargo/bin/cargo"
 
 PATH="$PATH:$PWD/osxcross/target/bin/" \
     CC=o64-clang \

--- a/contrib/reproducible/docker/windows.Dockerfile
+++ b/contrib/reproducible/docker/windows.Dockerfile
@@ -10,26 +10,26 @@ RUN apt update && apt satisfy -y \
                     "gcc (>=10.2, <=10.2)"
 
 # Download the cargo binary and compiled stdlib from the distributed releases to make sure to build with
-# the very same toolchain. We use 1.70.0 because it is unfortunately the MSRV of the GUI.
-RUN curl -O "https://static.rust-lang.org/dist/rust-1.70.0-x86_64-unknown-linux-gnu.tar.gz" && \
-    echo "8499c0b034dd881cd9a880c44021632422a28dc23d7a81ca0a97b04652245982 rust-1.70.0-x86_64-unknown-linux-gnu.tar.gz" | sha256sum -c && \
-    tar -xzf rust-1.70.0-x86_64-unknown-linux-gnu.tar.gz && \
-    curl -O "https://static.rust-lang.org/dist/rust-1.70.0-x86_64-pc-windows-gnu.tar.gz" && \
-    echo "52945bf6ab861d05be100e88a95766760d2daff1a0c0a2eff32a7fd8071495bd rust-1.70.0-x86_64-pc-windows-gnu.tar.gz" | sha256sum -c  && \
-    tar -xzf rust-1.70.0-x86_64-pc-windows-gnu.tar.gz && \
+# the very same toolchain. We use 1.71.1 because it is unfortunately the MSRV of the GUI.
+RUN curl -O "https://static.rust-lang.org/dist/rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz" && \
+    echo "34778d1cda674990dfc0537bc600066046ae9cb5d65a07809f7e7da31d4689c4 rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz" | sha256sum -c && \
+    tar -xzf rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz && \
+    curl -O "https://static.rust-lang.org/dist/rust-1.71.1-x86_64-pc-windows-gnu.tar.gz" && \
+    echo "15289233721ad7c3d697890d9c6079ca3b8a0f6740c080fbec3e8ae3a5ea5c8c rust-1.71.1-x86_64-pc-windows-gnu.tar.gz" | sha256sum -c  && \
+    tar -xzf rust-1.71.1-x86_64-pc-windows-gnu.tar.gz && \
     rm -r *.tar.gz
 
 # NOTE: we were previously caching dependencies here (through `cargo vendor`). It's a tradeoff between the image size
 # and not needing internet access when running the image to build the software.
 
 # For some reason, we can't just set the RUSTFLAGS environment variable to add `-L` for compiling dependencies.
-# This doesn't work: RUSTFLAGS="-L /liana/rust-1.70.0-x86_64-pc-windows-gnu/rust-std-x86_64-pc-windows-gnu/lib/rustlib/x86_64-pc-windows-gnu/lib/ -L /liana/rust-1.70.0-x86_64-unknown-linux-gnu/rust-std-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/"
+# This doesn't work: RUSTFLAGS="-L /liana/rust-1.71.1-x86_64-pc-windows-gnu/rust-std-x86_64-pc-windows-gnu/lib/rustlib/x86_64-pc-windows-gnu/lib/ -L /liana/rust-1.71.1-x86_64-unknown-linux-gnu/rust-std-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/"
 # As a workaround, we use a wrapped `rustc` binary that always links against the windows stdlib we just downloaded.
 # Some issues that seem to be related:
 # https://github.com/rust-lang/rust/issues/40717
 # https://github.com/rust-lang/rust/issues/48409
 RUN echo "#!/bin/sh" > rustc_wrapper.sh && \
-    echo "/liana/rust-1.70.0-x86_64-unknown-linux-gnu/rustc/bin/rustc \"\$@\" -L /liana/rust-1.70.0-x86_64-pc-windows-gnu/rust-std-x86_64-pc-windows-gnu/lib/rustlib/x86_64-pc-windows-gnu/lib/ -L /liana/rust-1.70.0-x86_64-unknown-linux-gnu/rust-std-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/" >> rustc_wrapper.sh && \
+    echo "/liana/rust-1.71.1-x86_64-unknown-linux-gnu/rustc/bin/rustc \"\$@\" -L /liana/rust-1.71.1-x86_64-pc-windows-gnu/rust-std-x86_64-pc-windows-gnu/lib/rustlib/x86_64-pc-windows-gnu/lib/ -L /liana/rust-1.71.1-x86_64-unknown-linux-gnu/rust-std-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/" >> rustc_wrapper.sh && \
     chmod +x rustc_wrapper.sh
 ENV RUSTC="/liana/rustc_wrapper.sh"
 

--- a/contrib/reproducible/docker/windows_cmd.sh
+++ b/contrib/reproducible/docker/windows_cmd.sh
@@ -8,7 +8,7 @@ set -xe
 
 # Build the GUI for Windows. The Windows Portable Execution (PE) format contains some timestamps.
 # Instruct ld to set them to 0.
-alias cargo="/liana/rust-1.70.0-x86_64-unknown-linux-gnu/cargo/bin/cargo"
+alias cargo="/liana/rust-1.71.1-x86_64-unknown-linux-gnu/cargo/bin/cargo"
 RUSTFLAGS="-Clink-arg=-Wl,--no-insert-timestamp" \
     cargo rustc \
         --release \

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -12,7 +12,7 @@ community).  See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the currently minim
 supported by `lianad`.
 
 To build the GUI too, you'll unfortunately need a more recent Rust version. The minimum version
-supported by the GUI at the moment is `1.70`. You will most likely have to [manually download
+supported by the GUI at the moment is `1.71.1`. You will most likely have to [manually download
 it](#by-manually-downloading-the-latest-stable-version) or [use `rustup`](#through-rustup) to
 install more recent compilers.
 
@@ -50,11 +50,11 @@ And then you can download the archive corresponding to your system and CPU archi
 signature and use the `cargo` binary from this archive to build Liana. Here is an example for
 `amd64`:
 ```
-$ curl -O https://static.rust-lang.org/dist/rust-1.70.0-x86_64-unknown-linux-gnu.tar.gz
-$ curl -O https://static.rust-lang.org/dist/rust-1.70.0-x86_64-unknown-linux-gnu.tar.gz.asc
-$ gpg --verify rust-1.70.0-x86_64-unknown-linux-gnu.tar.gz.asc
-$ tar -xzf rust-1.70.0-x86_64-unknown-linux-gnu.tar.gz
-$ ./rust-1.70.0-x86_64-unknown-linux-gnu/cargo/bin/cargo build --release
+$ curl -O https://static.rust-lang.org/dist/rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz
+$ curl -O https://static.rust-lang.org/dist/rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz.asc
+$ gpg --verify rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz.asc
+$ tar -xzf rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz
+$ ./rust-1.71.1-x86_64-unknown-linux-gnu/cargo/bin/cargo build --release
 ```
 
 ### Through `rustup`

--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -199,13 +199,14 @@ dependencies = [
 
 [[package]]
 name = "async-hwi"
-version = "0.0.23"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5e1703fc8cf217444fde8f3fdcf44382a1dec3afe5430620aa1b421c692b58"
+checksum = "fcf04ab1f98dc35aaa409cfd4dc44ea8d1d5af1dbed8dc34fc0cacdd1e30dcc5"
 dependencies = [
  "async-trait",
  "bitbox-api",
- "bitcoin",
+ "bitcoin 0.31.1",
+ "bitcoin 0.32.4",
  "coldcard",
  "futures",
  "hidapi",
@@ -279,6 +280,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,7 +322,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c601c4dc7e6c3efa538a0afbb43b964cefab9a9b5e8f352fa0ca38145448a5e7"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.31.1",
  "miniscript",
 ]
 
@@ -336,6 +347,12 @@ name = "bech32"
 version = "0.10.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bip39"
@@ -371,21 +388,22 @@ checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitbox-api"
-version = "0.2.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c0e1d593628bd289304902364f69c24686734d1825c54e03d89e003aa87b4f"
+checksum = "8349407999d3653dbbd3f75182742a6c8ad73f424ef83fcf5b87ead0c8ce2528"
 dependencies = [
  "async-trait",
  "base32",
- "bitcoin",
+ "bitcoin 0.32.4",
  "byteorder",
+ "chrono",
  "getrandom",
  "hex",
  "hidapi",
  "noise-protocol",
  "noise-rust-crypto",
  "num-bigint",
- "prost 0.12.2",
+ "prost 0.13.3",
  "prost-build",
  "semver",
  "serde",
@@ -402,13 +420,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd00f3c09b5f21fb357abe32d29946eb8bb7a0862bae62c0b5e4a692acbbe73c"
 dependencies = [
  "base64 0.21.6",
- "bech32",
- "bitcoin-internals",
+ "bech32 0.10.0-beta",
+ "bitcoin-internals 0.2.0",
  "bitcoin_hashes 0.13.0",
  "core2",
- "hex-conservative",
+ "hex-conservative 0.1.1",
  "hex_lit",
- "secp256k1",
+ "secp256k1 0.28.1",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
+dependencies = [
+ "base58ck",
+ "base64 0.21.6",
+ "bech32 0.11.0",
+ "bitcoin-internals 0.3.0",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
+ "hex_lit",
+ "secp256k1 0.29.1",
  "serde",
 ]
 
@@ -422,10 +459,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
+
+[[package]]
 name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "serde",
+]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -448,9 +510,20 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-internals 0.2.0",
  "core2",
- "hex-conservative",
+ "hex-conservative 0.1.1",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.1",
  "serde",
 ]
 
@@ -1291,7 +1364,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89008f106be6f303695522f2f4c1f28b40c3e8367ed8b3bb227f1f882cb52cc2"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.31.1",
  "byteorder",
  "libc",
  "log",
@@ -1989,6 +2062,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2617,7 +2699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8606a9c7375fb139e68fc1ca7cf9c6709566eeca448ff33e37632d8a4302eefe"
 dependencies = [
  "async-trait",
- "bitcoin",
+ "bitcoin 0.31.1",
  "miniscript",
 ]
 
@@ -2679,7 +2761,7 @@ dependencies = [
 name = "liana_ui"
 version = "0.1.0"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.31.1",
  "chrono",
  "iced",
 ]
@@ -2955,9 +3037,9 @@ version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86a23dd3ad145a980e231185d114399f25a0a307d2cd918010ddda6334323df9"
 dependencies = [
- "bech32",
- "bitcoin",
- "bitcoin-internals",
+ "bech32 0.10.0-beta",
+ "bitcoin 0.31.1",
+ "bitcoin-internals 0.2.0",
  "serde",
 ]
 
@@ -3684,12 +3766,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5a410fc7882af66deb8d01d01737353cf3ad6204c408177ba494291a626312"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
  "bytes",
- "prost-derive 0.12.2",
+ "prost-derive 0.13.3",
 ]
 
 [[package]]
@@ -3729,12 +3811,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065717a5dfaca4a83d2fe57db3487b311365200000551d7a364e715dbf4346bc"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -4257,8 +4339,19 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f622567e3b4b38154fb8190bcf6b160d7a4301d70595a49195b48c116007a27"
 dependencies = [
- "bitcoin_hashes 0.12.0",
- "secp256k1-sys",
+ "bitcoin_hashes 0.13.0",
+ "secp256k1-sys 0.9.2",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "bitcoin_hashes 0.13.0",
+ "secp256k1-sys 0.10.1",
  "serde",
 ]
 
@@ -4267,6 +4360,15 @@ name = "secp256k1-sys"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]

--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 async-trait = "0.1"
-async-hwi = { version = "0.0.23" }
+async-hwi = { version = "0.0.24" }
 liana = { git = "https://github.com/wizardsardine/liana", branch = "master", default-features = false, features = ["nonblocking_shutdown"] }
 liana_ui = { path = "ui" }
 backtrace = "0.3"


### PR DESCRIPTION
This PR updates our build system to use rust 1.71.1, required by the last version of async-hwi 