### PR TITLE
export transactions: output a blank if fee is 0

### DIFF
--- a/liana-gui/src/export.rs
+++ b/liana-gui/src/export.rs
@@ -305,6 +305,11 @@ impl State {
                     let value = value as f64 / 100_000_000.0;
                     let fee = fee as f64 / 100_000_000.0;
                     let block = tx.height.map(|h| h.to_string()).unwrap_or("".to_string());
+                    let fee = if fee != 0.0 {
+                        fee.to_string()
+                    } else {
+                        "".into()
+                    };
 
                     let line = format!(
                         "{},{},{},{},{},{}\n",


### PR DESCRIPTION
This PR replace the fee displayed as 0 by a blank.