### PR TITLE
Refresh cache more often in GUI while wallet or blockchain is syncing

### DIFF
--- a/gui/src/app/cache.rs
+++ b/gui/src/app/cache.rs
@@ -10,7 +10,10 @@ pub struct Cache {
     pub coins: Vec<Coin>,
     pub rescan_progress: Option<f64>,
     pub sync_progress: f64,
+    /// The most recent `last_poll_timestamp`.
     pub last_poll_timestamp: Option<u32>,
+    /// The `last_poll_timestamp` when starting the application.
+    pub last_poll_at_startup: Option<u32>,
 }
 
 /// only used for tests.
@@ -24,6 +27,7 @@ impl std::default::Default for Cache {
             rescan_progress: None,
             sync_progress: 1.0,
             last_poll_timestamp: None,
+            last_poll_at_startup: None,
         }
     }
 }

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -284,6 +284,7 @@ impl App {
                 let daemon = self.daemon.clone();
                 let datadir_path = self.cache.datadir_path.clone();
                 let network = self.cache.network;
+                let last_poll_at_startup = self.cache.last_poll_at_startup;
                 Command::perform(
                     async move {
                         // we check every 10 second if the daemon poller is alive
@@ -302,6 +303,7 @@ impl App {
                             rescan_progress: info.rescan_progress,
                             sync_progress: info.sync,
                             last_poll_timestamp: info.last_poll_timestamp,
+                            last_poll_at_startup, // doesn't change
                         })
                     },
                     Message::UpdateCache,

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -67,10 +67,13 @@ impl Panels {
             home: Home::new(
                 wallet.clone(),
                 &cache.coins,
-                cache.blockheight,
-                cache.sync_progress,
-                cache.last_poll_timestamp,
-                daemon_backend.clone(),
+                sync_status(
+                    daemon_backend.clone(),
+                    cache.blockheight,
+                    cache.sync_progress,
+                    cache.last_poll_timestamp,
+                    cache.last_poll_at_startup,
+                ),
             ),
             coins: CoinsPanel::new(&cache.coins, wallet.main_descriptor.first_timelock_value()),
             transactions: TransactionsPanel::new(wallet.clone()),

--- a/gui/src/app/mod.rs
+++ b/gui/src/app/mod.rs
@@ -231,16 +231,12 @@ impl App {
     pub fn subscription(&self) -> Subscription<Message> {
         Subscription::batch(vec![
             time::every(Duration::from_secs(
-                // Note that for now we pass `None` for `last_poll_at_startup`,
-                // which means the `LatestWalletSync` status will not be returned
-                // unless the last poll is also `None`.
-                // TODO: Store last poll at startup and use it here.
                 match sync_status(
                     self.daemon.backend(),
                     self.cache.blockheight,
                     self.cache.sync_progress,
                     self.cache.last_poll_timestamp,
-                    None,
+                    self.cache.last_poll_at_startup,
                 ) {
                     SyncStatus::BlockchainSync(_) => 5, // Only applies to local backends
                     SyncStatus::WalletFullScan

--- a/gui/src/app/state/mod.rs
+++ b/gui/src/app/state/mod.rs
@@ -25,17 +25,14 @@ use super::{
     menu::Menu,
     message::Message,
     view,
-    wallet::{SyncStatus, Wallet},
+    wallet::{sync_status, SyncStatus, Wallet},
 };
 
 pub const HISTORY_EVENT_PAGE_SIZE: u64 = 20;
 
-use crate::{
-    daemon::{
-        model::{remaining_sequence, Coin, HistoryTransaction, Labelled},
-        Daemon, DaemonBackend,
-    },
-    node::NodeType,
+use crate::daemon::{
+    model::{remaining_sequence, Coin, HistoryTransaction, Labelled},
+    Daemon, DaemonBackend,
 };
 pub use coins::CoinsPanel;
 use label::LabelsEdited;
@@ -74,45 +71,6 @@ pub fn redirect(menu: Menu) -> Command<Message> {
     Command::perform(async { menu }, |menu| {
         Message::View(view::Message::Menu(menu))
     })
-}
-
-fn sync_status(
-    daemon_backend: DaemonBackend,
-    blockheight: i32,
-    sync_progress: f64,
-    last_poll: Option<u32>,
-    last_poll_at_startup: Option<u32>,
-) -> SyncStatus {
-    if sync_progress < 1.0 {
-        return SyncStatus::BlockchainSync(sync_progress);
-    } else if blockheight <= 0 {
-        // If blockheight <= 0, then this is a newly created wallet.
-        // If user imported descriptor and is using a local bitcoind, a rescan
-        // will need to be performed in order to see past transactions and so the
-        // syncing status could be misleading as it could suggest the rescan is
-        // being performed.
-        // For external daemon or if we otherwise don't know the node type,
-        // treat it the same as bitcoind to be sure we don't mislead the user.
-        if daemon_backend == DaemonBackend::RemoteBackend
-            || daemon_backend == DaemonBackend::EmbeddedLianad(Some(NodeType::Electrum))
-        {
-            return SyncStatus::WalletFullScan;
-        }
-    }
-    // For an existing wallet with any local node type, if the first poll has
-    // not completed, then the wallet has not yet caught up with the tip.
-    // An existing wallet with remote backend remains synced so we can ignore it.
-    // If external daemon, we cannot be sure it will return last poll as it
-    // depends on the version, so assume it won't unless the last poll at
-    // startup is set.
-    // TODO: should we check the daemon version at GUI startup?
-    else if last_poll <= last_poll_at_startup
-        && (daemon_backend.is_embedded()
-            || (daemon_backend == DaemonBackend::ExternalLianad && last_poll_at_startup.is_some()))
-    {
-        return SyncStatus::LatestWalletSync;
-    }
-    SyncStatus::Synced
 }
 
 pub struct Home {

--- a/gui/src/loader.rs
+++ b/gui/src/loader.rs
@@ -407,7 +407,9 @@ pub async fn load_application(
         blockheight: info.block_height,
         coins,
         sync_progress: info.sync,
+        // Both last poll fields start with the same value.
         last_poll_timestamp: info.last_poll_timestamp,
+        last_poll_at_startup: info.last_poll_timestamp,
         ..Default::default()
     };
 

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -462,7 +462,9 @@ pub fn create_app_with_remote_backend(
             sync_progress: 1.0, // Remote backend is always synced
             datadir_path: datadir.clone(),
             blockheight: wallet.tip_height.unwrap_or(0),
-            last_poll_timestamp: None, // We ignore this field for remote backend.
+            // We ignore last poll fields for remote backend.
+            last_poll_timestamp: None,
+            last_poll_at_startup: None,
         },
         Arc::new(
             Wallet::new(wallet.descriptor)


### PR DESCRIPTION
This is to resolve #1414.

In the end, I felt it was simple enough to include commits that cover both parts of #1414 (the short-term change and the follow-up).

I start with the short-term change (setting the refresh interval ignoring the last poll logic) and then follow with commits that cover all syncing statuses.

I don't use as high a refresh frequency for a remote backend as for a local backend, but these values can be easily changed if required.