### PR TITLE
gui: allow to connect to an electrum server w/ a self signed certificate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,14 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
           profile: minimal
+      - name: Install OpenSSL (windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install openssl.light --no-progress
+          echo "C:\Program Files\OpenSSL" >> $env:GITHUB_PATH
+          echo "C:\Program Files\OpenSSL\bin" >> $env::GITHUB_PATH
+          echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >> $env:GITHUB_ENV
+
       - name: Test on Rust ${{ matrix.toolchain }} (only Windows)
         if: matrix.os == 'windows-latest'
         run: cargo test --verbose --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -978,7 +978,7 @@ dependencies = [
  "bitflags 2.6.0",
  "core-foundation 0.10.0",
  "core-graphics-types 0.2.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1359,6 +1359,7 @@ dependencies = [
  "byteorder",
  "libc",
  "log",
+ "openssl",
  "rustls",
  "serde",
  "serde_json",
@@ -1600,12 +1601,21 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1618,6 +1628,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2872,6 +2888,7 @@ dependencies = [
  "backtrace",
  "bdk_electrum",
  "dirs 5.0.1",
+ "electrum-client",
  "fern",
  "jsonrpc 0.17.0",
  "liana",
@@ -3123,7 +3140,7 @@ dependencies = [
  "bitflags 2.6.0",
  "block",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
  "paste",
@@ -3534,6 +3551,44 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl"
+version = "0.10.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -4789,7 +4844,7 @@ dependencies = [
  "core-graphics 0.24.0",
  "drm",
  "fastrand",
- "foreign-types",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "memmap2 0.9.5",

--- a/contrib/lianad_config_example.toml
+++ b/contrib/lianad_config_example.toml
@@ -50,8 +50,13 @@ poll_interval_secs = 30
 # In order to connect, it needs the address as a string, which can be
 # optionally prefixed with "ssl://" or "tcp://". If omitted, "tcp://"
 # will be assumed.
+# `validate_domain` field is optional: used in case of SSL connection,
+# if set to `false`, internal electrum client will not try to validate
+# the domain associated to the certificate: it's useful in case of 
+# self-signed certificate. Its default value is `true`.
 # [electrum_config]
 # addr = "127.0.0.1:50001"
+# validate_domain = false 
 #
 #
 [bitcoind_config]

--- a/liana-gui/src/app/state/settings/bitcoind.rs
+++ b/liana-gui/src/app/state/settings/bitcoind.rs
@@ -323,6 +323,7 @@ impl BitcoindSettings {
                     }
                 }
             }
+            view::SettingsEditMessage::ValidateDomainEdited(_) => {}
             view::SettingsEditMessage::BitcoindRpcAuthTypeSelected(auth_type) => {
                 if !self.processing {
                     self.selected_auth_type = auth_type;
@@ -462,6 +463,7 @@ impl ElectrumSettings {
                     daemon_config.bitcoin_backend =
                         Some(lianad::config::BitcoinBackend::Electrum(ElectrumConfig {
                             addr: self.addr.value.clone(),
+                            validate_domain: self.electrum_config.validate_domain,
                         }));
                     self.processing = true;
                     return Command::perform(async move { daemon_config }, |cfg| {
@@ -470,6 +472,11 @@ impl ElectrumSettings {
                 }
             }
             view::SettingsEditMessage::Clipboard(text) => return clipboard::write(text),
+            view::SettingsEditMessage::ValidateDomainEdited(b) => {
+                if !self.processing {
+                    self.electrum_config.validate_domain = b;
+                }
+            }
             _ => {}
         };
         Command::none()
@@ -484,6 +491,7 @@ impl ElectrumSettings {
                 cache.blockheight,
                 &self.addr,
                 self.processing,
+                self.electrum_config.validate_domain,
             )
         } else {
             view::settings::electrum(

--- a/liana-gui/src/app/view/message.rs
+++ b/liana-gui/src/app/view/message.rs
@@ -88,6 +88,7 @@ pub enum RemoteBackendSettingsMessage {
 pub enum SettingsEditMessage {
     Select,
     FieldEdited(&'static str, String),
+    ValidateDomainEdited(bool),
     BitcoindRpcAuthTypeSelected(RpcAuthType),
     Cancel,
     Confirm,

--- a/liana-gui/src/app/view/settings.rs
+++ b/liana-gui/src/app/view/settings.rs
@@ -32,7 +32,7 @@ use crate::{
     hw::HardwareWallet,
     node::{
         bitcoind::{RpcAuthType, RpcAuthValues},
-        electrum,
+        electrum::{self, validate_domain_checkbox},
     },
 };
 
@@ -563,6 +563,7 @@ pub fn electrum_edit<'a>(
     blockheight: i32,
     addr: &form::Value<String>,
     processing: bool,
+    validate_domain: bool,
 ) -> Element<'a, SettingsEditMessage> {
     let mut col = Column::new().spacing(20);
     if is_configured_node_type && blockheight != 0 {
@@ -595,6 +596,9 @@ pub fn electrum_edit<'a>(
             .push(separation().width(Length::Fill));
     }
 
+    let checkbox = validate_domain_checkbox(addr, validate_domain, |b| {
+        SettingsEditMessage::ValidateDomainEdited(b)
+    });
     col = col.push(
         Column::new()
             .push(text("Address:").bold().small())
@@ -606,6 +610,7 @@ pub fn electrum_edit<'a>(
                 .size(P1_SIZE)
                 .padding(5),
             )
+            .push_maybe(checkbox)
             .push(text(electrum::ADDRESS_NOTES).size(P2_SIZE))
             .spacing(5),
     );

--- a/liana-gui/src/installer/message.rs
+++ b/liana-gui/src/installer/message.rs
@@ -81,6 +81,7 @@ pub enum DefineBitcoind {
 #[derive(Debug, Clone)]
 pub enum DefineElectrum {
     ConfigFieldEdited(electrum::ConfigField, String),
+    ValidDomainChanged(bool),
 }
 
 #[derive(Debug, Clone)]

--- a/liana-gui/src/installer/step/node/electrum.rs
+++ b/liana-gui/src/installer/step/node/electrum.rs
@@ -14,9 +14,19 @@ use crate::{
     node::electrum::ConfigField,
 };
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct DefineElectrum {
     address: form::Value<String>,
+    validate_domain: bool,
+}
+
+impl Default for DefineElectrum {
+    fn default() -> Self {
+        Self {
+            address: Default::default(),
+            validate_domain: true,
+        }
+    }
 }
 
 impl DefineElectrum {
@@ -38,6 +48,7 @@ impl DefineElectrum {
                             crate::node::electrum::is_electrum_address_valid(&value);
                     }
                 },
+                message::DefineElectrum::ValidDomainChanged(v) => self.validate_domain = v,
             };
         };
         Command::none()
@@ -47,6 +58,7 @@ impl DefineElectrum {
         if self.can_try_ping() {
             ctx.bitcoin_backend = Some(lianad::config::BitcoinBackend::Electrum(ElectrumConfig {
                 addr: self.address.value.clone(),
+                validate_domain: self.validate_domain,
             }));
             return true;
         }
@@ -54,12 +66,15 @@ impl DefineElectrum {
     }
 
     pub fn view(&self) -> Element<Message> {
-        view::define_electrum(&self.address)
+        view::define_electrum(&self.address, self.validate_domain)
     }
 
     pub fn ping(&self) -> Result<(), Error> {
         let builder = electrum_client::Config::builder();
-        let config = builder.timeout(Some(3)).build();
+        let config = builder
+            .timeout(Some(3))
+            .validate_domain(self.validate_domain)
+            .build();
         let client = electrum_client::Client::from_config(&self.address.value, config)
             .map_err(|e| Error::Electrum(e.to_string()))?;
         client

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -29,6 +29,7 @@ use liana_ui::{
     widget::*,
 };
 
+use crate::node::electrum::validate_domain_checkbox;
 use crate::{
     hw::{is_compatible_with_tapminiscript, HardwareWallet, UnsupportedReason},
     installer::{
@@ -1134,7 +1135,15 @@ pub fn define_bitcoind<'a>(
         .into()
 }
 
-pub fn define_electrum<'a>(address: &form::Value<String>) -> Element<'a, Message> {
+pub fn define_electrum<'a>(
+    address: &form::Value<String>,
+    validate_domain: bool,
+) -> Element<'a, Message> {
+    let checkbox = validate_domain_checkbox(address, validate_domain, |b| {
+        Message::DefineNode(DefineNode::DefineElectrum(
+            message::DefineElectrum::ValidDomainChanged(b),
+        ))
+    });
     let col_address = Column::new()
         .push(text("Address:").bold())
         .push(
@@ -1150,7 +1159,8 @@ pub fn define_electrum<'a>(address: &form::Value<String>) -> Element<'a, Message
             .size(text::P1_SIZE)
             .padding(10),
         )
-        .push(text(electrum::ADDRESS_NOTES).size(text::P2_SIZE))
+        .push_maybe(checkbox)
+        .push(text(electrum::ADDRESS_NOTES))
         .spacing(10);
 
     Column::new().push(col_address).spacing(50).into()

--- a/liana-gui/src/node/electrum.rs
+++ b/liana-gui/src/node/electrum.rs
@@ -1,13 +1,18 @@
 use std::fmt;
 
+use iced::{widget::checkbox, Element, Renderer};
+use liana_ui::{component::form, theme::Theme};
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ConfigField {
     Address,
 }
 
 pub const ADDRESS_NOTES: &str = "Note: include \"ssl://\" as a prefix \
-    for SSL connections. Be aware that self-signed \
-    SSL certificates are currently not supported.";
+    for SSL connections.";
+
+pub const VALID_SSL_DOMAIN_NOTES: &str = "Do not validate SSL Domain \
+    (check this only if you want to use a self-signed certificate)";
 
 impl fmt::Display for ConfigField {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -15,6 +20,27 @@ impl fmt::Display for ConfigField {
             ConfigField::Address => write!(f, "RPC address"),
         }
     }
+}
+
+pub fn validate_domain_checkbox<'a, F, M>(
+    addr: &form::Value<String>,
+    value: bool,
+    closure: F,
+) -> Option<Element<'a, M, Theme, Renderer>>
+where
+    F: 'a + Fn(bool) -> M,
+    M: 'a,
+{
+    let checkbox = checkbox(VALID_SSL_DOMAIN_NOTES, !value).on_toggle(move |b| closure(!b));
+    if addr.valid && is_ssl(&addr.value) {
+        Some(checkbox.into())
+    } else {
+        None
+    }
+}
+
+pub fn is_ssl(value: &str) -> bool {
+    value.starts_with("ssl://")
 }
 
 pub fn is_electrum_address_valid(value: &str) -> bool {

--- a/lianad/Cargo.toml
+++ b/lianad/Cargo.toml
@@ -28,6 +28,7 @@ miniscript = { version = "11.0", features = ["serde", "compiler", "base64"] }
 # For Electrum backend. This is the latest version with the same bitcoin version as
 # the miniscript dependency.
 bdk_electrum = { version = "0.14" }
+electrum-client = { version = "0.19", features = ["use-openssl"] }
 
 # Don't reinvent the wheel
 dirs = "5.0"

--- a/lianad/src/bitcoin/electrum/client.rs
+++ b/lianad/src/bitcoin/electrum/client.rs
@@ -7,9 +7,10 @@ use bdk_electrum::{
         spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResult},
         BlockId, ChainPosition, ConfirmationHeightAnchor, TxGraph,
     },
-    electrum_client::{self, Config, ElectrumApi},
     ElectrumExt,
 };
+
+use electrum_client::{self, Config, ElectrumApi};
 
 use super::utils::{
     block_id_from_tip, height_i32_from_usize, height_usize_from_i32, outpoints_from_tx,
@@ -56,9 +57,13 @@ impl Client {
     /// Create a new client and perform sanity checks.
     pub fn new(electrum_config: &config::ElectrumConfig) -> Result<Self, Error> {
         // First use a dummy config to check connectivity (no retries, short timeout).
-        let dummy_config = Config::builder().retry(0).timeout(Some(3)).build();
+        let dummy_config = Config::builder()
+            .retry(0)
+            .validate_domain(electrum_config.validate_domain)
+            .timeout(Some(3))
+            .build();
         // Try to ping the server.
-        bdk_electrum::electrum_client::Client::from_config(&electrum_config.addr, dummy_config)
+        electrum_client::Client::from_config(&electrum_config.addr, dummy_config)
             .and_then(|dummy_client| dummy_client.ping())
             .map_err(Error::Server)?;
 
@@ -66,10 +71,10 @@ impl Client {
         let config = Config::builder()
             .retry(RETRY_LIMIT)
             .timeout(Some(RPC_SOCKET_TIMEOUT))
+            .validate_domain(electrum_config.validate_domain)
             .build();
-        let client =
-            bdk_electrum::electrum_client::Client::from_config(&electrum_config.addr, config)
-                .map_err(Error::Server)?;
+        let client = electrum_client::Client::from_config(&electrum_config.addr, config)
+            .map_err(Error::Server)?;
         Ok(Self(client))
     }
 

--- a/lianad/src/config.rs
+++ b/lianad/src/config.rs
@@ -128,6 +128,19 @@ pub struct ElectrumConfig {
     /// Include "ssl://" for SSL. otherwise TCP will be assumed.
     /// Can optionally prefix with "tcp://".
     pub addr: String,
+    /// If validate_domain == false, domain of ssl certificate will not be validated
+    /// (useful to allow usage of self signed certificates on local network)
+    #[serde(default)]
+    pub validate_domain: bool,
+}
+
+impl Default for ElectrumConfig {
+    fn default() -> Self {
+        Self {
+            addr: Default::default(),
+            validate_domain: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/lianad/src/config.rs
+++ b/lianad/src/config.rs
@@ -122,7 +122,7 @@ pub struct BitcoindConfig {
 }
 
 /// Everything we need to know for talking to Electrum serenely.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ElectrumConfig {
     /// The URL the Electrum's RPC is listening on.
     /// Include "ssl://" for SSL. otherwise TCP will be assumed.
@@ -130,17 +130,12 @@ pub struct ElectrumConfig {
     pub addr: String,
     /// If validate_domain == false, domain of ssl certificate will not be validated
     /// (useful to allow usage of self signed certificates on local network)
-    #[serde(default)]
+    #[serde(default = "default_validate_domain")]
     pub validate_domain: bool,
 }
 
-impl Default for ElectrumConfig {
-    fn default() -> Self {
-        Self {
-            addr: Default::default(),
-            validate_domain: true,
-        }
-    }
+fn default_validate_domain() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -299,7 +294,7 @@ impl Config {
 mod tests {
     use std::path::PathBuf;
 
-    use super::{config_file_path, BitcoindConfig, BitcoindRpcAuth, Config};
+    use super::*;
 
     // Test the format of the configuration file
     #[test]
@@ -490,6 +485,41 @@ mod tests {
         assert!(config_err
             .to_string()
             .contains("`auth` must be 'user:password'"));
+    }
+
+    // Test the format of the `electrum_config` section
+    #[test]
+    fn toml_electrum_config() {
+        // A valid config with `validate_domain`
+        let toml_str = r#"
+            addr = 'ssl://electrum.blockstream.info:60002'
+            validate_domain = false
+            "#
+        .trim_start()
+        .replace("            ", "");
+        toml::from_str::<ElectrumConfig>(&toml_str).expect("Deserializing toml_str");
+        let parsed = toml::from_str::<ElectrumConfig>(&toml_str).expect("Deserializing toml_str");
+        let serialized = toml::to_string_pretty(&parsed).expect("Serializing to toml");
+        assert_eq!(toml_str, serialized);
+        let expected = ElectrumConfig {
+            addr: "ssl://electrum.blockstream.info:60002".into(),
+            validate_domain: false,
+        };
+        assert_eq!(parsed, expected,);
+
+        // A valid config w/o `validate_domain`
+        let toml_str = r#"
+            addr = 'ssl://electrum.blockstream.info:60002'
+            "#
+        .trim_start()
+        .replace("            ", "");
+        let parsed = toml::from_str::<ElectrumConfig>(&toml_str).expect("Deserializing toml_str");
+        let expected = ElectrumConfig {
+            addr: "ssl://electrum.blockstream.info:60002".into(),
+            // `validate_domain` must default to true
+            validate_domain: true,
+        };
+        assert_eq!(parsed, expected,);
     }
 
     #[test]


### PR DESCRIPTION
closes #1300 
The issue about connecting to an electrum certificate using `rustls` have been fixed [upstream](https://github.com/bitcoindevkit/bdk/issues/1598) but in order to beneficiate from it we have to update `bdk_electrum` and `rust-bitvoin` dependencies.
Meanwhile, this PR introduce a workaround: the initial issue is related to `electrum-client` `use-rustls` feature and `use-openssl` feature is not reexported by `bdk_electrum` but we can use `electrum-client` crate directly and use `use-openssl` feature by this way:
 - [x] use `electrum-client` directly w/ `use-openssl`
 - [x] add and option to opt-out of ssl domain validation
 - [x] let user change the `validate_domain` values in `Settings` menu.
 
![image](https://github.com/user-attachments/assets/8314b89b-bfd2-4dc8-b331-ee980c3b24d5)

 
 Note: ssl://testnet.aranguren.org:51002 electrum server can be used to test this PR