### PR TITLE
Refactor launcher

### DIFF
--- a/liana-gui/src/launcher/launcher_update.rs
+++ b/liana-gui/src/launcher/launcher_update.rs
@@ -1,37 +1,14 @@
-use std::path::PathBuf;
-
-use iced::{
-    alignment::Horizontal,
-    widget::{pick_list, scrollable, Button, Space},
-    Alignment, Length, Subscription, Task,
-};
-
-use liana::miniscript::bitcoin::Network;
-use liana_ui::{
-    component::{button, card, modal::Modal, network_banner, notification, text::*},
-    icon, image, theme,
-    widget::*,
-};
-use lianad::config::ConfigError;
-
-use crate::{app, installer::UserFlow};
-
-const NETWORKS: [Network; 4] = [
-    Network::Bitcoin,
-    Network::Testnet,
-    Network::Signet,
-    Network::Regtest,
-];
+use super::launcher::*;
 
 // ===================
 // ~~~~~~ STATE ~~~~~~
 // ===================
 pub struct Launcher {
-    state: WalletState,
-    network: Network,
+    pub(super) state: WalletState,
+    pub(super) network: Network,
     datadir_path: PathBuf,
-    error: Option<String>,
-    delete_wallet_modal: Option<DeleteWalletModal>,
+    pub(super) error: Option<String>,
+    pub(super) delete_wallet_modal: Option<DeleteWalletModal>,
 }
 
 // ===================
@@ -150,7 +127,7 @@ impl Launcher {
         }
     }
 
