### PR TITLE
Use 2 decimal for sync progression in home page

### DIFF
--- a/gui/Cargo.lock
+++ b/gui/Cargo.lock
@@ -2706,7 +2706,7 @@ dependencies = [
 [[package]]
 name = "liana"
 version = "8.0.0"
-source = "git+https://github.com/wizardsardine/liana?branch=master#89299f60b4f1616ea0cb48aecd4763a5228f24d5"
+source = "git+https://github.com/wizardsardine/liana?branch=master#b46efc6cf47083b1cc2c66be88a31ea060b9fc88"
 dependencies = [
  "backtrace",
  "bdk_coin_select",
@@ -4339,7 +4339,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f622567e3b4b38154fb8190bcf6b160d7a4301d70595a49195b48c116007a27"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.13.0",
  "secp256k1-sys 0.9.2",
  "serde",
 ]
@@ -4350,7 +4350,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.14.0",
  "secp256k1-sys 0.10.1",
  "serde",
 ]

--- a/gui/src/app/view/home.rs
+++ b/gui/src/app/view/home.rs
@@ -63,7 +63,7 @@ pub fn home_view<'a>(
                             .push(
                                 match sync_status {
                                     SyncStatus::BlockchainSync(progress) => text(format!(
-                                        "Syncing blockchain ({:.1}%)",
+                                        "Syncing blockchain ({:.2}%)",
                                         100.0 * *progress
                                     )),
                                     SyncStatus::WalletFullScan => text("Syncing"),


### PR DESCRIPTION
Did the update for the home page.
For the loading screen (IBD) it was already formatting with 2 decimal, see `loader.rs:450`

Solves #907 