### PR TITLE
Revert 'hide progress bar once export completed'

### DIFF
--- a/liana-gui/src/app/view/export.rs
+++ b/liana-gui/src/app/view/export.rs
@@ -54,18 +54,16 @@ pub fn export_modal<'a>(
             100.0
         }
     };
-    let progress_bar_row = (*state != ExportState::Ended).then_some(
-        Row::new()
-            .push(Space::with_width(30))
-            .push(progress_bar(0.0..=100.0, p))
-            .push(Space::with_width(30)),
-    );
+    let progress_bar_row = Row::new()
+        .push(Space::with_width(30))
+        .push(progress_bar(0.0..=100.0, p))
+        .push(Space::with_width(30));
     card::simple(
         Column::new()
             .spacing(10)
             .push(Container::new(h4_bold(format!("Export {export_type}"))).width(Length::Fill))
             .push(Space::with_height(Length::Fill))
-            .push_maybe(progress_bar_row)
+            .push(progress_bar_row)
             .push(Space::with_height(Length::Fill))
             .push(Row::new().push(text(msg)))
             .push(Space::with_height(Length::Fill))


### PR DESCRIPTION
This reverts commit 98195e03b6878cd31e1d34ba246700b6ae95ceb1.

The progress bar can disappear too quickly.