### PR TITLE
commands: indicate in `listcoins` response whether coin is from self

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -135,6 +135,7 @@ A coin may have one of the following four statuses:
 | `spend_info`       | object        | Information about the transaction spending this coin. See [Spending transaction info](#spending_transaction_info). |
 | `is_immature`      | bool          | Whether this coin was created by a coinbase transaction that is still immature.                                    |
 | `is_change`        | bool          | Whether the coin deposit address was derived from the change descriptor.                                           |
+| `is_from_self`     | bool          | Whether the coin and all its unconfirmed ancestors, if any, are outputs of transactions from this wallet.          |
 
 
 ##### Spending transaction info

--- a/liana-gui/src/app/state/coins.rs
+++ b/liana-gui/src/app/state/coins.rs
@@ -226,6 +226,7 @@ mod tests {
                 address: dummy_address.clone(),
                 derivation_index: 0.into(),
                 is_change: false,
+                is_from_self: false,
             },
             Coin {
                 outpoint: bitcoin::OutPoint { txid, vout: 3 },
@@ -236,6 +237,7 @@ mod tests {
                 address: dummy_address.clone(),
                 derivation_index: 1.into(),
                 is_change: false,
+                is_from_self: false,
             },
             Coin {
                 outpoint: bitcoin::OutPoint { txid, vout: 0 },
@@ -246,6 +248,7 @@ mod tests {
                 address: dummy_address.clone(),
                 derivation_index: 2.into(),
                 is_change: false,
+                is_from_self: false,
             },
             Coin {
                 outpoint: bitcoin::OutPoint { txid, vout: 1 },
@@ -256,6 +259,7 @@ mod tests {
                 address: dummy_address,
                 derivation_index: 3.into(),
                 is_change: false,
+                is_from_self: false,
             },
         ]);
 

--- a/liana-gui/src/app/state/psbt.rs
+++ b/liana-gui/src/app/state/psbt.rs
@@ -793,6 +793,7 @@ mod tests {
                     "derivation_index": 0,
                     "is_immature": false,
                     "is_change": false,
+                    "is_from_self": false,
 
                 }]})),
             ),

--- a/liana-gui/src/lianalite/client/backend/mod.rs
+++ b/liana-gui/src/lianalite/client/backend/mod.rs
@@ -649,6 +649,7 @@ impl Daemon for BackendWalletClient {
                         txid: info.txid,
                         height: info.height,
                     }),
+                    is_from_self: false, // FIXME: use value from backend
                 })
                 .collect(),
         })
@@ -1133,6 +1134,7 @@ fn history_tx_from_api(value: api::Transaction, network: Network) -> HistoryTran
                         txid: info.txid,
                         height: info.height,
                     }),
+                    is_from_self: false, // FIXME: use value from backend
                 });
             }
         }
@@ -1188,6 +1190,7 @@ fn spend_tx_from_api(
                         txid: info.txid,
                         height: info.height,
                     }),
+                    is_from_self: false, // FIXME: use value from backend
                 });
             }
         }

--- a/lianad/src/bitcoin/poller/looper.rs
+++ b/lianad/src/bitcoin/poller/looper.rs
@@ -91,6 +91,7 @@ fn update_coins(
                 block_info: None,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             received.push(coin);
         }

--- a/lianad/src/bitcoin/poller/looper.rs
+++ b/lianad/src/bitcoin/poller/looper.rs
@@ -315,6 +315,9 @@ fn updates(
     db_conn.unspend_coins(&updated_coins.expired_spending);
     db_conn.spend_coins(&updated_coins.spending);
     db_conn.confirm_spend(&updated_coins.spent);
+    // Update info about which coins are from self only after
+    // coins have been inserted & updated above.
+    db_conn.update_coins_from_self(current_tip.height);
     if latest_tip != current_tip {
         db_conn.update_tip(&latest_tip);
         log::debug!("New tip: '{}'", latest_tip);

--- a/lianad/src/commands/mod.rs
+++ b/lianad/src/commands/mod.rs
@@ -425,6 +425,7 @@ impl DaemonControl {
                     spend_block,
                     is_immature,
                     is_change,
+                    is_from_self,
                     derivation_index,
                     ..
                 } = coin;
@@ -445,6 +446,7 @@ impl DaemonControl {
                     spend_info,
                     is_immature,
                     is_change,
+                    is_from_self,
                 }
             })
             .collect();
@@ -1229,6 +1231,10 @@ pub struct ListCoinsEntry {
     pub is_immature: bool,
     /// Whether the coin deposit address was derived from the change descriptor.
     pub is_change: bool,
+    /// Whether the coin is the output of a transaction whose inputs are all from
+    /// this same wallet. If the coin is unconfirmed, it also means that all its
+    /// unconfirmed ancestors, if any, are also from self.
+    pub is_from_self: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lianad/src/commands/mod.rs
+++ b/lianad/src/commands/mod.rs
@@ -1491,6 +1491,7 @@ mod tests {
             is_change: false,
             spend_txid: None,
             spend_block: None,
+            is_from_self: false,
         }]);
         // If we try to use coin selection, the unconfirmed non-change coin will not be used
         // as a candidate and so we get a coin selection error due to insufficient funds.
@@ -1733,6 +1734,7 @@ mod tests {
             is_change: false,
             spend_txid: None,
             spend_block: None,
+            is_from_self: false,
         }]);
         assert_eq!(
             control.create_spend(&destinations, &[dummy_op_dup], 1_001, None),
@@ -1755,6 +1757,7 @@ mod tests {
             is_change: true,
             spend_txid: None,
             spend_block: None,
+            is_from_self: false,
         };
         db_conn.new_unspent_coins(&[unconfirmed_coin]);
         // Coin selection error due to insufficient funds.
@@ -1786,6 +1789,7 @@ mod tests {
             is_change: false,
             spend_txid: None,
             spend_block: None,
+            is_from_self: false,
         }]);
         // First, create a transaction using auto coin selection.
         let psbt = if let CreateSpendResult::Success { psbt, .. } =
