### PR TITLE
[GUI] Change default file name for transactions export

### DIFF
--- a/liana-gui/src/app/view/export.rs
+++ b/liana-gui/src/app/view/export.rs
@@ -1,13 +1,12 @@
 use iced::{
-    widget::{progress_bar, Button, Column, Container, Row, Space},
+    widget::{progress_bar, Column, Container, Row, Space},
     Length,
 };
 use liana_ui::{
     component::{
-        card,
+        button, card,
         text::{h4_bold, text},
     },
-    theme,
     widget::Element,
 };
 
@@ -22,14 +21,13 @@ pub fn export_modal<'a>(
 ) -> Element<'a, Message> {
     let button = match state {
         ExportState::Started | ExportState::Progress(_) => {
-            Some(Button::new("Cancel").on_press(ExportMessage::UserStop.into()))
+            Some(button::secondary(None, "Cancel").on_press(ExportMessage::UserStop.into()))
         }
         ExportState::Ended | ExportState::TimedOut | ExportState::Aborted => {
-            Some(Button::new("Close").on_press(ExportMessage::Close.into()))
+            Some(button::secondary(None, "Close").on_press(ExportMessage::Close.into()))
         }
         _ => None,
-    }
-    .map(|b| b.height(32).style(theme::Button::Primary));
+    };
     let msg = if let Some(error) = error {
         format!("{:?}", error)
     } else {

--- a/liana-gui/src/app/view/export.rs
+++ b/liana-gui/src/app/view/export.rs
@@ -1,4 +1,5 @@
 use iced::{
+    alignment::Horizontal,
     widget::{progress_bar, Column, Container, Row, Space},
     Length,
 };
@@ -59,12 +60,6 @@ pub fn export_modal<'a>(
             .push(progress_bar(0.0..=100.0, p))
             .push(Space::with_width(30)),
     );
-    let button_row = button.map(|b| {
-        Row::new()
-            .push(Space::with_width(Length::Fill))
-            .push(b)
-            .push(Space::with_width(Length::Fill))
-    });
     card::simple(
         Column::new()
             .spacing(10)
@@ -79,7 +74,11 @@ pub fn export_modal<'a>(
                     .push(Space::with_width(Length::Fill)),
             )
             .push(Space::with_height(Length::Fill))
-            .push_maybe(button_row)
+            .push_maybe(button.map(|b| {
+                Container::new(b)
+                    .align_x(Horizontal::Right)
+                    .width(Length::Fill)
+            }))
             .push(Space::with_height(5)),
     )
     .width(Length::Fixed(500.0))

--- a/liana-gui/src/app/view/export.rs
+++ b/liana-gui/src/app/view/export.rs
@@ -53,10 +53,12 @@ pub fn export_modal<'a>(
             100.0
         }
     };
-    let progress_bar_row = Row::new()
-        .push(Space::with_width(30))
-        .push(progress_bar(0.0..=100.0, p))
-        .push(Space::with_width(30));
+    let progress_bar_row = (*state != ExportState::Ended).then_some(
+        Row::new()
+            .push(Space::with_width(30))
+            .push(progress_bar(0.0..=100.0, p))
+            .push(Space::with_width(30)),
+    );
     let button_row = button.map(|b| {
         Row::new()
             .push(Space::with_width(Length::Fill))
@@ -68,7 +70,7 @@ pub fn export_modal<'a>(
             .spacing(10)
             .push(Container::new(h4_bold(format!("Export {export_type}"))).width(Length::Fill))
             .push(Space::with_height(Length::Fill))
-            .push(progress_bar_row)
+            .push_maybe(progress_bar_row)
             .push(Space::with_height(Length::Fill))
             .push(
                 Row::new()

--- a/liana-gui/src/app/view/export.rs
+++ b/liana-gui/src/app/view/export.rs
@@ -67,12 +67,7 @@ pub fn export_modal<'a>(
             .push(Space::with_height(Length::Fill))
             .push_maybe(progress_bar_row)
             .push(Space::with_height(Length::Fill))
-            .push(
-                Row::new()
-                    .push(Space::with_width(Length::Fill))
-                    .push(text(msg))
-                    .push(Space::with_width(Length::Fill)),
-            )
+            .push(Row::new().push(text(msg)))
             .push(Space::with_height(Length::Fill))
             .push_maybe(button.map(|b| {
                 Container::new(b)

--- a/liana-gui/src/app/view/transactions.rs
+++ b/liana-gui/src/app/view/transactions.rs
@@ -45,11 +45,7 @@ pub fn transactions_view<'a>(
                 Row::new()
                     .push(Container::new(h3("Transactions")))
                     .push(Space::with_width(Length::Fill))
-                    .push(
-                        Button::new("Export")
-                            .on_press(ExportMessage::Open.into())
-                            .style(theme::Button::Secondary),
-                    ),
+                    .push(button::secondary(None, "Export").on_press(ExportMessage::Open.into())),
             )
             .push(
                 Column::new()

--- a/liana-gui/src/export.rs
+++ b/liana-gui/src/export.rs
@@ -382,9 +382,11 @@ pub async fn export_subscription(mut state: State) -> (ExportProgress, State) {
 }
 
 pub async fn get_path() -> Option<PathBuf> {
+    let date = chrono::Local::now().format("%Y-%m-%dT%H-%M-%S");
+    let file_name = format!("liana-txs-{date}.csv");
     rfd::AsyncFileDialog::new()
         .set_title("Choose a location to export...")
-        .set_file_name("liana.csv")
+        .set_file_name(file_name)
         .save_file()
         .await
         .map(|fh| fh.path().to_path_buf())


### PR DESCRIPTION
The default file name has been changed to "liana-txs-{date}.csv", e.g. "liana-txs-2025-01-03T10-03-39.csv".

I also changed the "Export" button to use a helper as suggested by edouardparis.