### PR TITLE
fix: merge Taproot sigs when updating PSBT

### DIFF
--- a/liana-gui/src/app/state/psbt.rs
+++ b/liana-gui/src/app/state/psbt.rs
@@ -692,27 +692,7 @@ impl Action for UpdateAction {
                         self.success = true;
                         self.error = None;
                         let psbt = Psbt::from_str(&self.updated.value).expect("Already checked");
-                        for (i, input) in tx.psbt.inputs.iter_mut().enumerate() {
-                            if tx
-                                .psbt
-                                .unsigned_tx
-                                .input
-                                .get(i)
-                                .map(|tx_in| tx_in.previous_output)
-                                != psbt
-                                    .unsigned_tx
-                                    .input
-                                    .get(i)
-                                    .map(|tx_in| tx_in.previous_output)
-                            {
-                                continue;
-                            }
-                            if let Some(updated_input) = psbt.inputs.get(i) {
-                                input
-                                    .partial_sigs
-                                    .extend(updated_input.partial_sigs.clone().into_iter());
-                            }
-                        }
+                        merge_signatures(&mut tx.psbt, &psbt);
                         tx.sigs = self
                             .wallet
                             .main_descriptor


### PR DESCRIPTION
While testing #1513, it became apparent that Taproot signatures were not being merged properly when updating a PSBT.

This PR fixes and refactors the code to use the `merge_signatures` function that contains the required logic.