### PR TITLE
[GUI] include unconfirmed coins from self in confirmed balance

### DIFF
--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -75,6 +75,7 @@ impl Panels {
                     cache.last_poll_timestamp,
                     cache.last_poll_at_startup,
                 ),
+                cache.blockheight,
             ),
             coins: CoinsPanel::new(&cache.coins, wallet.main_descriptor.first_timelock_value()),
             transactions: TransactionsPanel::new(wallet.clone()),

--- a/liana-gui/src/app/state/mod.rs
+++ b/liana-gui/src/app/state/mod.rs
@@ -133,7 +133,7 @@ impl Home {
         sync_status: SyncStatus,
         tip_height: i32,
     ) -> Self {
-        let (balance, unconfirmed_balance, _, _) = coins_summary(
+        let (balance, unconfirmed_balance, expiring_coins, remaining_seq) = coins_summary(
             coins,
             tip_height as u32,
             wallet.main_descriptor.first_timelock_value(),
@@ -144,8 +144,8 @@ impl Home {
             sync_status,
             balance,
             unconfirmed_balance,
-            remaining_sequence: None,
-            expiring_coins: Vec::new(),
+            remaining_sequence: remaining_seq,
+            expiring_coins,
             selected_event: None,
             events: Vec::new(),
             labels_edited: LabelsEdited::default(),

--- a/liana-gui/src/lianalite/client/backend/api.rs
+++ b/liana-gui/src/lianalite/client/backend/api.rs
@@ -201,6 +201,7 @@ pub struct Coin {
     pub spend_info: Option<CoinSpendInfo>,
     pub is_immature: bool,
     pub is_change_address: bool,
+    pub is_from_self: bool,
 }
 
 #[derive(Clone, Deserialize)]

--- a/liana-gui/src/lianalite/client/backend/mod.rs
+++ b/liana-gui/src/lianalite/client/backend/mod.rs
@@ -649,7 +649,7 @@ impl Daemon for BackendWalletClient {
                         txid: info.txid,
                         height: info.height,
                     }),
-                    is_from_self: false, // FIXME: use value from backend
+                    is_from_self: c.is_from_self,
                 })
                 .collect(),
         })
@@ -1134,7 +1134,7 @@ fn history_tx_from_api(value: api::Transaction, network: Network) -> HistoryTran
                         txid: info.txid,
                         height: info.height,
                     }),
-                    is_from_self: false, // FIXME: use value from backend
+                    is_from_self: c.is_from_self,
                 });
             }
         }
@@ -1190,7 +1190,7 @@ fn spend_tx_from_api(
                         txid: info.txid,
                         height: info.height,
                     }),
-                    is_from_self: false, // FIXME: use value from backend
+                    is_from_self: c.is_from_self,
                 });
             }
         }


### PR DESCRIPTION
This is to complete #1375, building on the changes from #1483.

:warning: It will not work for Liana Connect until the API response has been updated to include `is_from_self`.