### PR TITLE
gui(installer): better warn. if a signer is not compatible w/ tapminiscript

### DIFF
--- a/gui/src/installer/view/editor/template/custom.rs
+++ b/gui/src/installer/view/editor/template/custom.rs
@@ -115,7 +115,7 @@ pub fn custom_template<'a>(
                                     color::GREEN,
                                     "Primary key",
                                     if use_taproot && !key.is_compatible_taproot {
-                                        Some("Key is not compatible with taproot")
+                                        Some("This device does not support Taproot")
                                     } else {
                                         None
                                     },
@@ -157,7 +157,7 @@ pub fn custom_template<'a>(
                                             color::ORANGE,
                                             "Recovery key",
                                             if use_taproot && !key.is_compatible_taproot {
-                                                Some("Key is not compatible with Taproot")
+                                                Some("This device does not support Taproot")
                                             } else {
                                                 None
                                             },

--- a/gui/src/installer/view/editor/template/inheritance.rs
+++ b/gui/src/installer/view/editor/template/inheritance.rs
@@ -114,7 +114,7 @@ pub fn inheritance_template<'a>(
                             color::GREEN,
                             "Primary key",
                             if use_taproot && !key.is_compatible_taproot {
-                                Some("Key is not compatible with Taproot")
+                                Some("This device does not support Taproot")
                             } else {
                                 None
                             },
@@ -141,7 +141,7 @@ pub fn inheritance_template<'a>(
                             color::WHITE,
                             "Inheritance key",
                             if use_taproot && !key.is_compatible_taproot {
-                                Some("Key is not compatible with taproot")
+                                Some("This device does not support Taproot")
                             } else {
                                 None
                             },

--- a/gui/src/installer/view/editor/template/multisig_security_wallet.rs
+++ b/gui/src/installer/view/editor/template/multisig_security_wallet.rs
@@ -129,7 +129,7 @@ pub fn multisig_security_template<'a>(
                                     color::GREEN,
                                     format!("Primary key #{}", i + 1),
                                     if use_taproot && !key.is_compatible_taproot {
-                                        Some("Key is not compatible with taproot")
+                                        Some("This device does not support Taproot")
                                     } else {
                                         None
                                     },
@@ -177,7 +177,7 @@ pub fn multisig_security_template<'a>(
                                         color::GREEN,
                                         format!("Primary key #{}", j + 1),
                                         if use_taproot && !key.is_compatible_taproot {
-                                            Some("Key is not compatible with Taproot")
+                                            Some("This device does not support Taproot")
                                         } else {
                                             None
                                         },
@@ -188,7 +188,7 @@ pub fn multisig_security_template<'a>(
                                         color::ORANGE,
                                         "Recovery key".to_string(),
                                         if use_taproot && !key.is_compatible_taproot {
-                                            Some("Key is not compatible with Taproot")
+                                            Some("This device does not support Taproot")
                                         } else {
                                             None
                                         },

--- a/gui/src/installer/view/mod.rs
+++ b/gui/src/installer/view/mod.rs
@@ -1559,8 +1559,6 @@ pub fn hw_list_view(
         } => {
             if chosen && processing {
                 hw::processing_hardware_wallet(kind, version.as_ref(), fingerprint, alias.as_ref())
-            } else if selected {
-                hw::selected_hardware_wallet(kind, version.as_ref(), fingerprint, alias.as_ref())
             } else if device_must_support_taproot
                 && !is_compatible_with_tapminiscript(kind, version.as_ref())
             {
@@ -1571,6 +1569,8 @@ pub fn hw_list_view(
                     alias.as_ref(),
                     "Device firmware version does not support taproot miniscript",
                 )
+            } else if selected {
+                hw::selected_hardware_wallet(kind, version.as_ref(), fingerprint, alias.as_ref())
             } else {
                 hw::supported_hardware_wallet(kind, version.as_ref(), fingerprint, alias.as_ref())
             }


### PR DESCRIPTION
- replace this warning:
![image](https://github.com/user-attachments/assets/113f9608-a695-4389-8c53-f0da40fcb04f)
by this one:
![image](https://github.com/user-attachments/assets/da666783-88ef-466c-a16a-5619c122d687)


- before if a non tap miniscript compatible device was selected, the selected icon was displayed, now the warning icon have priority:
![image](https://github.com/user-attachments/assets/54b0e44e-c169-4aa0-b45d-7609b735cee2)
