### PR TITLE
export: list transaction in chronological order

### DIFF
--- a/liana-gui/src/export.rs
+++ b/liana-gui/src/export.rs
@@ -268,7 +268,7 @@ impl State {
                 }
 
                 let mut txs: Vec<_> = map.into_values().collect();
-                txs.sort_by(|a, b| a.compare(b));
+                txs.sort_by(|a, b| b.compare(a));
 
                 for mut tx in txs {
                     let date_time = tx


### PR DESCRIPTION
backport of #1537 