### PR TITLE
Fix update of rescan state upon completion

### DIFF
--- a/liana-gui/src/app/message.rs
+++ b/liana-gui/src/app/message.rs
@@ -19,7 +19,7 @@ use crate::{
 pub enum Message {
     Tick,
     UpdateCache(Result<Cache, Error>),
-    UpdatePanelCache(/* is current panel */ bool, Result<Cache, Error>),
+    UpdatePanelCache(/* is current panel */ bool),
     View(view::Message),
     LoadDaemonConfig(Box<DaemonConfig>),
     DaemonConfigLoaded(Result<(), Error>),

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -317,7 +317,10 @@ impl App {
                         let current = &self.panels.current;
                         let daemon = self.daemon.clone();
                         // These are the panels to update with the cache.
-                        let mut panels = [(&mut self.panels.home as &mut dyn State, Menu::Home)];
+                        let mut panels = [
+                            (&mut self.panels.home as &mut dyn State, Menu::Home),
+                            (&mut self.panels.settings as &mut dyn State, Menu::Settings),
+                        ];
                         let commands: Vec<_> = panels
                             .iter_mut()
                             .map(|(panel, menu)| {

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -317,7 +317,7 @@ impl App {
                         let current = &self.panels.current;
                         let daemon = self.daemon.clone();
                         // These are the panels to update with the cache.
-                        let mut panels = [(&mut self.panels.home, Menu::Home)];
+                        let mut panels = [(&mut self.panels.home as &mut dyn State, Menu::Home)];
                         let commands: Vec<_> = panels
                             .iter_mut()
                             .map(|(panel, menu)| {

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -327,7 +327,7 @@ impl App {
                                 panel.update(
                                     daemon.clone(),
                                     &cache,
-                                    Message::UpdatePanelCache(current == menu, Ok(cache.clone())),
+                                    Message::UpdatePanelCache(current == menu),
                                 )
                             })
                             .collect();

--- a/liana-gui/src/app/state/mod.rs
+++ b/liana-gui/src/app/state/mod.rs
@@ -254,7 +254,7 @@ impl State for Home {
                     }
                 }
             },
-            Message::UpdatePanelCache(is_current, Ok(cache)) => {
+            Message::UpdatePanelCache(is_current) => {
                 let wallet_was_syncing = !self.sync_status.is_synced();
                 self.sync_status = sync_status(
                     daemon.backend(),

--- a/liana-gui/src/app/state/settings/bitcoind.rs
+++ b/liana-gui/src/app/state/settings/bitcoind.rs
@@ -136,6 +136,9 @@ impl State for BitcoindSettingsState {
                 self.rescan_settings.past_possible_height = true;
                 self.rescan_settings.processing = false;
             }
+            Message::UpdatePanelCache(_, Ok(_)) => {
+                self.rescan_settings.processing = cache.rescan_progress.is_some_and(|p| p < 1.0);
+            }
             Message::View(view::Message::Settings(view::SettingsMessage::BitcoindSettings(
                 msg,
             ))) => {

--- a/liana-gui/src/app/state/settings/bitcoind.rs
+++ b/liana-gui/src/app/state/settings/bitcoind.rs
@@ -136,7 +136,7 @@ impl State for BitcoindSettingsState {
                 self.rescan_settings.past_possible_height = true;
                 self.rescan_settings.processing = false;
             }
-            Message::UpdatePanelCache(_, Ok(_)) => {
+            Message::UpdatePanelCache(_) => {
                 self.rescan_settings.processing = cache.rescan_progress.is_some_and(|p| p < 1.0);
             }
             Message::View(view::Message::Settings(view::SettingsMessage::BitcoindSettings(


### PR DESCRIPTION
This is to fix #1528.

It updates the `processing` field of the rescan settings each time the cache is updated.