-    fn view_update(&mut self, view_message: ViewMessage) -> Option<Task<Message>> {
+    fn handle_view(&mut self, view_message: ViewMessage) -> Option<Task<Message>> {
         match view_message {
             ViewMessage::ImportWallet => Some(self.do_import_wallet()),
             ViewMessage::CreateWallet => Some(self.do_create_wallet()),
@@ -184,7 +161,7 @@ impl Launcher {
     pub fn update(&mut self, message: Message) -> Task<Message> {
         match message.clone() {
             Message::View(view_message) => self
-                .view_update(view_message)
+                .handle_view(view_message)
                 .unwrap_or(self.default_update(&message)),
             Message::Checked(res) => match res {
                 Err(e) => {
@@ -198,177 +175,6 @@ impl Launcher {
             },
             Message::Install(..) | Message::Run(..) => self.default_update(&message),
         }
-    }
-
-    fn view_wallet(
-        &self,
-        email: &Option<String>,
-        checksum: &Option<String>,
-    ) -> Column<ViewMessage> {
-        Column::new().push(
-            Row::new()
-                .align_y(Alignment::Center)
-                .spacing(20)
-                .push(
-                    Container::new(
-                        Button::new(
-                            Column::new()
-                                .push(p1_bold(format!(
-                                    "My Liana {} wallet",
-                                    match self.network {
-                                        Network::Bitcoin => "Bitcoin",
-                                        Network::Signet => "Signet",
-                                        Network::Testnet => "Testnet",
-                                        Network::Regtest => "Regtest",
-                                        _ => "",
-                                    }
-                                )))
-                                .push_maybe(checksum.as_ref().map(|checksum| {
-                                    p1_regular(format!("Liana-{}", checksum))
-                                        .style(theme::text::secondary)
-                                }))
-                                .push_maybe(email.as_ref().map(|email| {
-                                    Row::new()
-                                        .push(Space::with_width(Length::Fill))
-                                        .push(p1_regular(email).style(theme::text::secondary))
-                                })),
-                        )
-                        .on_press(ViewMessage::Run)
-                        .padding(15)
-                        .style(theme::button::container_border)
-                        .width(Length::Fill),
-                    )
-                    .style(theme::card::simple),
-                )
-                .push(
-                    Button::new(icon::trash_icon())
-                        .style(theme::button::secondary)
-                        .padding(10)
-                        .on_press(ViewMessage::DeleteWallet(DeleteWalletMessage::ShowModal)),
-                ),
-        )
-    }
-
-    fn view_no_wallet(&self) -> Column<ViewMessage> {
-        Column::new()
-            .push(
-                Row::new()
-                    .align_y(Alignment::End)
-                    .spacing(20)
-                    .push(
-                        Container::new(
-                            Column::new()
-                                .spacing(20)
-                                .align_x(Alignment::Center)
-                                .push(image::create_new_wallet_icon().width(Length::Fixed(100.0)))
-                                .push(
-                                    p1_regular("Create a new Liana wallet")
-                                        .style(theme::text::secondary),
-                                )
-                                .push(
-                                    button::secondary(None, "Select")
-                                        .width(Length::Fixed(200.0))
-                                        .on_press(ViewMessage::CreateWallet),
-                                )
-                                .align_x(Alignment::Center),
-                        )
-                        .padding(20),
-                    )
-                    .push(
-                        Container::new(
-                            Column::new()
-                                .spacing(20)
-                                .align_x(Alignment::Center)
-                                .push(image::restore_wallet_icon().width(Length::Fixed(100.0)))
-                                .push(
-                                    p1_regular("Add an existing Liana wallet")
-                                        .style(theme::text::secondary),
-                                )
-                                .push(
-                                    button::secondary(None, "Select")
-                                        .width(Length::Fixed(200.0))
-                                        .on_press(ViewMessage::ImportWallet),
-                                )
-                                .align_x(Alignment::Center),
-                        )
-                        .padding(20),
-                    ),
-            )
-            .align_x(Alignment::Center)
-    }
-
-    fn view_navigation_bar(&self) -> Row<ViewMessage> {
-        Row::new()
-            .spacing(20)
-            .push(
-                Container::new(image::liana_brand_grey().width(Length::Fixed(200.0)))
-                    .width(Length::Fill),
-            )
-            .push(button::secondary(None, "Share Xpubs").on_press(ViewMessage::ShareXpubs))
-            .push(
-                pick_list(
-                    &NETWORKS[..],
-                    Some(self.network),
-                    ViewMessage::SelectNetwork,
-                )
-                .style(theme::pick_list::primary)
-                .padding(10),
-            )
-            .align_y(Alignment::Center)
-            .padding(100)
-    }
-
-    fn view_body(&self) -> Container<ViewMessage> {
-        Container::new(
-            Column::new()
-                .align_x(Alignment::Center)
-                .spacing(30)
-                .push(if matches!(self.state, WalletState::Wallet { .. }) {
-                    text("Welcome back").size(50).bold()
-                } else {
-                    text("Welcome").size(50).bold()
-                })
-                .push_maybe(self.error.as_ref().map(|e| card::simple(text(e))))
-                .push(match &self.state {
-                    WalletState::Unchecked => Column::new(),
-                    WalletState::Wallet {
-                        email, checksum, ..
-                    } => self.view_wallet(email, checksum),
-                    WalletState::NoWallet => self.view_no_wallet(),
-                })
-                .max_width(500),
-        )
-    }
-
-    fn with_children<'a>(&'a self, content: Element<'a, Message>) -> Element<'a, Message> {
-        if self.network != Network::Bitcoin {
-            Column::with_children(vec![network_banner(self.network).into(), content]).into()
-        } else {
-            content
-        }
-    }
-
-    fn with_modal<'a>(&'a self, content: Element<'a, Message>) -> Element<'a, Message> {
-        if let Some(modal) = &self.delete_wallet_modal {
-            Modal::new(Container::new(content).height(Length::Fill), modal.view())
-                .on_blur(Some(Message::View(ViewMessage::DeleteWallet(
-                    DeleteWalletMessage::CloseModal,
-                ))))
-                .into()
-        } else {
-            content
-        }
-    }
-
-    pub fn view(&self) -> Element<Message> {
-        let content = Into::<Element<ViewMessage>>::into(scrollable(
-            Column::new()
-                .push(self.view_navigation_bar())
-                .push(self.view_body().center_x(Length::Fill))
-                .push(Space::with_height(Length::Fixed(100.0))),
-        ))
-        .map(Message::View);
-        self.with_modal(self.with_children(content))
     }
 }
 
@@ -400,7 +206,7 @@ pub enum DeleteWalletMessage {
     Deleted,
 }
 
-struct DeleteWalletModal {
+pub(super) struct DeleteWalletModal {
     network: Network,
     wallet_datadir: PathBuf,
     warning: Option<std::io::Error>,
@@ -434,7 +240,8 @@ impl DeleteWalletModal {
         }
         Task::none()
     }
-    fn view(&self) -> Element<Message> {
+
+    pub(super) fn view(&self) -> Element<Message> {
         let mut confirm_button = button::secondary(None, "Delete wallet")
             .width(Length::Fixed(200.0))
             .style(theme::button::destructive);

--- a/liana-gui/src/launcher/launcher_view.rs
+++ b/liana-gui/src/launcher/launcher_view.rs
@@ -1,0 +1,178 @@
+use super::launcher::*;
+
+impl Launcher {
+    pub fn view(&self) -> Element<Message> {
+        let content = self.view_core().map(Message::View);
+        self.with_modal(self.with_children(content))
+    }
+
+    fn view_core(&self) -> Element<ViewMessage> {
+        scrollable(
+            Column::new()
+                .push(self.view_navigation_bar())
+                .push(self.view_body().center_x(Length::Fill))
+                .push(Space::with_height(Length::Fixed(100.0))),
+        )
+        .into()
+    }
+
+    fn view_body(&self) -> Container<ViewMessage> {
+        Container::new(
+            Column::new()
+                .align_x(Alignment::Center)
+                .spacing(30)
+                .push(if matches!(self.state, WalletState::Wallet { .. }) {
+                    text("Welcome back").size(50).bold()
+                } else {
+                    text("Welcome").size(50).bold()
+                })
+                .push_maybe(self.error.as_ref().map(|e| card::simple(text(e))))
+                .push(match &self.state {
+                    WalletState::Unchecked => Column::new(),
+                    WalletState::Wallet {
+                        email, checksum, ..
+                    } => self.view_wallet(email, checksum),
+                    WalletState::NoWallet => self.view_no_wallet(),
+                })
+                .max_width(500),
+        )
+    }
+
+    fn view_wallet(
+        &self,
+        email: &Option<String>,
+        checksum: &Option<String>,
+    ) -> Column<ViewMessage> {
+        Column::new().push(
+            Row::new()
+                .align_y(Alignment::Center)
+                .spacing(20)
+                .push(
+                    Container::new(
+                        Button::new(
+                            Column::new()
+                                .push(p1_bold(format!(
+                                    "My Liana {} wallet",
+                                    match self.network {
+                                        Network::Bitcoin => "Bitcoin",
+                                        Network::Signet => "Signet",
+                                        Network::Testnet => "Testnet",
+                                        Network::Regtest => "Regtest",
+                                        _ => "",
+                                    }
+                                )))
+                                .push_maybe(checksum.as_ref().map(|checksum| {
+                                    p1_regular(format!("Liana-{}", checksum))
+                                        .style(theme::text::secondary)
+                                }))
+                                .push_maybe(email.as_ref().map(|email| {
+                                    Row::new()
+                                        .push(Space::with_width(Length::Fill))
+                                        .push(p1_regular(email).style(theme::text::secondary))
+                                })),
+                        )
+                        .on_press(ViewMessage::Run)
+                        .padding(15)
+                        .style(theme::button::container_border)
+                        .width(Length::Fill),
+                    )
+                    .style(theme::card::simple),
+                )
+                .push(
+                    Button::new(icon::trash_icon())
+                        .style(theme::button::secondary)
+                        .padding(10)
+                        .on_press(ViewMessage::DeleteWallet(DeleteWalletMessage::ShowModal)),
+                ),
+        )
+    }
+
+    fn view_no_wallet(&self) -> Column<ViewMessage> {
+        Column::new()
+            .push(
+                Row::new()
+                    .align_y(Alignment::End)
+                    .spacing(20)
+                    .push(
+                        Container::new(
+                            Column::new()
+                                .spacing(20)
+                                .align_x(Alignment::Center)
+                                .push(image::create_new_wallet_icon().width(Length::Fixed(100.0)))
+                                .push(
+                                    p1_regular("Create a new Liana wallet")
+                                        .style(theme::text::secondary),
+                                )
+                                .push(
+                                    button::secondary(None, "Select")
+                                        .width(Length::Fixed(200.0))
+                                        .on_press(ViewMessage::CreateWallet),
+                                )
+                                .align_x(Alignment::Center),
+                        )
+                        .padding(20),
+                    )
+                    .push(
+                        Container::new(
+                            Column::new()
+                                .spacing(20)
+                                .align_x(Alignment::Center)
+                                .push(image::restore_wallet_icon().width(Length::Fixed(100.0)))
+                                .push(
+                                    p1_regular("Add an existing Liana wallet")
+                                        .style(theme::text::secondary),
+                                )
+                                .push(
+                                    button::secondary(None, "Select")
+                                        .width(Length::Fixed(200.0))
+                                        .on_press(ViewMessage::ImportWallet),
+                                )
+                                .align_x(Alignment::Center),
+                        )
+                        .padding(20),
+                    ),
+            )
+            .align_x(Alignment::Center)
+    }
+
+    fn view_navigation_bar(&self) -> Row<ViewMessage> {
+        Row::new()
+            .spacing(20)
+            .push(
+                Container::new(image::liana_brand_grey().width(Length::Fixed(200.0)))
+                    .width(Length::Fill),
+            )
+            .push(button::secondary(None, "Share Xpubs").on_press(ViewMessage::ShareXpubs))
+            .push(
+                pick_list(
+                    &NETWORKS[..],
+                    Some(self.network),
+                    ViewMessage::SelectNetwork,
+                )
+                .style(theme::pick_list::primary)
+                .padding(10),
+            )
+            .align_y(Alignment::Center)
+            .padding(100)
+    }
+
+    fn with_children<'a>(&'a self, content: Element<'a, Message>) -> Element<'a, Message> {
+        if self.network != Network::Bitcoin {
+            Column::with_children(vec![network_banner(self.network).into(), content]).into()
+        } else {
+            content
+        }
+    }
+
+    fn with_modal<'a>(&'a self, content: Element<'a, Message>) -> Element<'a, Message> {
+        if let Some(modal) = &self.delete_wallet_modal {
+            Modal::new(Container::new(content).height(Length::Fill), modal.view())
+                .on_blur(Some(Message::View(ViewMessage::DeleteWallet(
+                    DeleteWalletMessage::CloseModal,
+                ))))
+                .into()
+        } else {
+            content
+        }
+    }
+}

--- a/liana-gui/src/launcher/mod.rs
+++ b/liana-gui/src/launcher/mod.rs
@@ -28,6 +28,7 @@ pub(super) mod prelude {
 mod launcher_update;
 mod launcher_view;
 
+#[allow(clippy::module_inception)]
 pub mod launcher {
     pub use super::launcher_update::*;
     pub(super) use super::prelude::*;

--- a/liana-gui/src/launcher/mod.rs
+++ b/liana-gui/src/launcher/mod.rs
@@ -1,0 +1,36 @@
+pub(super) mod prelude {
+    pub(super) use std::path::PathBuf;
+
+    pub(super) use iced::{
+        alignment::Horizontal,
+        widget::{pick_list, scrollable, Button, Space},
+        Alignment, Length, Subscription, Task,
+    };
+
+    pub(super) use liana::miniscript::bitcoin::Network;
+    pub(super) use liana_ui::{
+        component::{button, card, modal::Modal, network_banner, notification, text::*},
+        icon, image, theme,
+        widget::*,
+    };
+    pub(super) use lianad::config::ConfigError;
+
+    pub(super) use crate::{app, installer::UserFlow};
+
+    pub(super) const NETWORKS: [Network; 4] = [
+        Network::Bitcoin,
+        Network::Testnet,
+        Network::Signet,
+        Network::Regtest,
+    ];
+}
+
+mod launcher_update;
+mod launcher_view;
+
+pub mod launcher {
+    pub use super::launcher_update::*;
+    pub(super) use super::prelude::*;
+}
+
+pub use launcher::*;


### PR DESCRIPTION
> [!NOTE]
> This is an **opinionated** refactoring of the `Launcher` feature - I completely understand if you dislike/hate
> this style! 

I'm new to GUI in Rust and Iced - but I've developed Redux styled applications in SwiftUI using [TCA][tca] for many years, where it is quite a common pattern to split:
* View and logic into seperate files
* Split large view methods into many sub-view methods
* Split large `update` methods into smaller sub-update methods

Which is what I've done in this PR - mostly to ask for input if it is something you as maintainers of Liana  or the ICED community in large likes?

> [!TIP]
> The advantages of this approach is two fold:
> 1. Un-doom the pyramid of doom; less indentation in deeply nested views 
> 2. Code search/goto-ability improved; especially with file split one can faster get to the relevant code, and with search/goto _symbol_ one can go straight to a method for a subview or an handle Message method.

# Other changes
* Exhaustive match on message in update => safer code

[tca]: https://github.com/pointfreeco/swift-composable-architecture