### PR TITLE
skip policy compilation when parsing descriptor

### DIFF
--- a/liana/src/descriptors/mod.rs
+++ b/liana/src/descriptors/mod.rs
@@ -115,7 +115,10 @@ impl str::FromStr for LianaDescriptor {
     fn from_str(s: &str) -> Result<LianaDescriptor, Self::Err> {
         // Parse a descriptor and check it is a multipath descriptor corresponding to a valid Liana
         // spending policy.
+        // Sanity checks are not always performed when calling `Descriptor::from_str`, so we perform
+        // them explicitly. See https://github.com/rust-bitcoin/rust-miniscript/issues/734.
         let desc = descriptor::Descriptor::<descriptor::DescriptorPublicKey>::from_str(s)
+            .and_then(|desc| desc.sanity_check().map(|_| desc))
             .map_err(LianaDescError::Miniscript)?;
         LianaPolicy::from_multipath_descriptor(&desc)?;
 


### PR DESCRIPTION
This allows to create a new `LianaPolicy` without checking that it compiles into miniscript. This compilation check is used as a sanity check on the policy in addition to other Liana-specific checks, but this compiled policy is not otherwise used.

When parsing an existing descriptor, we will assume that the policy can be compiled. Otherwise, the method `LianaPolicy::from_multipath_descriptor` ends up calling `LianaPolicy::into_multipath_descriptor_fallible`.

A `LianaPolicy` is created from a descriptor each time we call `LianaDescriptor::from_str`, which is done often, e.g. when updating derivation indices in the DB. Removing the compilation check won't affect the `LianaDescriptor` that we end up with when parsing a string as we already use the `Descriptor` obtained from parsing the string rather than that obtained by compilation of the policy.

This change is particularly important with the upcoming upgrade to miniscript 12.0, which has been found to increase Liana policy compilation times significantly.

An additional option would be to reduce the number of times we call `LianaDescriptor::from_str`, e.g. by passing the descriptor as a parameter rather than reading from DB, but this current change should address the main performance issues.