### PR TITLE
bump msrv 1.80

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.71.1
+          - 1.80.0
           - nightly
         os:
           - ubuntu-latest

--- a/contrib/reproducible/guix/manifest.scm
+++ b/contrib/reproducible/guix/manifest.scm
@@ -221,7 +221,7 @@
         "pkg-config"
         "eudev"
         "fontconfig"))
-    ;; The GUI's MSRV is 1.70 and the daemon's 1.63. We just use the same rustc version for
+    ;; The GUI's MSRV is 1.80 and the daemon's 1.63. We just use the same rustc version for
     ;; both.
     ;; FIXME: be able to compile against a specified glibc (or musl) instead of having to
     ;; resort to backporting the newer rustc releases here. Also have proper Guix packages

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -12,7 +12,7 @@ community).  See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the currently minim
 supported by `lianad`.
 
 To build the GUI too, you'll unfortunately need a more recent Rust version. The minimum version
-supported by the GUI at the moment is `1.71.1`. You will most likely have to [manually download
+supported by the GUI at the moment is `1.80.0`. You will most likely have to [manually download
 it](#by-manually-downloading-the-latest-stable-version) or [use `rustup`](#through-rustup) to
 install more recent compilers.
 
@@ -50,11 +50,11 @@ And then you can download the archive corresponding to your system and CPU archi
 signature and use the `cargo` binary from this archive to build Liana. Here is an example for
 `amd64`:
 ```
-$ curl -O https://static.rust-lang.org/dist/rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz
-$ curl -O https://static.rust-lang.org/dist/rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz.asc
-$ gpg --verify rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz.asc
-$ tar -xzf rust-1.71.1-x86_64-unknown-linux-gnu.tar.gz
-$ ./rust-1.71.1-x86_64-unknown-linux-gnu/cargo/bin/cargo build --release
+$ curl -O https://static.rust-lang.org/dist/rust-1.80.0-x86_64-unknown-linux-gnu.tar.gz
+$ curl -O https://static.rust-lang.org/dist/rust-1.80.0-x86_64-unknown-linux-gnu.tar.gz.asc
+$ gpg --verify rust-1.80.0-x86_64-unknown-linux-gnu.tar.gz.asc
+$ tar -xzf rust-1.80.0-x86_64-unknown-linux-gnu.tar.gz
+$ ./rust-1.80.0-x86_64-unknown-linux-gnu/cargo/bin/cargo build --release
 ```
 
 ### Through `rustup`

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.80.0"
+profile = "default"
+components = ["rust-src", "rust-analyzer"]


### PR DESCRIPTION
The update of the reproducible system allow us to bump the minimal rust supported version. Although bumping a MSRV should be conservative, it is a requirement for us if we want to be able to support last https://github.com/iced-rs/iced version and improve the experience of our users.