### PR TITLE
gui(installer): list wallets using secondary buttons

### DIFF
--- a/gui/src/installer/view/mod.rs
+++ b/gui/src/installer/view/mod.rs
@@ -60,6 +60,7 @@ pub fn import_wallet_or_descriptor<'a>(
     for (i, wallet) in wallets.into_iter().enumerate() {
         col_wallets = col_wallets.push(
             Button::new(h5_regular(wallet).width(Length::Fill))
+                .style(theme::Button::Secondary)
                 .padding(10)
                 .on_press(Message::Select(i)),
         );


### PR DESCRIPTION
This is to fix #1445:

![image](https://github.com/user-attachments/assets/007ec779-f5b5-468b-825b-865106716f31)
