### PR TITLE
gui(installer): re-add next button when starting managed bitcoind

### DIFF
--- a/gui/src/installer/view/mod.rs
+++ b/gui/src/installer/view/mod.rs
@@ -1360,7 +1360,17 @@ pub fn start_internal_bitcoind<'a>(
                 }
             })
             .spacing(50)
-            .push(Row::new())
+            .push(
+                Row::new().push(
+                    button::secondary(None, "Next")
+                        .width(Length::Fixed(200.0))
+                        .on_press_maybe(if let Some(Ok(_)) = started {
+                            Some(Message::Next)
+                        } else {
+                            None
+                        }),
+                ),
+            )
             .push_maybe(error.map(|e| card::invalid(text(e)))),
         true,
         Some(message::Message::InternalBitcoind(


### PR DESCRIPTION
This Next button was accidentally removed in commit bd03cc9cfffb7c5c45dd0dd60d54db807d4e02a2.