### PR TITLE
gui: reload home if wallet is not syncing

### DIFF
--- a/liana-gui/src/app/state/mod.rs
+++ b/liana-gui/src/app/state/mod.rs
@@ -313,8 +313,11 @@ impl State for Home {
         daemon: Arc<dyn Daemon + Sync + Send>,
         wallet: Arc<Wallet>,
     ) -> Command<Message> {
-        // Wait for wallet to finish syncing before reloading data.
-        if !self.sync_status.is_synced() {
+        // If the wallet is syncing, we expect it to finish soon and so better to wait for
+        // updated data before reloading. Besides, if the wallet is syncing, the DB may be
+        // locked if the poller is running and we wouldn't be able to reload data until
+        // syncing completes anyway.
+        if self.sync_status.wallet_is_syncing() {
             return Command::none();
         }
         self.selected_event = None;

--- a/liana-gui/src/app/wallet.rs
+++ b/liana-gui/src/app/wallet.rs
@@ -207,6 +207,11 @@ impl SyncStatus {
     pub fn is_synced(&self) -> bool {
         self == &SyncStatus::Synced
     }
+
+    /// Whether the wallet itself, and not the blockchain, is syncing.
+    pub fn wallet_is_syncing(&self) -> bool {
+        self == &SyncStatus::WalletFullScan || self == &SyncStatus::LatestWalletSync
+    }
 }
 
 /// Get the [`SyncStatus`].


### PR DESCRIPTION
Following #1386, this PR will show past payments on the home page while the blockchain is still syncing. Currently, these are not loaded until the wallet has finished syncing.

This change won't apply if the wallet itself is still syncing. The reason is that this is not expected to take so long and so it's better to wait for the updated data. Furthermore, the DB may be locked if the poller is running, in which case we wouldn't be able to load past transactions until the wallet has synced anyway. The home page reloads automatically as soon as the wallet finishes syncing.