### PR TITLE
Modify how Taproot signatures are merged when updating PSBT

### DIFF
--- a/liana-gui/src/app/state/psbt.rs
+++ b/liana-gui/src/app/state/psbt.rs
@@ -711,6 +711,12 @@ impl Action for UpdateAction {
                                 input
                                     .partial_sigs
                                     .extend(updated_input.partial_sigs.clone().into_iter());
+                                input
+                                    .tap_script_sigs
+                                    .extend(updated_input.tap_script_sigs.iter());
+                                if let Some(sig) = updated_input.tap_key_sig {
+                                    input.tap_key_sig = Some(sig);
+                                }
                             }
                         }
                         tx.sigs = self


### PR DESCRIPTION
This reverts the change from #1519, which changed slightly the logic (the `merge_signatures` function doesn't check the previous outputs are the same in the PSBT inputs at each index) and applies a smaller change to add just the missing Taproot sigs.

~~Possibly~~ After further testing, it appears that this is not related to #1533.