### PR TITLE
Introduce lighter struct Payment in home panel

### DIFF
--- a/liana-gui/src/app/message.rs
+++ b/liana-gui/src/app/message.rs
@@ -40,6 +40,8 @@ pub enum Message {
     HardwareWallets(HardwareWalletMessage),
     HistoryTransactionsExtension(Result<Vec<HistoryTransaction>, Error>),
     HistoryTransactions(Result<Vec<HistoryTransaction>, Error>),
+    Payments(Result<Vec<Payment>, Error>),
+    PaymentsExtension(Result<Vec<Payment>, Error>),
     Payment(Result<(HistoryTransaction, usize), Error>),
     LabelsUpdated(Result<HashMap<String, Option<String>>, Error>),
     BroadcastModal(Result<HashSet<Txid>, Error>),

--- a/liana-gui/src/app/message.rs
+++ b/liana-gui/src/app/message.rs
@@ -40,6 +40,7 @@ pub enum Message {
     HardwareWallets(HardwareWalletMessage),
     HistoryTransactionsExtension(Result<Vec<HistoryTransaction>, Error>),
     HistoryTransactions(Result<Vec<HistoryTransaction>, Error>),
+    Payment(Result<(HistoryTransaction, usize), Error>),
     LabelsUpdated(Result<HashMap<String, Option<String>>, Error>),
     BroadcastModal(Result<HashSet<Txid>, Error>),
     RbfModal(Box<HistoryTransaction>, bool, Result<HashSet<Txid>, Error>),

--- a/liana-gui/src/app/state/coins.rs
+++ b/liana-gui/src/app/state/coins.rs
@@ -7,6 +7,7 @@ use iced::Command;
 use liana_ui::widget::Element;
 use lianad::commands::CoinStatus;
 
+use crate::daemon::model::LabelsLoader;
 use crate::{
     app::{
         cache::Cache,
@@ -132,7 +133,7 @@ impl State for CoinsPanel {
                 match self.labels_edited.update(
                     daemon,
                     message,
-                    std::iter::once(&mut self.coins).map(|a| a as &mut dyn Labelled),
+                    std::iter::once(&mut self.coins).map(|a| a as &mut dyn LabelsLoader),
                 ) {
                     Ok(cmd) => return cmd,
                     Err(e) => {

--- a/liana-gui/src/app/state/label.rs
+++ b/liana-gui/src/app/state/label.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, iter::IntoIterator, sync::Arc};
 use crate::{
     app::{error::Error, message::Message, view},
     daemon::{
-        model::{LabelItem, Labelled},
+        model::{LabelItem, Labelled, LabelsLoader},
         Daemon,
     },
 };

--- a/liana-gui/src/app/state/label.rs
+++ b/liana-gui/src/app/state/label.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, iter::IntoIterator, sync::Arc};
 use crate::{
     app::{error::Error, message::Message, view},
     daemon::{
-        model::{LabelItem, Labelled, LabelsLoader},
+        model::{LabelItem, LabelsLoader},
         Daemon,
     },
 };
@@ -19,7 +19,7 @@ impl LabelsEdited {
     pub fn cache(&self) -> &HashMap<String, form::Value<String>> {
         &self.0
     }
-    pub fn update<'a, T: IntoIterator<Item = &'a mut dyn Labelled>>(
+    pub fn update<'a, T: IntoIterator<Item = &'a mut dyn LabelsLoader>>(
         &mut self,
         daemon: Arc<dyn Daemon + Sync + Send>,
         message: Message,

--- a/liana-gui/src/app/state/psbt.rs
+++ b/liana-gui/src/app/state/psbt.rs
@@ -18,6 +18,7 @@ use liana_ui::{
     widget::Element,
 };
 
+use crate::daemon::model::LabelsLoader;
 use crate::{
     app::{
         cache::Cache,
@@ -193,7 +194,7 @@ impl PsbtState {
                 match self.labels_edited.update(
                     daemon,
                     message,
-                    std::iter::once(&mut self.tx).map(|tx| tx as &mut dyn Labelled),
+                    std::iter::once(&mut self.tx).map(|tx| tx as &mut dyn LabelsLoader),
                 ) {
                     Ok(cmd) => {
                         return cmd;

--- a/liana-gui/src/app/state/receive.rs
+++ b/liana-gui/src/app/state/receive.rs
@@ -9,6 +9,7 @@ use liana::miniscript::bitcoin::{
 };
 use liana_ui::{component::modal, widget::*};
 
+use crate::daemon::model::LabelsLoader;
 use crate::{
     app::{
         cache::Cache,
@@ -117,7 +118,7 @@ impl State for ReceivePanel {
                 match self.labels_edited.update(
                     daemon,
                     message,
-                    std::iter::once(&mut self.addresses).map(|a| a as &mut dyn Labelled),
+                    std::iter::once(&mut self.addresses).map(|a| a as &mut dyn LabelsLoader),
                 ) {
                     Ok(cmd) => cmd,
                     Err(e) => {

--- a/liana-gui/src/app/state/transactions.rs
+++ b/liana-gui/src/app/state/transactions.rs
@@ -27,7 +27,7 @@ use crate::{
         view,
         wallet::Wallet,
     },
-    daemon::model,
+    daemon::model::{self, LabelsLoader},
 };
 
 use crate::daemon::{
@@ -192,11 +192,14 @@ impl State for TransactionsPanel {
                 match self.labels_edited.update(
                     daemon,
                     message,
-                    self.txs.iter_mut().map(|tx| tx as &mut dyn Labelled).chain(
-                        self.selected_tx
-                            .iter_mut()
-                            .map(|tx| tx as &mut dyn Labelled),
-                    ),
+                    self.txs
+                        .iter_mut()
+                        .map(|tx| tx as &mut dyn LabelsLoader)
+                        .chain(
+                            self.selected_tx
+                                .iter_mut()
+                                .map(|tx| tx as &mut dyn LabelsLoader),
+                        ),
                 ) {
                     Ok(cmd) => {
                         return cmd;

--- a/liana-gui/src/app/view/home.rs
+++ b/liana-gui/src/app/view/home.rs
@@ -23,7 +23,7 @@ use crate::{
         view::{coins, dashboard, label, message::Message},
         wallet::SyncStatus,
     },
-    daemon::model::{HistoryTransaction, TransactionKind},
+    daemon::model::{HistoryTransaction, Payment, PaymentKind, TransactionKind},
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -32,7 +32,7 @@ pub fn home_view<'a>(
     unconfirmed_balance: &'a bitcoin::Amount,
     remaining_sequence: &Option<u32>,
     expiring_coins: &[bitcoin::OutPoint],
-    events: &'a [HistoryTransaction],
+    events: &'a [Payment],
     is_last_page: bool,
     processing: bool,
     sync_status: &SyncStatus,
@@ -147,16 +147,9 @@ pub fn home_view<'a>(
             Column::new()
                 .spacing(10)
                 .push(h4_bold("Last payments"))
-                .push(events.iter().enumerate().fold(
-                    Column::new().spacing(10),
-                    |col, (i, event)| {
-                        if !event.is_send_to_self() {
-                            col.push(event_list_view(i, event))
-                        } else {
-                            col
-                        }
-                    },
-                ))
+                .push(events.iter().fold(Column::new().spacing(10), |col, event| {
+                    col.push(event_list_view(event))
+                }))
                 .push_maybe(if !is_last_page && !events.is_empty() {
                     Some(
                         Container::new(
@@ -189,62 +182,48 @@ pub fn home_view<'a>(
         .into()
 }
 
-fn event_list_view(i: usize, event: &HistoryTransaction) -> Column<'_, Message> {
-    event.tx.output.iter().enumerate().fold(
-        Column::new().spacing(10),
-        |col, (output_index, output)| {
-            let label = if let Some(label) = event.labels.get(
-                &bitcoin::OutPoint {
-                    txid: event.tx.txid(),
-                    vout: output_index as u32,
-                }
-                .to_string(),
-            ) {
-                Some(p1_regular(label))
-            } else if let Ok(addr) =
-                bitcoin::Address::from_script(&output.script_pubkey, event.network)
-            {
-                event.labels.get(&addr.to_string()).map(|label| {
-                    p1_regular(format!("address label: {}", label)).style(color::GREY_3)
-                })
-            } else {
-                None
-            };
-            if event.is_external() {
-                if !event.change_indexes.contains(&output_index) {
-                    col
-                } else if let Some(t) = event.time {
-                    col.push(event::confirmed_incoming_event(
-                        label,
-                        DateTime::<Utc>::from_timestamp(t as i64, 0).unwrap(),
-                        &output.value,
-                        Message::SelectSub(i, output_index),
-                    ))
-                } else {
-                    col.push(event::unconfirmed_incoming_event(
-                        label,
-                        &output.value,
-                        Message::SelectSub(i, output_index),
-                    ))
-                }
-            } else if event.change_indexes.contains(&output_index) {
-                col
-            } else if let Some(t) = event.time {
-                col.push(event::confirmed_outgoing_event(
-                    label,
-                    DateTime::<Utc>::from_timestamp(t as i64, 0).unwrap(),
-                    &output.value,
-                    Message::SelectSub(i, output_index),
-                ))
-            } else {
-                col.push(event::unconfirmed_outgoing_event(
-                    label,
-                    &output.value,
-                    Message::SelectSub(i, output_index),
-                ))
-            }
-        },
-    )
+fn event_list_view(event: &Payment) -> Element<'_, Message> {
+    let label = if let Some(label) = &event.label {
+        Some(p1_regular(label))
+    } else {
+        event
+            .address_label
+            .as_ref()
+            .map(|label| p1_regular(format!("address label: {}", label)).style(color::GREY_3))
+    };
+    if event.kind == PaymentKind::Incoming {
+        if let Some(t) = event.time {
+            event::confirmed_incoming_event(
+                label,
+                t,
+                &event.amount,
+                Message::SelectPayment(event.outpoint),
+            )
+            .into()
+        } else {
+            event::unconfirmed_incoming_event(
+                label,
+                &event.amount,
+                Message::SelectPayment(event.outpoint),
+            )
+            .into()
+        }
+    } else if let Some(t) = event.time {
+        event::confirmed_outgoing_event(
+            label,
+            t,
+            &event.amount,
+            Message::SelectPayment(event.outpoint),
+        )
+        .into()
+    } else {
+        event::unconfirmed_outgoing_event(
+            label,
+            &event.amount,
+            Message::SelectPayment(event.outpoint),
+        )
+        .into()
+    }
 }
 
 pub fn payment_view<'a>(

--- a/liana-gui/src/app/view/message.rs
+++ b/liana-gui/src/app/view/message.rs
@@ -1,5 +1,5 @@
 use crate::{app::menu::Menu, node::bitcoind::RpcAuthType};
-use liana::miniscript::bitcoin::bip32::Fingerprint;
+use liana::miniscript::bitcoin::{bip32::Fingerprint, OutPoint};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -8,7 +8,7 @@ pub enum Message {
     Menu(Menu),
     Close,
     Select(usize),
-    SelectSub(usize, usize),
+    SelectPayment(OutPoint),
     Label(Vec<String>, LabelMessage),
     Settings(SettingsMessage),
     CreateSpend(CreateSpendMessage),

--- a/liana-gui/src/daemon/mod.rs
+++ b/liana-gui/src/daemon/mod.rs
@@ -333,7 +333,7 @@ pub trait Daemon: Debug {
     }
 }
 
-async fn load_labels<T: model::Labelled, D: Daemon + ?Sized>(
+async fn load_labels<T: model::Labelled + model::LabelsLoader, D: Daemon + ?Sized>(
     daemon: &D,
     targets: &mut Vec<T>,
 ) -> Result<(), DaemonError> {

--- a/liana-gui/src/daemon/model.rs
+++ b/liana-gui/src/daemon/model.rs
@@ -447,6 +447,16 @@ impl Labelled for HistoryTransaction {
 pub trait Labelled {
     fn labelled(&self) -> Vec<LabelItem>;
     fn labels(&mut self) -> &mut HashMap<String, String>;
+}
+
+pub trait LabelsLoader {
+    fn load_labels(&mut self, new_labels: &HashMap<String, Option<String>>);
+}
+
+impl<T: ?Sized> LabelsLoader for T
+where
+    T: Labelled,
+{
     fn load_labels(&mut self, new_labels: &HashMap<String, Option<String>>) {
         let items = self.labelled();
         let labels = self.labels();

--- a/liana-gui/src/daemon/model.rs
+++ b/liana-gui/src/daemon/model.rs
@@ -409,6 +409,96 @@ impl HistoryTransaction {
 }
 
 #[derive(Debug, Clone)]
+pub struct Payment {
+    pub label: Option<String>,
+    pub address: Option<String>,
+    pub address_label: Option<String>,
+    pub amount: Amount,
+    pub outpoint: OutPoint,
+    pub time: Option<chrono::DateTime<chrono::Utc>>,
+    pub kind: PaymentKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PaymentKind {
+    Outgoing,
+    Incoming,
+}
+
+impl Payment {
+    pub fn compare(&self, other: &Self) -> Ordering {
+        match (&self.time, &other.time) {
+            // `None` values come first
+            (None, Some(_)) => Ordering::Less,
+            (Some(_), None) => Ordering::Greater,
+            // Both are `None`, so we consider them equal
+            (None, None) => self
+                .outpoint
+                .txid
+                .cmp(&other.outpoint.txid)
+                .then_with(|| self.outpoint.vout.cmp(&other.outpoint.vout)),
+            // Both are `Some`, compare by descending time, then by txid
+            (Some(time1), Some(time2)) => time2
+                .cmp(time1)
+                .then_with(|| self.outpoint.txid.cmp(&other.outpoint.txid))
+                .then_with(|| self.outpoint.vout.cmp(&other.outpoint.vout)),
+        }
+    }
+}
+
+impl LabelsLoader for Payment {
+    fn load_labels(&mut self, new_labels: &HashMap<String, Option<String>>) {
+        if let Some(label) = self.address.as_ref().and_then(|addr| new_labels.get(addr)) {
+            self.address_label = label.clone();
+        }
+        if let Some(label) = new_labels.get(&self.outpoint.to_string()) {
+            self.label = label.clone();
+        }
+    }
+}
+
+pub fn payments_from_tx(history_tx: HistoryTransaction) -> Vec<Payment> {
+    let time = history_tx
+        .time
+        .map(|t| chrono::DateTime::<chrono::Utc>::from_timestamp(t as i64, 0).unwrap());
+    history_tx
+        .tx
+        .output
+        .iter()
+        .enumerate()
+        .fold(Vec::new(), |mut array, (output_index, output)| {
+            if history_tx.is_external() && !history_tx.change_indexes.contains(&output_index) {
+                return array;
+            }
+            let outpoint = OutPoint {
+                txid: history_tx.tx.txid(),
+                vout: output_index as u32,
+            };
+            let label = history_tx.labels.get(&outpoint.to_string()).cloned();
+            let address = Address::from_script(&output.script_pubkey, history_tx.network)
+                .ok()
+                .map(|addr| addr.to_string());
+            let address_label = address
+                .as_ref()
+                .and_then(|addr| history_tx.labels.get(addr).cloned());
+            array.push(Payment {
+                label,
+                address,
+                address_label,
+                outpoint,
+                time,
+                amount: output.value,
+                kind: if history_tx.is_external() {
+                    PaymentKind::Incoming
+                } else {
+                    PaymentKind::Outgoing
+                },
+            });
+            array
+        })
+}
+
+#[derive(Debug, Clone)]
 pub enum TransactionKind {
     IncomingSinglePayment(OutPoint),
     IncomingPaymentBatch(Vec<OutPoint>),


### PR DESCRIPTION
Some users may have txs with a lot of inputs/outputs. We wrongly iter over them in the view which is the origin of performance issues.