### PR TITLE
gui(installer): prevent deletion of all recovery paths

### DIFF
--- a/liana-gui/src/installer/step/descriptor/editor/mod.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/mod.rs
@@ -508,6 +508,7 @@ impl Step for DefineDescriptor {
                         threshold: p.threshold,
                         keys: self.path_keys(p),
                     }),
+                self.paths.len().saturating_sub(1), // subtract 1 for primary path
                 self.valid(),
             ),
         };

--- a/liana-gui/src/installer/view/editor/template/custom.rs
+++ b/liana-gui/src/installer/view/editor/template/custom.rs
@@ -59,6 +59,7 @@ pub fn custom_template<'a>(
     use_taproot: bool,
     primary_path: Path<'a>,
     recovery_paths: &mut dyn Iterator<Item = Path<'a>>,
+    num_recovery_paths: usize,
     valid: bool,
 ) -> Element<'a, Message> {
     layout(
@@ -144,6 +145,9 @@ pub fn custom_template<'a>(
                                 .iter()
                                 .enumerate()
                                 .map(|(j, recovery_key)| {
+                                    // We cannot delete a key if doing so would remove all recovery paths,
+                                    // i.e. if there is only 1 recovery path and it contains only 1 key.
+                                    let fixed = num_recovery_paths < 2 && p.keys.len() < 2;
                                     if let Some(key) = recovery_key {
                                         defined_key(
                                             &key.name,
@@ -154,14 +158,14 @@ pub fn custom_template<'a>(
                                             } else {
                                                 None
                                             },
-                                            false,
+                                            fixed,
                                         )
                                     } else {
                                         undefined_key(
                                             color::ORANGE,
                                             "Recovery key",
                                             !p.keys[0..j].iter().any(|k| k.is_none()),
-                                            false,
+                                            fixed,
                                         )
                                     }
                                     .map(move |msg| message::DefinePath::Key(j, msg))


### PR DESCRIPTION
This is to fix #1407.

It lets a user delete a key from a recovery path only if there are at least two recovery paths or at least two keys in the given recovery path.