### PR TITLE
Allow RBF without saved PSBT

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -276,7 +276,9 @@ This command does not return anything for now.
 
 ### `rbfpsbt`
 
-Create PSBT to replace the given transaction, which must point to a PSBT in our database, using RBF.
+Create PSBT to replace, using RBF, the given transaction, which must either point to a PSBT in our database
+(not necessarily broadcast) or an unconfirmed spend transaction (whether or not any associated
+PSBT is saved in our database).
 
 This command can be used to either:
 - "cancel" the transaction: the replacement will include at least one input from the previous transaction and will have only

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1144,13 +1144,9 @@ def test_rbfpsbt_bump_fee(lianad, bitcoind):
     # Using a higher feerate works.
     lianad.rpc.rbfpsbt(first_txid, False, 2)
 
-    # But we cannot use RBF if the PSBT is no longer in the DB.
+    # We can still use RBF if the PSBT is no longer in the DB.
     lianad.rpc.delspendtx(first_txid)
-    with pytest.raises(RpcError, match=f"Unknown spend transaction '{first_txid}'."):
-        lianad.rpc.rbfpsbt(first_txid, False, 2)
-
-    # Now re-save the PSBT in the DB.
-    lianad.rpc.updatespend(first_psbt.to_base64())
+    lianad.rpc.rbfpsbt(first_txid, False, 2)
 
     # Let's use an even higher feerate.
     rbf_1_res = lianad.rpc.rbfpsbt(first_txid, False, 10)
@@ -1192,9 +1188,14 @@ def test_rbfpsbt_bump_fee(lianad, bitcoind):
         mempool_rbf_1["fees"]["ancestor"] * COIN / mempool_rbf_1["ancestorsize"]
     )
     assert 9.75 < rbf_1_feerate < 10.25
-    # If we try to RBF the first transaction again, it will use the first RBF's
-    # feerate to set the min feerate, instead of 1 sat/vb of first
-    # transaction:
+    # If we try to RBF the first transaction again, it will not be possible as we
+    # deleted the PSBT above and the tx is no longer part of our wallet's
+    # spending txs (even though it's saved in the DB).
+    with pytest.raises(RpcError, match=f"Unknown spend transaction '{first_txid}'."):
+        lianad.rpc.rbfpsbt(first_txid, False, 2)
+    # If we resave the PSBT, then we can use RBF and it will use the first RBF's
+    # feerate to set the min feerate, instead of 1 sat/vb of the first transaction:
+    lianad.rpc.updatespend(first_psbt.to_base64())
     with pytest.raises(
         RpcError,
         match=f"Feerate {int(rbf_1_feerate)} too low for minimum feerate {int(rbf_1_feerate) + 1}.",

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1143,6 +1143,15 @@ def test_rbfpsbt_bump_fee(lianad, bitcoind):
         lianad.rpc.rbfpsbt(first_txid, False, 1)
     # Using a higher feerate works.
     lianad.rpc.rbfpsbt(first_txid, False, 2)
+
+    # But we cannot use RBF if the PSBT is no longer in the DB.
+    lianad.rpc.delspendtx(first_txid)
+    with pytest.raises(RpcError, match=f"Unknown spend transaction '{first_txid}'."):
+        lianad.rpc.rbfpsbt(first_txid, False, 2)
+
+    # Now re-save the PSBT in the DB.
+    lianad.rpc.updatespend(first_psbt.to_base64())
+
     # Let's use an even higher feerate.
     rbf_1_res = lianad.rpc.rbfpsbt(first_txid, False, 10)
     rbf_1_psbt = PSBT.from_base64(rbf_1_res["psbt"])


### PR DESCRIPTION
This is to fix #854 when using a local node. If we don't have the PSBT saved in our DB, we query the wallet transaction instead.

The Liana Connect backend will also need to be updated in a similar way.