@@ -1921,6 +1925,7 @@ mod tests {
             is_change: false,
             spend_txid: None,
             spend_block: None,
+            is_from_self: false,
         }]);
         let empty_dest = &HashMap::<bitcoin::Address<address::NetworkUnchecked>, u64>::new();
         assert!(matches!(
@@ -1960,6 +1965,7 @@ mod tests {
             is_change: false,
             spend_txid: None,
             spend_block: None,
+            is_from_self: false,
         }]);
         assert_eq!(
             control.create_spend(&destinations, &[imma_op], 1_001, None),
@@ -2005,6 +2011,7 @@ mod tests {
                 is_change: false,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             },
             Coin {
                 outpoint: dummy_op_b,
@@ -2015,6 +2022,7 @@ mod tests {
                 is_change: false,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             },
         ]);
 
@@ -2162,6 +2170,7 @@ mod tests {
                 height: 184500,
                 time: 184500,
             }),
+            is_from_self: false,
         }]);
         // The coin is spent so we cannot RBF.
         assert_eq!(
@@ -2273,6 +2282,7 @@ mod tests {
                 derivation_index: ChildNumber::from(0),
                 amount: bitcoin::Amount::from_sat(100_000_000),
                 spend_txid: Some(spend_tx.txid()),
+                is_from_self: false,
             },
             // Deposit 2
             Coin {
@@ -2287,6 +2297,7 @@ mod tests {
                 derivation_index: ChildNumber::from(1),
                 amount: bitcoin::Amount::from_sat(2000),
                 spend_txid: None,
+                is_from_self: false,
             },
             // This coin is a change output.
             Coin {
@@ -2298,6 +2309,7 @@ mod tests {
                 derivation_index: ChildNumber::from(2),
                 amount: bitcoin::Amount::from_sat(100_000_000 - 4000 - 1000),
                 spend_txid: None,
+                is_from_self: false,
             },
             // Deposit 3
             Coin {
@@ -2312,6 +2324,7 @@ mod tests {
                 derivation_index: ChildNumber::from(3),
                 amount: bitcoin::Amount::from_sat(3000),
                 spend_txid: None,
+                is_from_self: false,
             },
         ]);
 
@@ -2532,6 +2545,7 @@ mod tests {
                     is_change: false,
                     spend_txid: None,
                     spend_block: None,
+                    is_from_self: false,
                 }]);
             }
         }

