### PR TITLE
[GUI] Improve coin selection logic when creating spend

### DIFF
--- a/liana-gui/src/app/state/mod.rs
+++ b/liana-gui/src/app/state/mod.rs
@@ -29,7 +29,7 @@ use super::{
 
 pub const HISTORY_EVENT_PAGE_SIZE: u64 = 20;
 
-use crate::daemon::model::LabelsLoader;
+use crate::daemon::model::{coin_is_owned, LabelsLoader};
 use crate::daemon::{
     model::{remaining_sequence, Coin, HistoryTransaction, Payment},
     Daemon,
@@ -94,7 +94,7 @@ fn coins_summary(
     for coin in coins {
         if coin.spend_info.is_none() {
             // Include unconfirmed coins from self in confirmed balance.
-            if coin.block_height.is_some() || coin.is_from_self {
+            if coin_is_owned(coin) {
                 balance += coin.amount;
                 // Only consider confirmed coins for remaining seq
                 // (they would not be considered as expiring so we can also skip that part)

--- a/liana-gui/src/app/state/spend/step.rs
+++ b/liana-gui/src/app/state/spend/step.rs
@@ -283,8 +283,11 @@ impl DefineSpend {
             }
             outpoints
         } else if self.send_max_to_recipient.is_some() {
-            // If user has not selected coins, send the max available from all coins.
-            self.coins.iter().map(|(c, _)| c.outpoint).collect()
+            // If user has not selected coins, send the max available from all owned coins.
+            self.coins
+                .iter()
+                .filter_map(|(c, _)| coin_is_owned(c).then_some(c.outpoint))
+                .collect()
         } else {
             Vec::new() // pass empty list for auto-selection
         };
@@ -358,10 +361,9 @@ impl DefineSpend {
                 self.amount_left_to_select = Some(Amount::from_sat(missing));
                 if !self.is_user_coin_selection {
                     // The missing amount is based on all candidates for coin selection
-                    // being used, which are all coins if there's a recipient with max
-                    // or otherwise all owned coins.
+                    // being used, which are all owned coins.
                     for (coin, selected) in &mut self.coins {
-                        *selected = self.send_max_to_recipient.is_some() || coin_is_owned(coin);
+                        *selected = coin_is_owned(coin);
                     }
                 }
                 if let Some((i, recipient)) = recipient_with_max {

--- a/liana-gui/src/daemon/model.rs
+++ b/liana-gui/src/daemon/model.rs
@@ -29,6 +29,13 @@ pub fn remaining_sequence(coin: &Coin, blockheight: u32, timelock: u16) -> u32 {
     }
 }
 
+/// Whether the coin is owned by this wallet.
+/// This comprises all confirmed coins together with those
+/// unconfirmed coins from self.
+pub fn coin_is_owned(coin: &Coin) -> bool {
+    coin.block_height.is_some() || coin.is_from_self
+}
+
 #[derive(Debug, Clone)]
 pub struct SpendTx {
     pub network: Network,


### PR DESCRIPTION
This is to resolve #1326. In case of insufficient funds when creating a spend, the selected coins will be updated to correspond to the missing amount. Previously, no changes were made to selected coins.

Furthermore, if a user selects the max option for a recipient, only owned coins (confirmed or unconfirmed from self) will be considered rather than all coins, since unconfirmed coins that are not from self should only be used if the user has selected them manually.