### PR TITLE
gui(installer): change collapse icon from left arrow to righ arrow

### DIFF
--- a/liana-ui/src/icon.rs
+++ b/liana-ui/src/icon.rs
@@ -92,7 +92,7 @@ pub fn pencil_icon() -> Text<'static> {
 }
 
 pub fn collapse_icon() -> Text<'static> {
-    bootstrap_icon('\u{F284}')
+    bootstrap_icon('\u{F285}')
 }
 
 pub fn collapsed_icon() -> Text<'static> {


### PR DESCRIPTION
Fixes #1416 

![image](https://github.com/user-attachments/assets/8bcc3cbe-0db5-41aa-bd54-7e1a069aaaa9)
