### PR TITLE
gui(installer): align title & descrpition in path cards

### DIFF
--- a/gui/src/installer/view/editor/mod.rs
+++ b/gui/src/installer/view/editor/mod.rs
@@ -97,7 +97,7 @@ pub fn path(
     Container::new(
         Column::new()
             .spacing(10)
-            .push_maybe(title.map(p1_bold))
+            .push_maybe(title.map(|t| Row::new().push(Space::with_width(10)).push(p1_bold(t))))
             .push(defined_sequence(sequence, duplicate_sequence))
             .push(
                 Column::new()


### PR DESCRIPTION
fixes #1427
![image](https://github.com/user-attachments/assets/4bf68994-6bb7-4929-9a98-8cda7a4039fd)
