### PR TITLE
tests: notifyAll() is deprecated, replace w/ notify_all()

### DIFF
--- a/tests/test_framework/utils.py
+++ b/tests/test_framework/utils.py
@@ -372,7 +372,7 @@ class TailableProc(object):
                 logging.debug(f"{self.prefix}: {line.decode().rstrip()}")
             with self.logs_cond:
                 self.logs.append(str(line.rstrip()))
-                self.logs_cond.notifyAll()
+                self.logs_cond.notify_all()
         self.running = False
         self.proc.stdout.close()
         if self.proc.stderr is not None:


### PR DESCRIPTION
closes #1253 