### PR TITLE
gui(installer): add space at bottom of pages

### DIFF
--- a/gui/src/installer/view/editor/template/custom.rs
+++ b/gui/src/installer/view/editor/template/custom.rs
@@ -46,6 +46,7 @@ pub fn custom_template_description(progress: (usize, usize)) -> Element<'static,
                 .horizontal_alignment(alignment::Horizontal::Left)
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
             .push(Row::new().push(Space::with_width(Length::Fill)).push(button::primary(None, "Select").width(Length::Fixed(200.0)).on_press(Message::Next)))
+            .push(Space::with_height(50.0))
             .spacing(20),
         true,
         Some(Message::Previous),

--- a/gui/src/installer/view/editor/template/inheritance.rs
+++ b/gui/src/installer/view/editor/template/inheritance.rs
@@ -57,6 +57,7 @@ After a period of inactivity (but not before that) your Inheritance Key will bec
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
             .push(image::inheritance_template_description().width(Length::Fill))
             .push(Row::new().push(Space::with_width(Length::Fill)).push(button::primary(None, "Select").width(Length::Fixed(200.0)).on_press(Message::Next)))
+            .push(Space::with_height(50.0))
             .spacing(20),
         true,
         Some(Message::Previous),

--- a/gui/src/installer/view/editor/template/multisig_security_wallet.rs
+++ b/gui/src/installer/view/editor/template/multisig_security_wallet.rs
@@ -67,6 +67,7 @@ pub fn multisig_security_template_description(
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
             .push(image::multisig_security_template_description().width(Length::Fill))
             .push(Row::new().push(Space::with_width(Length::Fill)).push(button::primary(None, "Select").width(Length::Fixed(200.0)).on_press(Message::Next)))
+            .push(Space::with_height(50.0))
             .spacing(20),
         true,
         Some(Message::Previous),

--- a/gui/src/installer/view/mod.rs
+++ b/gui/src/installer/view/mod.rs
@@ -758,6 +758,7 @@ pub fn backup_descriptor<'a>(
             } else {
                 button::secondary(None, "Next").width(Length::Fixed(200.0))
             })
+            .push(Space::with_height(20.0))
             .spacing(50),
         true,
         Some(Message::Previous),
@@ -1682,6 +1683,7 @@ pub fn backup_mnemonic<'a>(
             } else {
                 button::secondary(None, "Next").width(Length::Fixed(200.0))
             })
+            .push(Space::with_height(20.0))
             .spacing(50),
         true,
         Some(Message::Previous),


### PR DESCRIPTION
This is to fix #1410, including for the mnemonic and descriptor backup steps.

The space height in all cases will be 70.0 when combined with the existing vertical spacing between elements.