--- a/lianad/src/database/mod.rs
+++ b/lianad/src/database/mod.rs
@@ -181,6 +181,10 @@ pub trait DatabaseConnection {
     /// Store transactions in database, ignoring any that already exist.
     fn new_txs(&mut self, txs: &[bitcoin::Transaction]);
 
+    /// For all unconfirmed coins and those confirmed after `prev_tip_height`,
+    /// update whether the coin is from self or not.
+    fn update_coins_from_self(&mut self, prev_tip_height: i32);
+
     /// Retrieve a list of transactions and their corresponding block heights and times.
     fn list_wallet_transactions(
         &mut self,
@@ -377,6 +381,11 @@ impl DatabaseConnection for SqliteConn {
 
     fn new_txs<'a>(&mut self, txs: &[bitcoin::Transaction]) {
         self.new_txs(txs)
+    }
+
+    fn update_coins_from_self(&mut self, prev_tip_height: i32) {
+        self.update_coins_from_self(prev_tip_height)
+            .expect("must not fail")
     }
 
     fn list_wallet_transactions(

--- a/lianad/src/database/mod.rs
+++ b/lianad/src/database/mod.rs
@@ -430,6 +430,7 @@ pub struct Coin {
     pub is_change: bool,
     pub spend_txid: Option<bitcoin::Txid>,
     pub spend_block: Option<BlockInfo>,
+    pub is_from_self: bool,
 }
 
 impl std::convert::From<DbCoin> for Coin {
@@ -443,6 +444,7 @@ impl std::convert::From<DbCoin> for Coin {
             is_change,
             spend_txid,
             spend_block,
+            is_from_self,
             ..
         } = db_coin;
         Coin {
@@ -454,6 +456,7 @@ impl std::convert::From<DbCoin> for Coin {
             is_change,
             spend_txid,
             spend_block: spend_block.map(BlockInfo::from),
+            is_from_self,
         }
     }
 }

--- a/lianad/src/database/sqlite/mod.rs
+++ b/lianad/src/database/sqlite/mod.rs
@@ -43,7 +43,7 @@ use miniscript::bitcoin::{
     secp256k1,
 };
 
-const DB_VERSION: i64 = 7;
+const DB_VERSION: i64 = 8;
 
 /// Last database version for which Bitcoin transactions were not stored in database. In practice
 /// this meant we relied on the bitcoind watchonly wallet to store them for us.
@@ -750,6 +750,91 @@ impl SqliteConn {
         .expect("Database must be available")
     }
 
+    /// Update `is_from_self` in coins table for all unconfirmed coins
+    /// and those confirmed after `prev_tip_height`.
+    ///
+    /// This only sets the value to true as we do not expect the value
+    /// to change from true to false. In case of a reorg, the value
+    /// for all unconfirmed coins should be set to false before this
+    /// method is called.
+    pub fn update_coins_from_self(&mut self, prev_tip_height: i32) -> Result<(), rusqlite::Error> {
+        db_exec(&mut self.conn, |db_tx| {
+            // Given the requirement for unconfirmed coins that all ancestors
+            // be from self, we perform the update in a loop until no further
+            // rows are updated in order to iterate over the unconfirmed coins.
+            // Although we don't expect any unconfirmed transaction to have
+            // more than 25 in-mempool descendants including itself, there
+            // could be more descendants in the DB following a reorg and a
+            // rollback of the tip. The max number of iterations would be
+            // one per unconfirmed coin not from self plus one for all
+            // confirmed coins.
+            // In any case, the query only sets `is_from_self` to 1 for
+            // those coins with value 0 and so the number of rows affected
+            // by each iteration must become 0.
+            let max_iterations = {
+                let num_unconfirmed: u64 = db_tx.query_row(
+                    "SELECT COUNT(*) FROM coins
+                    WHERE blockheight IS NULL AND is_from_self = 0",
+                    [],
+                    |row| row.get(0),
+                )?;
+                // Add 1 for the confirmed coins, which will all
+                // be updated in the first iteration, and another 1
+                // as a final check there's nothing left to update.
+                num_unconfirmed.checked_add(2).expect("must fit")
+            };
+            log::debug!(
+                "Updating is_from_self in up to {} iterations..",
+                max_iterations
+            );
+            let mut updated = 0;
+            for i in 0..max_iterations {
+                updated = db_tx.execute(
+                    "
+                    UPDATE coins
+                    SET is_from_self = 1
+                    FROM transactions t
+                        INNER JOIN (
+                            SELECT
+                                spend_txid,
+                                SUM(
+                                    CASE
+                                        WHEN blockheight IS NOT NULL THEN 1
+                                        -- If the spending coin is unconfirmed, only count
+                                        -- it as an input coin if it is from self.
+                                        WHEN blockheight IS NULL AND is_from_self = 1 THEN 1
+                                        ELSE 0
+                                    END
+                                ) AS cnt
+                            FROM coins
+                            WHERE spend_txid IS NOT NULL
+                            -- We only need to consider spend transactions that are
+                            -- unconfirmed or confirmed after `prev_tip_height
+                            -- as only these transactions will affect the coins that
+                            -- we are updating.
+                            AND (spend_block_height IS NULL OR spend_block_height > ?1)
+                            GROUP BY spend_txid
+                        ) spends
+                        ON t.txid = spends.spend_txid AND t.num_inputs = spends.cnt
+                    WHERE coins.txid = t.txid
+                    AND (coins.blockheight IS NULL OR coins.blockheight > ?1)
+                    AND coins.is_from_self = 0
+                    ",
+                    [prev_tip_height],
+                )?;
+                if updated == 0 {
+                    log::debug!("Finished updating is_from_self in {} iterations.", i + 1);
+                    break;
+                }
+            }
+            assert_eq!(
+                updated, 0,
+                "no rows expected to be updated on final iteration while updating is_from_self",
+            );
+            Ok(())
+        })
+    }
+
     pub fn list_wallet_transactions(
         &mut self,
         txids: &[bitcoin::Txid],
@@ -814,6 +899,10 @@ impl SqliteConn {
     /// - Spending transactions confirmation
     /// - Tip
     ///
+    /// The `is_from_self` value for all unconfirmed coins following the rollback is
+    /// set to false. This is because this value depends on the confirmation status
+    /// of ancestor coins and so will need to be re-evaluated.
+    ///
     /// This will have to be updated if we are to add new fields based on block data
     /// in the database eventually.
     pub fn rollback_tip(&mut self, new_tip: &BlockChainTip) {
@@ -825,6 +914,12 @@ impl SqliteConn {
             db_tx.execute(
                 "UPDATE coins SET spend_block_height = NULL, spend_block_time = NULL WHERE spend_block_height > ?1",
                 rusqlite::params![new_tip.height],
+            )?;
+            // This statement must be run after updating `blockheight` above so that it includes coins
+            // that become unconfirmed following the rollback.
+            db_tx.execute(
+                "UPDATE coins SET is_from_self = 0 WHERE blockheight IS NULL",
+                rusqlite::params![],
             )?;
             db_tx.execute(
                 "UPDATE tip SET blockheight = (?1), blockhash = (?2)",
@@ -847,7 +942,7 @@ mod tests {
         str::FromStr,
     };
 
-    use bitcoin::{bip32, ScriptBuf};
+    use bitcoin::{bip32, BlockHash, ScriptBuf, TxIn};
 
     // The database schema used by the first versions of Liana (database version 0). Used to test
     // migrations starting from the first version.
@@ -2469,7 +2564,332 @@ CREATE TABLE labels (
     }
 
     #[test]
-    fn v0_to_v7_migration() {
+    fn sqlite_update_coins_from_self() {
+        let (tmp_dir, _, _, db) = dummy_db();
+
+        // Helper to create a dummy transaction.
+        // Varying `lock_time_height` allows to obtain a unique txid for the given `num_inputs`.
+        fn dummy_tx(num_inputs: u32, lock_time_height: u32) -> bitcoin::Transaction {
+            bitcoin::Transaction {
+                version: bitcoin::transaction::Version::TWO,
+                lock_time: bitcoin::absolute::LockTime::from_height(lock_time_height).unwrap(),
+                input: (0..num_inputs).map(|_| TxIn::default()).collect(),
+                output: vec![bitcoin::TxOut::minimal_non_dust(ScriptBuf::default())], // a single output,
+            }
+        }
+
+        {
+            let mut conn = db.connection().unwrap();
+
+            // Deposit two coins from two different external transactions.
+            let tx_a = dummy_tx(1, 0);
+            let tx_b = dummy_tx(1, 1);
+            let coin_tx_a: Coin = Coin {
+                outpoint: bitcoin::OutPoint::new(tx_a.txid(), 0),
+                is_immature: false,
+                amount: bitcoin::Amount::from_sat(1_000_000),
+                derivation_index: bip32::ChildNumber::from_normal_idx(0).unwrap(),
+                is_change: false,
+                block_info: None,
+                spend_txid: None,
+                spend_block: None,
+            };
+            let coin_tx_b: Coin = Coin {
+                outpoint: bitcoin::OutPoint::new(tx_b.txid(), 0),
+                is_immature: false,
+                amount: bitcoin::Amount::from_sat(1_000_000),
+                derivation_index: bip32::ChildNumber::from_normal_idx(1).unwrap(),
+                is_change: false,
+                block_info: None,
+                spend_txid: None,
+                spend_block: None,
+            };
+            conn.new_txs(&[tx_a, tx_b]);
+            conn.new_unspent_coins(&[coin_tx_a, coin_tx_b]);
+
+            // The coins are not from self.
+            assert!(conn.coins(&[], &[]).iter().all(|c| !c.is_from_self));
+            // Update from self info.
+            conn.update_coins_from_self(0).unwrap();
+            // As expected, the coins are still not marked as from self.
+            assert!(conn.coins(&[], &[]).iter().all(|c| !c.is_from_self));
+
+            // Spend `coin_tx_a` in `tx_c` with change `coin_tx_c`.
+            let tx_c = dummy_tx(1, 2);
+            let coin_tx_c: Coin = Coin {
+                outpoint: bitcoin::OutPoint::new(tx_c.txid(), 0),
+                is_immature: false,
+                amount: bitcoin::Amount::from_sat(1_000_000),
+                derivation_index: bip32::ChildNumber::from_normal_idx(2).unwrap(),
+                is_change: true,
+                block_info: None,
+                spend_txid: None,
+                spend_block: None,
+            };
+            conn.new_txs(&[tx_c.clone()]);
+            conn.spend_coins(&[(coin_tx_a.outpoint, tx_c.txid())]);
+            conn.new_unspent_coins(&[coin_tx_c]);
+
+            // Although `coin_tx_c` has only one parent, `coin_tx_a` is
+            // unconfirmed and not from self. So all our coins are still
+            // not marked as from self.
+            assert!(conn.coins(&[], &[]).iter().all(|c| !c.is_from_self));
+            conn.update_coins_from_self(0).unwrap();
+            assert!(conn.coins(&[], &[]).iter().all(|c| !c.is_from_self));
+
+            // Now refresh `coin_tx_c` in `tx_d`, creating `coin_tx_d`.
+            let tx_d = dummy_tx(1, 3);
+            let coin_tx_d: Coin = Coin {
+                outpoint: bitcoin::OutPoint::new(tx_d.txid(), 0),
+                is_immature: false,
+                amount: bitcoin::Amount::from_sat(1_000_000),
+                derivation_index: bip32::ChildNumber::from_normal_idx(3).unwrap(),
+                is_change: true,
+                block_info: None,
+                spend_txid: None,
+                spend_block: None,
+            };
+            conn.new_txs(&[tx_d.clone()]);
+            conn.spend_coins(&[(coin_tx_c.outpoint, tx_d.txid())]);
+            conn.new_unspent_coins(&[coin_tx_d]);
+
+            // All coins are unconfirmed and none are from self.
+            assert!(conn.coins(&[], &[]).iter().all(|c| !c.is_from_self));
+            conn.update_coins_from_self(0).unwrap();
+            assert!(conn.coins(&[], &[]).iter().all(|c| !c.is_from_self));
+
+            // Spend the deposited coin `coin_tx_b` and the refreshed coin `coin_tx_d`
+            // together in `tx_e`, creating `coin_tx_e`.
+            let tx_e = dummy_tx(2, 4); // 2 inputs
+            let coin_tx_e: Coin = Coin {
+                outpoint: bitcoin::OutPoint::new(tx_e.txid(), 0),
+                is_immature: false,
+                amount: bitcoin::Amount::from_sat(1_000_000),
+                derivation_index: bip32::ChildNumber::from_normal_idx(4).unwrap(),
+                is_change: false,
+                block_info: None,
+                spend_txid: None,
+                spend_block: None,
+            };
+            conn.new_txs(&[tx_e.clone()]);
+            conn.spend_coins(&[
+                (coin_tx_b.outpoint, tx_e.txid()),
+                (coin_tx_d.outpoint, tx_e.txid()),
+            ]);
+            conn.new_unspent_coins(&[coin_tx_e]);
+
+            // Still there are no confirmed coins, so everything remains as not from self.
+            assert!(conn.coins(&[], &[]).iter().all(|c| !c.is_from_self));
+            conn.update_coins_from_self(0).unwrap();
+            assert!(conn.coins(&[], &[]).iter().all(|c| !c.is_from_self));
+
+            // Finally, refresh `coin_tx_e` in transaction `tx_f`, creating `coin_tx_f`.
+            let tx_f = dummy_tx(1, 5);
+            let coin_tx_f: Coin = Coin {
+                outpoint: bitcoin::OutPoint::new(tx_f.txid(), 0),
+                is_immature: false,
+                amount: bitcoin::Amount::from_sat(1_000_000),
+                derivation_index: bip32::ChildNumber::from_normal_idx(5).unwrap(),
+                is_change: true,
+                block_info: None,
+                spend_txid: None,
+                spend_block: None,
+            };
+            conn.new_txs(&[tx_f.clone()]);
+            conn.spend_coins(&[(coin_tx_e.outpoint, tx_f.txid())]);
+            conn.new_unspent_coins(&[coin_tx_f]);
+
+            // Still no coins are from self.
+            assert!(conn.coins(&[], &[]).iter().all(|c| !c.is_from_self));
+            conn.update_coins_from_self(0).unwrap();
+            assert!(conn.coins(&[], &[]).iter().all(|c| !c.is_from_self));
+
+            // Now confirm `tx_a` and `tx_c` in successive blocks.
+            conn.confirm_coins(&[
+                (coin_tx_a.outpoint, 100, 1_000),
+                (coin_tx_c.outpoint, 101, 1_001),
+            ]);
+            conn.confirm_spend(&[(coin_tx_a.outpoint, tx_c.txid(), 101, 1_001)]);
+            // Coins are still not marked as from self.
+            assert!(conn.coins(&[], &[]).iter().all(|c| !c.is_from_self));
+            // Now update from self for coins confirmed after 101, which excludes the two coins above.
+            // Only `coin_tx_d` is from self, because it's unconfirmed and its parent is a confirmed coin.
+            // `coin_tx_e` still depends on `coin_tx_b` which is an unconfirmed deposit.
+            conn.update_coins_from_self(101).unwrap();
+            assert!(conn
+                .coins(&[], &[coin_tx_d.outpoint])
+                .iter()
+                .all(|c| c.is_from_self));
+            assert!(conn
+                .coins(
+                    &[],
+                    &[
+                        coin_tx_a.outpoint,
+                        coin_tx_b.outpoint,
+                        coin_tx_c.outpoint,
+                        coin_tx_e.outpoint,
+                        coin_tx_f.outpoint
+                    ]
+                )
+                .iter()
+                .all(|c| !c.is_from_self));
+
+            // Now run the update for coins confirmed after 100.
+            conn.update_coins_from_self(100).unwrap();
+            // `coin_tx_c` is now marked as from self as it has a single parent
+            // that is confirmed (even though its parent is an external deposit).
+            assert!(conn
+                .coins(&[], &[coin_tx_c.outpoint, coin_tx_d.outpoint])
+                .iter()
+                .all(|c| c.is_from_self));
+            assert!(conn
+                .coins(
+                    &[],
+                    &[
+                        coin_tx_a.outpoint,
+                        coin_tx_b.outpoint,
+                        coin_tx_e.outpoint,
+                        coin_tx_f.outpoint
+                    ]
+                )
+                .iter()
+                .all(|c| !c.is_from_self));
+
+            // Even if we run the update for coins confirmed after height 99,
+            // `coin_tx_a` will not be marked as from self as it's an external deposit.
+            conn.update_coins_from_self(99).unwrap();
+            assert!(conn
+                .coins(&[], &[coin_tx_c.outpoint, coin_tx_d.outpoint])
+                .iter()
+                .all(|c| c.is_from_self));
+            assert!(conn
+                .coins(
+                    &[],
+                    &[
+                        coin_tx_a.outpoint,
+                        coin_tx_b.outpoint,
+                        coin_tx_e.outpoint,
+                        coin_tx_f.outpoint
+                    ]
+                )
+                .iter()
+                .all(|c| !c.is_from_self));
+
+            // Now confirm the other external deposit coin.
+            conn.confirm_coins(&[(coin_tx_b.outpoint, 102, 1_002)]);
+            // If we run the update, it doesn't matter if we use a later height
+            // as there are only unconfirmed coins that need to be updated.
+            conn.update_coins_from_self(110).unwrap();
+            // `coin_tx_e` and `coin_tx_f` are also now from self.
+            assert!(conn
+                .coins(
+                    &[],
+                    &[
+                        coin_tx_c.outpoint,
+                        coin_tx_d.outpoint,
+                        coin_tx_e.outpoint,
+                        coin_tx_f.outpoint
+                    ]
+                )
+                .iter()
+                .all(|c| c.is_from_self));
+            assert!(conn
+                .coins(&[], &[coin_tx_a.outpoint, coin_tx_b.outpoint,])
+                .iter()
+                .all(|c| !c.is_from_self));
+
+            // Even if we now run the update with an earlier height,
+            // `coin_tx_b` will not be marked as from self.
+            conn.update_coins_from_self(101).unwrap();
+            // No changes from above.
+            assert!(conn
+                .coins(
+                    &[],
+                    &[
+                        coin_tx_c.outpoint,
+                        coin_tx_d.outpoint,
+                        coin_tx_e.outpoint,
+                        coin_tx_f.outpoint
+                    ]
+                )
+                .iter()
+                .all(|c| c.is_from_self));
+            assert!(conn
+                .coins(&[], &[coin_tx_a.outpoint, coin_tx_b.outpoint,])
+                .iter()
+                .all(|c| !c.is_from_self));
+
+            // Now we will roll the tip back earlier than some of our confirmed coins.
+            let new_tip = {
+                // It doesn't matter what this hash value is as we only care about the height.
+                let hash = BlockHash::from_str(
+                    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+                )
+                .unwrap();
+                &BlockChainTip { height: 101, hash }
+            };
+            conn.rollback_tip(new_tip);
+
+            // Only `coin_tx_a` and `coin_tx_c` are still confirmed.
+            assert_eq!(
+                conn.coins(&[], &[])
+                    .iter()
+                    .filter_map(|c| if c.block_info.is_some() {
+                        Some(c.outpoint)
+                    } else {
+                        None
+                    })
+                    .collect::<Vec<_>>(),
+                vec![coin_tx_a.outpoint, coin_tx_c.outpoint]
+            );
+            // Rolling back sets all unconfirmed coins as not from self so only
+            // `coin_tx_c` is still marked as from self.
+            assert!(conn
+                .coins(&[], &[coin_tx_c.outpoint])
+                .iter()
+                .all(|c| c.is_from_self));
+            assert!(conn
+                .coins(
+                    &[],
+                    &[
+                        coin_tx_a.outpoint,
+                        coin_tx_b.outpoint,
+                        coin_tx_d.outpoint,
+                        coin_tx_e.outpoint,
+                        coin_tx_f.outpoint
+                    ]
+                )
+                .iter()
+                .all(|c| !c.is_from_self));
+
+            // Now run the update from the current tip height of 101.
+            conn.update_coins_from_self(101).unwrap();
+            // `coin_tx_d` is now marked as from self as its parent `coin_tx_c`
+            // is confirmed. Coins `coin_tx_e` and `coin_tx_f` depend on the
+            // unconfirmed `tx_coin_b` and so remain as not from self.
+            assert!(conn
+                .coins(&[], &[coin_tx_c.outpoint, coin_tx_d.outpoint])
+                .iter()
+                .all(|c| c.is_from_self));
+            assert!(conn
+                .coins(
+                    &[],
+                    &[
+                        coin_tx_a.outpoint,
+                        coin_tx_b.outpoint,
+                        coin_tx_e.outpoint,
+                        coin_tx_f.outpoint,
+                    ]
+                )
+                .iter()
+                .all(|c| !c.is_from_self));
+        }
+
+        fs::remove_dir_all(tmp_dir).unwrap();
+    }
+
+    #[test]
+    fn v0_to_v8_migration() {
         let secp = secp256k1::Secp256k1::verification_only();
 
         // Create a database with version 0, using the old schema.
@@ -2492,8 +2912,8 @@ CREATE TABLE labels (
             .map(|i| bitcoin::Transaction {
                 version: bitcoin::transaction::Version::TWO,
                 lock_time: bitcoin::absolute::LockTime::from_height(i).unwrap(),
-                input: Vec::new(),
-                output: Vec::new(),
+                input: vec![bitcoin::TxIn::default()], // a single input
+                output: vec![bitcoin::TxOut::minimal_non_dust(ScriptBuf::default())], // a single output,
             })
             .collect();
         // The helper that was used to store Spend transaction in previous versions of the software
@@ -2575,7 +2995,7 @@ CREATE TABLE labels (
         {
             let mut conn = db.connection().unwrap();
             let version = conn.db_version();
-            assert_eq!(version, 7);
+            assert_eq!(version, 8);
         }
         // We should now be able to insert another PSBT, to query both, and the first PSBT must
         // have no associated timestamp.
@@ -2649,7 +3069,7 @@ CREATE TABLE labels (
     }
 
     #[test]
-    fn v3_to_v7_migration() {
+    fn v3_to_v8_migration() {
         let secp = secp256k1::Secp256k1::verification_only();
 
         // Create a database with version 3, using the old schema.
@@ -2672,8 +3092,8 @@ CREATE TABLE labels (
                 .map(|i| bitcoin::Transaction {
                     version: bitcoin::transaction::Version::TWO,
                     lock_time: bitcoin::absolute::LockTime::from_height(i).unwrap(),
-                    input: Vec::new(),
-                    output: Vec::new(),
+                    input: vec![bitcoin::TxIn::default()], // a single input
+                    output: vec![bitcoin::TxOut::minimal_non_dust(ScriptBuf::default())], // a single output,
                 })
                 .collect();
 
@@ -2799,10 +3219,10 @@ CREATE TABLE labels (
 
             // Migrate the DB.
             maybe_apply_migration(&db_path, &bitcoin_txs).unwrap();
-            assert_eq!(conn.db_version(), 7);
+            assert_eq!(conn.db_version(), 8);
             // Migrating twice will be a no-op. No need to pass `bitcoin_txs` second time.
             maybe_apply_migration(&db_path, &[]).unwrap();
-            assert!(conn.db_version() == 7);
+            assert!(conn.db_version() == 8);
 
             // Compare the `DbCoin`s with the expected values.
             let coins_post = conn.coins(&[], &[]);
@@ -2821,6 +3241,11 @@ CREATE TABLE labels (
                 assert_eq!(c_post.is_change, c_pre.is_change);
                 assert_eq!(c_post.spend_txid, c_pre.spend_txid);
                 assert_eq!(c_post.spend_block, c_pre.spend_block);
+                // only coins D and E are from self.
+                assert_eq!(
+                    c_post.is_from_self,
+                    [coin_d_outpoint, coin_e_outpoint].contains(&c_pre.outpoint)
+                );
             }
         }
 
@@ -2847,8 +3272,8 @@ CREATE TABLE labels (
             .map(|i| bitcoin::Transaction {
                 version: bitcoin::transaction::Version::TWO,
                 lock_time: bitcoin::absolute::LockTime::from_height(i).unwrap(),
-                input: Vec::new(),
-                output: Vec::new(),
+                input: vec![bitcoin::TxIn::default()], // a single input
+                output: vec![bitcoin::TxOut::minimal_non_dust(ScriptBuf::default())], // a single output,
             })
             .collect();
         let spend_txs: Vec<_> = (0..10)
@@ -2857,12 +3282,12 @@ CREATE TABLE labels (
                     bitcoin::Transaction {
                         version: bitcoin::transaction::Version::TWO,
                         lock_time: bitcoin::absolute::LockTime::from_height(1_234 + i).unwrap(),
-                        input: Vec::new(),
-                        output: Vec::new(),
+                        input: vec![bitcoin::TxIn::default()], // a single input
+                        output: vec![bitcoin::TxOut::minimal_non_dust(ScriptBuf::default())], // a single output,
                     },
                     if i % 2 == 0 {
                         Some(DbBlockInfo {
-                            height: (i % 5) as i32 * 2_000,
+                            height: 1 + (i % 5) as i32 * 2_000,
                             time: 1722488619 + (i % 5) * 84_999,
                         })
                     } else {
@@ -2890,7 +3315,7 @@ CREATE TABLE labels (
                 is_change: (i % 4) == 0,
                 block_info: if i & 2 == 0 {
                     Some(DbBlockInfo {
-                        height: (i % 100) as i32 * 1_000,
+                        height: 1 + (i % 100) as i32 * 1_000,
                         time: 1722408619 + (i % 100) as u32 * 42_000,
                     })
                 } else {

--- a/lianad/src/database/sqlite/mod.rs
+++ b/lianad/src/database/sqlite/mod.rs
@@ -1373,9 +1373,10 @@ CREATE TABLE labels (
                 conn.db_coins(&[outpoint_a, outpoint_b]),
             ]
             .iter()
-            .all(|c| c.len() == 2
-                && c[0].outpoint == coin_a.outpoint
-                && c[1].outpoint == coin_b.outpoint));
+            .all(|coins| coins.len() == 2
+                && coins
+                    .iter()
+                    .all(|c| [coin_a.outpoint, coin_b.outpoint].contains(&c.outpoint))));
             // We can filter for just the first coin.
             assert!([
                 conn.coins(&[CoinStatus::Unconfirmed], &[outpoint_a]),
@@ -1425,9 +1426,10 @@ CREATE TABLE labels (
                 conn.db_coins(&[outpoint_a, outpoint_b]),
             ]
             .iter()
-            .all(|c| c.len() == 2
-                && c[0].outpoint == coin_a.outpoint
-                && c[1].outpoint == coin_b.outpoint));
+            .all(|coins| coins.len() == 2
+                && coins
+                    .iter()
+                    .all(|c| [coin_a.outpoint, coin_b.outpoint].contains(&c.outpoint))));
 
             // Now if we spend one, it'll be marked as such.
             conn.spend_coins(&[(coin_a.outpoint, txs.get(2).unwrap().txid())]);
@@ -1478,9 +1480,10 @@ CREATE TABLE labels (
                 conn.db_coins(&[outpoint_a, outpoint_b]),
             ]
             .iter()
-            .all(|c| c.len() == 2
-                && c[0].outpoint == coin_a.outpoint
-                && c[1].outpoint == coin_b.outpoint));
+            .all(|coins| coins.len() == 2
+                && coins
+                    .iter()
+                    .all(|c| [coin_a.outpoint, coin_b.outpoint].contains(&c.outpoint))));
 
             // Add a third and fourth coin.
             let outpoint_c = bitcoin::OutPoint::new(txs.get(3).unwrap().txid(), 42);
@@ -1518,10 +1521,11 @@ CREATE TABLE labels (
                 conn.db_coins(&[outpoint_b, outpoint_c, outpoint_d]),
             ]
             .iter()
-            .all(|coin| coin.len() == 3
-                && coin[0].outpoint == coin_b.outpoint
-                && coin[1].outpoint == coin_c.outpoint
-                && coin[2].outpoint == coin_d.outpoint));
+            .all(|coins| coins.len() == 3
+                && coins
+                    .iter()
+                    .all(|c| [coin_b.outpoint, coin_c.outpoint, coin_d.outpoint]
+                        .contains(&c.outpoint))));
 
             // We can also get two of the three unconfirmed coins by filtering for their outpoints.
             assert!([
@@ -1530,9 +1534,10 @@ CREATE TABLE labels (
                 conn.db_coins(&[outpoint_b, outpoint_c]),
             ]
             .iter()
-            .all(|coin| coin.len() == 2
-                && coin[0].outpoint == coin_b.outpoint
-                && coin[1].outpoint == coin_c.outpoint));
+            .all(|coins| coins.len() == 2
+                && coins
+                    .iter()
+                    .all(|c| [coin_b.outpoint, coin_c.outpoint].contains(&c.outpoint))));
 
             // Now spend second coin, even though it is still unconfirmed.
             conn.spend_coins(&[(coin_b.outpoint, txs.get(5).unwrap().txid())]);

--- a/lianad/src/database/sqlite/mod.rs
+++ b/lianad/src/database/sqlite/mod.rs
@@ -1418,6 +1418,7 @@ CREATE TABLE labels (
                 is_change: false,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             conn.new_unspent_coins(&[coin_a]);
             // We can query by status and/or outpoint.
@@ -1464,6 +1465,7 @@ CREATE TABLE labels (
                 is_change: true,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             conn.new_unspent_coins(&[coin_b]);
             // Both coins are unconfirmed.
@@ -1598,6 +1600,7 @@ CREATE TABLE labels (
                 is_change: false,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             let outpoint_d = bitcoin::OutPoint::new(txs.get(4).unwrap().txid(), 43);
             let coin_d = Coin {
@@ -1609,6 +1612,7 @@ CREATE TABLE labels (
                 is_change: false,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             conn.new_unspent_coins(&[coin_c, coin_d]);
 
@@ -1723,6 +1727,7 @@ CREATE TABLE labels (
                 is_change: false,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             conn.new_unspent_coins(&[coin_a]);
             assert_eq!(conn.coins(&[], &[])[0].outpoint, coin_a.outpoint);
@@ -1765,6 +1770,7 @@ CREATE TABLE labels (
                 is_change: true,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             conn.new_unspent_coins(&[coin_b]);
             let outpoints: HashSet<bitcoin::OutPoint> = conn
@@ -1888,6 +1894,7 @@ CREATE TABLE labels (
                 is_change: false,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             conn.new_unspent_coins(&[coin_imma]);
             let outpoints: HashSet<bitcoin::OutPoint> = conn
@@ -2059,6 +2066,7 @@ CREATE TABLE labels (
                     is_change: false,
                     spend_txid: None,
                     spend_block: None,
+                    is_from_self: false,
                 },
                 Coin {
                     outpoint: bitcoin::OutPoint::new(txs.get(1).unwrap().txid(), 2),
@@ -2072,6 +2080,7 @@ CREATE TABLE labels (
                     is_change: false,
                     spend_txid: None,
                     spend_block: None,
+                    is_from_self: false,
                 },
                 Coin {
                     outpoint: bitcoin::OutPoint::new(txs.get(2).unwrap().txid(), 3),
@@ -2088,6 +2097,7 @@ CREATE TABLE labels (
                         height: 101_199,
                         time: 1_231_678,
                     }),
+                    is_from_self: false,
                 },
                 Coin {
                     outpoint: bitcoin::OutPoint::new(txs.get(4).unwrap().txid(), 4),
@@ -2101,6 +2111,7 @@ CREATE TABLE labels (
                     is_change: false,
                     spend_txid: None,
                     spend_block: None,
+                    is_from_self: false,
                 },
                 Coin {
                     outpoint: bitcoin::OutPoint::new(txs.get(5).unwrap().txid(), 5),
@@ -2117,6 +2128,7 @@ CREATE TABLE labels (
                         height: 101_105,
                         time: 1_201_678,
                     }),
+                    is_from_self: false,
                 },
             ];
             conn.new_unspent_coins(&coins);
@@ -2262,6 +2274,7 @@ CREATE TABLE labels (
                     is_change: false,
                     spend_txid: None,
                     spend_block: None,
+                    is_from_self: false,
                 },
                 Coin {
                     outpoint: bitcoin::OutPoint::new(txs.get(1).unwrap().txid(), 2),
@@ -2275,6 +2288,7 @@ CREATE TABLE labels (
                     is_change: false,
                     spend_txid: None,
                     spend_block: None,
+                    is_from_self: false,
                 },
                 Coin {
                     outpoint: bitcoin::OutPoint::new(txs.get(2).unwrap().txid(), 3),
@@ -2291,6 +2305,7 @@ CREATE TABLE labels (
                         height: 101_199,
                         time: 1_123_000,
                     }),
+                    is_from_self: false,
                 },
                 Coin {
                     outpoint: bitcoin::OutPoint::new(txs.get(4).unwrap().txid(), 4),
@@ -2304,6 +2319,7 @@ CREATE TABLE labels (
                     is_change: false,
                     spend_txid: None,
                     spend_block: None,
+                    is_from_self: false,
                 },
                 Coin {
                     outpoint: bitcoin::OutPoint::new(txs.get(5).unwrap().txid(), 5),
@@ -2320,6 +2336,7 @@ CREATE TABLE labels (
                         height: 101_105,
                         time: 1_126_000,
                     }),
+                    is_from_self: false,
                 },
             ];
             conn.new_unspent_coins(&coins);
@@ -2448,6 +2465,7 @@ CREATE TABLE labels (
                     } else {
                         None
                     },
+                    is_from_self: false,
                 })
                 .collect();
 
@@ -2593,6 +2611,7 @@ CREATE TABLE labels (
                 block_info: None,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             let coin_tx_b: Coin = Coin {
                 outpoint: bitcoin::OutPoint::new(tx_b.txid(), 0),
@@ -2603,6 +2622,7 @@ CREATE TABLE labels (
                 block_info: None,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             conn.new_txs(&[tx_a, tx_b]);
             conn.new_unspent_coins(&[coin_tx_a, coin_tx_b]);
@@ -2625,6 +2645,7 @@ CREATE TABLE labels (
                 block_info: None,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             conn.new_txs(&[tx_c.clone()]);
             conn.spend_coins(&[(coin_tx_a.outpoint, tx_c.txid())]);
@@ -2648,6 +2669,7 @@ CREATE TABLE labels (
                 block_info: None,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             conn.new_txs(&[tx_d.clone()]);
             conn.spend_coins(&[(coin_tx_c.outpoint, tx_d.txid())]);
@@ -2670,6 +2692,7 @@ CREATE TABLE labels (
                 block_info: None,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             conn.new_txs(&[tx_e.clone()]);
             conn.spend_coins(&[
@@ -2694,6 +2717,7 @@ CREATE TABLE labels (
                 block_info: None,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             };
             conn.new_txs(&[tx_f.clone()]);
             conn.spend_coins(&[(coin_tx_e.outpoint, tx_f.txid())]);
@@ -3035,6 +3059,7 @@ CREATE TABLE labels (
                 is_change: false,
                 spend_txid: None,
                 spend_block: None,
+                is_from_self: false,
             }]);
             let coins = conn.coins(&[], &[]);
             assert_eq!(coins.len(), 3);

--- a/lianad/src/database/sqlite/utils.rs
+++ b/lianad/src/database/sqlite/utils.rs
@@ -50,6 +50,21 @@ where
         .collect::<rusqlite::Result<Vec<T>>>()
 }
 
+/// Internal helper for queries boilerplate
+pub fn db_query_row<P, F, T>(
+    conn: &mut rusqlite::Connection,
+    stmt_str: &str,
+    params: P,
+    f: F,
+) -> Result<T, rusqlite::Error>
+where
+    P: IntoIterator + rusqlite::Params,
+    P::Item: rusqlite::ToSql,
+    F: FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
+{
+    conn.prepare(stmt_str)?.query_row(params, f)
+}
+
 /// The current time as the number of seconds since the UNIX epoch, truncated to u32 since SQLite
 /// only supports i64 integers.
 pub fn curr_timestamp() -> u32 {

--- a/lianad/src/testutils.rs
+++ b/lianad/src/testutils.rs
@@ -484,6 +484,10 @@ impl DatabaseConnection for DummyDatabase {
         }
     }
 
+    fn update_coins_from_self(&mut self, _prev_tip_height: i32) {
+        // noop
+    }
+
     fn list_wallet_transactions(
         &mut self,
         txids: &[bitcoin::Txid],


### PR DESCRIPTION
:warning: This PR upgrades and migrates DB version so a wallet opened against this PR will no longer work on Liana v8.

This is a first step towards #1375.

Following the approach from #1391, this PR adds a new `is_from_self` field to the response of the `listcoins` command.

The underlying information is stored in a new `is_from_self` column in the coins database table. This column could instead have been added to the transactions table, but for consistency with other transaction-related columns, I added it to the coins table. It's also important to note that being from self is wallet-dependent, so adding it to the transactions table would not work if multiple wallets were supported in the same DB (h/t edouardparis).

A subsequent PR will then use this field in the GUI to determine which unconfirmed coins, if any, can be included in the confirmed balance. It also needs to be added to the corresponding Liana Connect API call. Another use of this field will be to determine which unconfirmed coins to include in coin selection (https://github.com/wizardsardine/liana/issues/1484).

The first commit in this PR refactors some existing DB migration tests so that they will not be affected by future changes to the coins table schema.