### PR TITLE
Fetch and redeem provider keys using tokens

### DIFF
--- a/liana-gui/src/app/state/settings/wallet.rs
+++ b/liana-gui/src/app/state/settings/wallet.rs
@@ -82,6 +82,7 @@ impl State for WalletSettingsState {
             self.warning.as_ref(),
             &self.descriptor,
             &self.keys_aliases,
+            &self.wallet.provider_keys,
             self.processing,
             self.updated,
         );
@@ -389,6 +390,7 @@ async fn update_keys_aliases(
                 .map(|(master_fingerprint, name)| settings::KeySetting {
                     master_fingerprint: *master_fingerprint,
                     name: name.clone(),
+                    provider_key: wallet.provider_keys.get(master_fingerprint).cloned(),
                 })
                 .collect();
         }

--- a/liana-gui/src/installer/context.rs
+++ b/liana-gui/src/installer/context.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -56,7 +57,7 @@ pub struct Context {
     pub bitcoin_backend: Option<BitcoinBackend>,
     pub descriptor_template: DescriptorTemplate,
     pub descriptor: Option<LianaDescriptor>,
-    pub keys: Vec<KeySetting>,
+    pub keys: HashMap<bitcoin::bip32::Fingerprint, KeySetting>,
     pub hws: Vec<(DeviceKind, bitcoin::bip32::Fingerprint, Option<[u8; 32]>)>,
     pub data_dir: PathBuf,
     pub network: bitcoin::Network,
@@ -83,7 +84,7 @@ impl Context {
                 poll_interval_secs: Duration::from_secs(30),
             },
             hws: Vec::new(),
-            keys: Vec::new(),
+            keys: HashMap::new(),
             bitcoin_backend: None,
             descriptor: None,
             data_dir,

--- a/liana-gui/src/installer/descriptor.rs
+++ b/liana-gui/src/installer/descriptor.rs
@@ -1,0 +1,242 @@
+use async_hwi::{DeviceKind, Version};
+use liana::miniscript::{bitcoin::bip32::Fingerprint, descriptor::DescriptorPublicKey};
+
+use crate::{
+    app::settings::ProviderKey, hw::is_compatible_with_tapminiscript, services::api::KeyKind,
+};
+
+/// Whether to enable cosigner keys on all paths (excluding safety net paths).
+const ENABLE_COSIGNER_KEYS: bool = true; // FIXME: Set to false after testing.
+
+/// The source of a descriptor public key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeySource {
+    /// A hardware signing device with the given kind and version.
+    Device(DeviceKind, Option<Version>),
+    /// A hot signer on the user's computer.
+    HotSigner,
+    /// A manually inserted xpub.
+    Manual,
+    /// A token for a key with the given kind.
+    Token(KeyKind, ProviderKey),
+}
+
+impl KeySource {
+    pub fn device_kind(&self) -> Option<&DeviceKind> {
+        if let KeySource::Device(ref device_kind, _) = self {
+            Some(device_kind)
+        } else {
+            None
+        }
+    }
+
+    pub fn device_version(&self) -> Option<&Version> {
+        if let KeySource::Device(_, ref version) = self {
+            version.as_ref()
+        } else {
+            None
+        }
+    }
+
+    pub fn is_compatible_taproot(&self) -> bool {
+        if let KeySource::Device(ref device_kind, ref version) = self {
+            is_compatible_with_tapminiscript(device_kind, version.as_ref())
+        } else {
+            true
+        }
+    }
+
+    pub fn is_manual(&self) -> bool {
+        matches!(self, KeySource::Manual)
+    }
+
+    pub fn is_token(&self) -> bool {
+        matches!(self, KeySource::Token(_, _))
+    }
+
+    pub fn kind(&self) -> KeySourceKind {
+        match self {
+            Self::Device(_, _) => KeySourceKind::Device,
+            Self::HotSigner => KeySourceKind::HotSigner,
+            Self::Manual => KeySourceKind::Manual,
+            Self::Token(kind, _) => KeySourceKind::Token(*kind),
+        }
+    }
+
+    pub fn token(&self) -> Option<&String> {
+        if let KeySource::Token(_, ProviderKey { token, .. }) = self {
+            Some(token)
+        } else {
+            None
+        }
+    }
+
+    pub fn provider_key(&self) -> Option<ProviderKey> {
+        if let KeySource::Token(_, provider_key) = self {
+            Some(provider_key.clone())
+        } else {
+            None
+        }
+    }
+
+    pub fn provider_key_kind(&self) -> Option<KeyKind> {
+        if let KeySource::Token(key_kind, _) = self {
+            Some(*key_kind)
+        } else {
+            None
+        }
+    }
+}
+
+/// The kind of `KeySource`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+pub enum KeySourceKind {
+    /// A hardware signing device.
+    Device,
+    /// A hot signer.
+    HotSigner,
+    /// A manually inserted xpub.
+    Manual,
+    /// A token for a key with the given kind.
+    Token(KeyKind),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Key {
+    pub source: KeySource,
+    pub name: String,
+    pub fingerprint: Fingerprint,
+    pub key: DescriptorPublicKey,
+}
+
+pub struct Path {
+    pub keys: Vec<Option<Key>>,
+    pub threshold: usize,
+    pub sequence: PathSequence,
+    pub warning: Option<PathWarning>,
+}
+
+impl Path {
+    pub fn new(kind: PathKind) -> Self {
+        let sequence = match kind {
+            PathKind::Primary => PathSequence::Primary,
+            PathKind::Recovery => PathSequence::Recovery(52_596), // displays "1y" in GUI
+            PathKind::SafetyNet => PathSequence::SafetyNet,
+        };
+        Self {
+            keys: vec![None],
+            threshold: 1,
+            sequence,
+            warning: None,
+        }
+    }
+
+    pub fn new_primary_path() -> Self {
+        Self::new(PathKind::Primary)
+    }
+
+    pub fn new_recovery_path() -> Self {
+        Self::new(PathKind::Recovery)
+    }
+
+    pub fn new_safety_net_path() -> Self {
+        Self::new(PathKind::SafetyNet)
+    }
+
+    pub fn with_n_keys(mut self, n: usize) -> Self {
+        self.keys = Vec::new();
+        for _i in 0..n {
+            self.keys.push(None);
+        }
+        self
+    }
+
+    pub fn with_threshold(mut self, t: usize) -> Self {
+        self.threshold = if t > self.keys.len() {
+            self.keys.len()
+        } else {
+            t
+        };
+        self
+    }
+
+    pub fn kind(&self) -> PathKind {
+        self.sequence.path_kind()
+    }
+
+    pub fn valid(&self) -> bool {
+        !self.keys.is_empty() && !self.keys.iter().any(|k| k.is_none()) && self.warning.is_none()
+    }
+}
+
+/// The kind of spending path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathKind {
+    Primary,
+    Recovery,
+    SafetyNet,
+}
+
+impl PathKind {
+    /// Whether a key with the given `KeySourceKind` can be chosen for this `PathKind`.
+    pub fn can_choose_key_source_kind(&self, source_kind: &KeySourceKind) -> bool {
+        match (self, source_kind) {
+            // Safety net path only allows safety net keys.
+            (Self::SafetyNet, KeySourceKind::Token(KeyKind::SafetyNet)) => true,
+            (Self::SafetyNet, _) => false,
+            // Safety net keys cannot be used in any other path kind.
+            (_, KeySourceKind::Token(KeyKind::SafetyNet)) => false,
+            // Enable/disable cosigner keys.
+            (_, KeySourceKind::Token(KeyKind::Cosigner)) => ENABLE_COSIGNER_KEYS,
+            _ => true,
+        }
+    }
+}
+
+/// The sequence of a spending path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathSequence {
+    Primary,
+    Recovery(u16), // this excludes zero, but we don't enforce it here.
+    SafetyNet,
+}
+
+impl PathSequence {
+    pub fn as_u16(&self) -> u16 {
+        match self {
+            Self::Primary => 0,
+            Self::Recovery(s) => *s,
+            Self::SafetyNet => u16::MAX,
+        }
+    }
+
+    pub fn path_kind(&self) -> PathKind {
+        match self {
+            Self::Primary => PathKind::Primary,
+            Self::Recovery(_) => PathKind::Recovery,
+            Self::SafetyNet => PathKind::SafetyNet,
+        }
+    }
+}
+
+/// A path warning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathWarning {
+    DuplicateSequence,
+    OnlyCosignerKeys,
+    KeySourceKindDisallowed,
+}
+
+impl PathWarning {
+    pub fn message(&self) -> &'static str {
+        match self {
+            Self::DuplicateSequence => {
+                "No two recovery options may become available at the very same date."
+            }
+            Self::OnlyCosignerKeys => "A path cannot contain only cosigner keys.",
+            Self::KeySourceKindDisallowed => {
+                "Path contains a key that is disallowed for this kind of path."
+            }
+        }
+    }
+}

--- a/liana-gui/src/installer/message.rs
+++ b/liana-gui/src/installer/message.rs
@@ -6,20 +6,22 @@ use std::path::PathBuf;
 
 use super::{context, Error};
 use crate::{
+    app::settings::ProviderKey,
     download::{DownloadError, Progress},
     hw::HardwareWalletMessage,
-    installer::step::descriptor::editor::key::Key,
+    installer::descriptor::{Key, PathKind},
     lianalite::client::{auth::AuthClient, backend::api},
     node::{
         bitcoind::{Bitcoind, ConfigField, RpcAuthType},
         electrum, NodeType,
     },
+    services,
 };
 
 #[derive(Debug, Clone)]
 pub enum Message {
     UserActionDone(bool),
-    Exit(PathBuf, Option<Bitcoind>),
+    Exit(PathBuf, Option<Bitcoind>, /* remove log */ bool),
     Clibpboard(String),
     Next,
     Skip,
@@ -44,6 +46,9 @@ pub enum Message {
     WalletRegistered(Result<(Fingerprint, Option<[u8; 32]>), Error>),
     MnemonicWord(usize, String),
     ImportMnemonic(bool),
+    RedeemNextKey,
+    KeyRedeemed(ProviderKey, Result<(), services::Error>),
+    AllKeysRedeemed,
 }
 
 #[derive(Debug, Clone)]
@@ -114,9 +119,10 @@ pub enum DefineDescriptor {
     ChangeTemplate(context::DescriptorTemplate),
     ImportDescriptor(String),
     KeysEdited(Vec<(usize, usize)>, Key),
-    KeysEdit(Vec<(usize, usize)>),
+    KeysEdit(PathKind, Vec<(usize, usize)>),
     Path(usize, DefinePath),
     AddRecoveryPath,
+    AddSafetyNetPath,
     KeyModal(ImportKeyModal),
     ThresholdSequenceModal(ThresholdSequenceModal),
 }
@@ -147,6 +153,9 @@ pub enum ImportKeyModal {
     NameEdited(String),
     ManuallyImportXpub,
     ConfirmXpub,
+    UseToken(services::api::KeyKind),
+    TokenEdited(String),
+    ConfirmToken,
     SelectKey(usize),
 }
 

--- a/liana-gui/src/installer/step/descriptor/mod.rs
+++ b/liana-gui/src/installer/step/descriptor/mod.rs
@@ -16,7 +16,7 @@ use liana_ui::{component::form, widget::Element};
 use async_hwi::DeviceKind;
 
 use crate::{
-    app::wallet::wallet_name,
+    app::{settings::KeySetting, wallet::wallet_name},
     hw::{HardwareWallet, HardwareWallets},
     installer::{
         message::{self, Message},
@@ -169,7 +169,7 @@ impl Step for RegisterDescriptor {
         }
         self.descriptor.clone_from(&ctx.descriptor);
         let mut map = HashMap::new();
-        for key in ctx.keys.iter().filter(|k| !k.name.is_empty()) {
+        for key in ctx.keys.values().filter(|k| !k.name.is_empty()) {
             map.insert(key.master_fingerprint, key.name.clone());
         }
     }
@@ -291,7 +291,7 @@ impl From<RegisterDescriptor> for Box<dyn Step> {
 pub struct BackupDescriptor {
     done: bool,
     descriptor: Option<LianaDescriptor>,
-    key_aliases: HashMap<Fingerprint, String>,
+    keys: HashMap<Fingerprint, KeySetting>,
 }
 
 impl Step for BackupDescriptor {
@@ -306,12 +306,11 @@ impl Step for BackupDescriptor {
             self.descriptor.clone_from(&ctx.descriptor);
             self.done = false;
         }
-        self.key_aliases = ctx
+        self.keys = ctx
             .keys
-            .iter()
-            .cloned()
-            .map(|k| (k.master_fingerprint, k.name))
-            .collect()
+            .values()
+            .map(|k| (k.master_fingerprint, k.clone()))
+            .collect();
     }
     fn view<'a>(
         &'a self,
@@ -323,7 +322,7 @@ impl Step for BackupDescriptor {
             progress,
             email,
             self.descriptor.as_ref().expect("Must be a descriptor"),
-            &self.key_aliases,
+            &self.keys,
             self.done,
         )
     }

--- a/liana-gui/src/installer/step/mod.rs
+++ b/liana-gui/src/installer/step/mod.rs
@@ -19,17 +19,20 @@ pub use descriptor::{
 pub use backend::{ChooseBackend, ImportRemoteWallet, RemoteBackendLogin};
 pub use mnemonic::{BackupMnemonic, RecoverMnemonic};
 pub use share_xpubs::ShareXpubs;
+use tracing::warn;
 
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use iced::{Subscription, Task};
 
 use liana_ui::widget::*;
 
 use crate::{
+    app::settings::ProviderKey,
     hw::HardwareWallets,
     installer::{context::Context, message::Message, view},
     node::bitcoind::Bitcoind,
+    services,
 };
 
 pub trait Step {
@@ -65,6 +68,7 @@ pub struct Final {
     internal_bitcoind: Option<Bitcoind>,
     warning: Option<String>,
     config_path: Option<PathBuf>,
+    key_redemptions: HashMap<ProviderKey, Option<Result<(), services::Error>>>,
 }
 
 impl Final {
@@ -74,6 +78,7 @@ impl Final {
             generating: false,
             warning: None,
             config_path: None,
+            key_redemptions: HashMap::new(),
         }
     }
 }
@@ -87,6 +92,11 @@ impl Default for Final {
 impl Step for Final {
     fn load_context(&mut self, ctx: &Context) {
         self.internal_bitcoind.clone_from(&ctx.internal_bitcoind);
+        self.key_redemptions = ctx
+            .keys
+            .values()
+            .filter_map(|ks| ks.provider_key.as_ref().map(|pk| (pk.clone(), None)))
+            .collect();
     }
     fn load(&self) -> Task<Message> {
         if !self.generating && self.config_path.is_none() {
@@ -97,24 +107,62 @@ impl Step for Final {
     }
     fn update(&mut self, _hws: &mut HardwareWallets, message: Message) -> Task<Message> {
         match message {
-            Message::Installed(res) => {
+            Message::RedeemNextKey => {
+                if let Some((pk, _)) = self.key_redemptions.iter().find(|(_, v)| v.is_none()) {
+                    let client = services::Client::new();
+                    let pk = pk.clone();
+                    return Task::perform(
+                        async move { (pk.clone(), client.redeem_key(pk.uuid, pk.token).await) },
+                        |(pk, res)| Message::KeyRedeemed(pk, res.map(|_| ())),
+                    );
+                }
+                return Task::perform(async move {}, |_| Message::AllKeysRedeemed);
+            }
+            Message::KeyRedeemed(pk, res) => {
+                if let Some(v) = self.key_redemptions.get_mut(&pk) {
+                    *v = Some(res);
+                }
+                return Task::perform(async move {}, |_| Message::RedeemNextKey);
+            }
+            Message::AllKeysRedeemed => {
                 self.generating = false;
-                match res {
-                    Err(e) => {
-                        self.config_path = None;
-                        self.warning = Some(e.to_string());
-                    }
-                    Ok(path) => {
-                        self.config_path = Some(path.clone());
-                        let internal_bitcoind = self.internal_bitcoind.clone();
-                        let path = path.clone();
-                        return Task::perform(
-                            async { (path, internal_bitcoind) },
-                            |(path, internal_bitcoind)| Message::Exit(path, internal_bitcoind),
-                        );
+                // If any errors occurred redeeming tokens, add a warning to the log.
+                let mut has_error = false;
+                for (pk, res) in &self.key_redemptions {
+                    if let Some(res) = res {
+                        if let Err(e) = res {
+                            warn!("Error redeeming key for token '{}': '{}'.", pk.token, e);
+                            has_error = true;
+                        }
+                    } else {
+                        // We expect to have all redemption results by now.
+                        warn!("Missing redemption info for token '{}'.", pk.token);
+                        has_error = true;
                     }
                 }
+                // Now exit the installer whether or not any redemption errors occurred.
+                let internal_bitcoind = self.internal_bitcoind.clone();
+                let path = self.config_path.clone().expect("config path already set");
+                // If there were any errors, don't remove the installer log.
+                return Task::perform(
+                    async move { (path, internal_bitcoind, has_error) },
+                    |(path, internal_bitcoind, has_error)| {
+                        Message::Exit(path, internal_bitcoind, !has_error)
+                    },
+                );
             }
+            Message::Installed(res) => match res {
+                Err(e) => {
+                    self.generating = false;
+                    self.config_path = None;
+                    self.warning = Some(e.to_string());
+                }
+                Ok(path) => {
+                    self.config_path = Some(path.clone());
+                    // Now redeem any provider keys.
+                    return Task::perform(async move {}, |_| Message::RedeemNextKey);
+                }
+            },
             Message::Install => {
                 self.generating = true;
                 self.config_path = None;

--- a/liana-gui/src/installer/view/editor/template/custom.rs
+++ b/liana-gui/src/installer/view/editor/template/custom.rs
@@ -1,4 +1,8 @@
-use iced::{alignment, widget::Space, Alignment, Length};
+use iced::{
+    alignment,
+    widget::{tooltip, Container, Space},
+    Alignment, Length,
+};
 
 use liana_ui::{
     color,
@@ -11,13 +15,15 @@ use liana_ui::{
 };
 
 use crate::installer::{
+    descriptor::Path,
     message::{self, Message},
-    step::descriptor::editor::key::Key,
     view::{
         editor::{define_descriptor_advanced_settings, defined_key, path, undefined_key},
         layout,
     },
 };
+
+const SAFETY_NET_DESCRIPTION: &str = "This adds a final recovery option containing keys from professional key agents.\n\nUse this option if you have been provided one or more Safety Net tokens.";
 
 pub fn custom_template_description(progress: (usize, usize)) -> Element<'static, Message> {
     layout(
@@ -47,19 +53,13 @@ pub fn custom_template_description(progress: (usize, usize)) -> Element<'static,
     )
 }
 
-pub struct Path<'a> {
-    pub keys: Vec<Option<&'a Key>>,
-    pub sequence: u16,
-    pub duplicate_sequence: bool,
-    pub threshold: usize,
-}
-
 pub fn custom_template<'a>(
     progress: (usize, usize),
     use_taproot: bool,
-    primary_path: Path<'a>,
-    recovery_paths: &mut dyn Iterator<Item = Path<'a>>,
-    num_recovery_paths: usize,
+    primary_path: &'a Path,
+    recovery_paths: &mut dyn Iterator<Item = (usize, &'a Path)>,
+    safety_net_path: Option<(usize, &'a Path)>,
+    num_non_primary_paths: usize,
     valid: bool,
 ) -> Element<'a, Message> {
     let prim_keys_fixed = primary_path.keys.len() < 2; // can only delete a primary key if there are 2 or more
@@ -98,7 +98,7 @@ pub fn custom_template<'a>(
                     color::GREEN,
                     Some("Primary spending option:".to_string()),
                     primary_path.sequence,
-                    primary_path.duplicate_sequence,
+                    primary_path.warning,
                     primary_path.threshold,
                     primary_path
                         .keys
@@ -110,7 +110,7 @@ pub fn custom_template<'a>(
                                     &key.name,
                                     color::GREEN,
                                     "Primary key",
-                                    if use_taproot && !key.is_compatible_taproot {
+                                    if use_taproot && !key.source.is_compatible_taproot() {
                                         Some("This device does not support Taproot")
                                     } else {
                                         None
@@ -134,27 +134,28 @@ pub fn custom_template<'a>(
             )
             .push(recovery_paths.into_iter().enumerate().fold(
                 Column::new().spacing(20),
-                |col, (i, p)| {
+                |col, (i, (p_idx, p))| {
                     col.push(
                         path(
                             color::ORANGE,
                             Some(format!("Recovery option #{}:", i + 1)),
                             p.sequence,
-                            p.duplicate_sequence,
+                            p.warning,
                             p.threshold,
                             p.keys
                                 .iter()
                                 .enumerate()
                                 .map(|(j, recovery_key)| {
                                     // We cannot delete a key if doing so would remove all recovery paths,
-                                    // i.e. if there is only 1 recovery path and it contains only 1 key.
-                                    let fixed = num_recovery_paths < 2 && p.keys.len() < 2;
+                                    // i.e. if there is only 1 recovery path and it contains only 1 key,
+                                    // and there is no safety net path.
+                                    let fixed = num_non_primary_paths < 2 && p.keys.len() < 2;
                                     if let Some(key) = recovery_key {
                                         defined_key(
                                             &key.name,
                                             color::ORANGE,
                                             "Recovery key",
-                                            if use_taproot && !key.is_compatible_taproot {
+                                            if use_taproot && !key.source.is_compatible_taproot() {
                                                 Some("This device does not support Taproot")
                                             } else {
                                                 None
@@ -175,7 +176,10 @@ pub fn custom_template<'a>(
                             false,
                         )
                         .map(move |msg| {
-                            Message::DefineDescriptor(message::DefineDescriptor::Path(i + 1, msg))
+                            Message::DefineDescriptor(message::DefineDescriptor::Path(
+                                p_idx + 1, // add one to index to account for primary path.
+                                msg,
+                            ))
                         }),
                     )
                 },
@@ -189,12 +193,72 @@ pub fn custom_template<'a>(
                                 message::DefineDescriptor::AddRecoveryPath,
                             )),
                     )
-                    .push(Space::with_width(Length::Fill))
-                    .push(
-                        button::primary(None, "Continue")
-                            .width(Length::Fixed(200.0))
-                            .on_press_maybe(if valid { Some(Message::Next) } else { None }),
-                    ),
+                    .push_maybe(
+                        safety_net_path.is_none().then_some(tooltip::Tooltip::new(
+                            button::secondary(Some(icon::plus_icon()), "Add Safety Net")
+                                .width(Length::Fixed(210.0))
+                                .on_press(Message::DefineDescriptor(
+                                    message::DefineDescriptor::AddSafetyNetPath,
+                                )),
+                            Container::new(text(SAFETY_NET_DESCRIPTION))
+                                .style(theme::card::simple)
+                                .padding(10),
+                            tooltip::Position::Bottom,
+                        )),
+                    )
+                    .spacing(10),
+            )
+            .push_maybe(safety_net_path.map(|(sn_index, sn_path)| {
+                path(
+                    color::WHITE,
+                    Some("Safety Net:".to_string()),
+                    sn_path.sequence,
+                    sn_path.warning,
+                    sn_path.threshold,
+                    sn_path
+                        .keys
+                        .iter()
+                        .enumerate()
+                        .map(|(i, sn_key)| {
+                            // Cannot delete safety net key if doing so would remove the safety net path
+                            // and there are no other recovery paths.
+                            let fixed = num_non_primary_paths < 2 && sn_path.keys.len() < 2;
+                            if let Some(key) = sn_key {
+                                defined_key(
+                                    &key.name,
+                                    color::WHITE,
+                                    "Safety Net key",
+                                    if use_taproot && !key.source.is_compatible_taproot() {
+                                        Some("This key source does not support Taproot")
+                                    } else {
+                                        None
+                                    },
+                                    fixed,
+                                )
+                            } else {
+                                undefined_key(
+                                    color::WHITE,
+                                    "Safety Net key",
+                                    !sn_path.keys[0..i].iter().any(|k| k.is_none()),
+                                    fixed,
+                                )
+                            }
+                            .map(move |msg| message::DefinePath::Key(i, msg))
+                        })
+                        .collect(),
+                    false,
+                )
+                .map(move |msg| {
+                    // Add 1 to index to account for primary path.
+                    Message::DefineDescriptor(message::DefineDescriptor::Path(sn_index + 1, msg))
+                })
+            }))
+            .push(
+                Row::new().push(Space::with_width(Length::Fill)).push(
+                    button::primary(None, "Continue")
+                        .width(Length::Fixed(200.0))
+                        .on_press_maybe(if valid { Some(Message::Next) } else { None }),
+                ),
             )
             .push(Space::with_height(100.0))
             .spacing(20),

--- a/liana-gui/src/installer/view/editor/template/inheritance.rs
+++ b/liana-gui/src/installer/view/editor/template/inheritance.rs
@@ -12,8 +12,8 @@ use liana_ui::{
 
 use crate::installer::{
     context,
+    descriptor::{Path, PathSequence},
     message::{self, Message},
-    step::descriptor::editor::key::Key,
     view::{
         editor::{define_descriptor_advanced_settings, defined_key, path, undefined_key},
         layout,
@@ -67,11 +67,15 @@ After a period of inactivity (but not before that) your Inheritance Key will bec
 pub fn inheritance_template<'a>(
     progress: (usize, usize),
     use_taproot: bool,
-    primary_key: Option<&'a Key>,
-    recovery_key: Option<&'a Key>,
-    sequence: u16,
+    primary_path: &'a Path,
+    recovery_path: &'a Path,
     valid: bool,
 ) -> Element<'a, Message> {
+    let primary_key = if let Some(first) = primary_path.keys.first() {
+        first.as_ref()
+    } else {
+        None
+    };
     layout(
         progress,
         None,
@@ -106,15 +110,15 @@ pub fn inheritance_template<'a>(
                 path(
                     color::GREEN,
                     None,
-                    0,
-                    false,
+                    PathSequence::Primary,
+                    primary_path.warning,
                     1,
                     vec![if let Some(key) = primary_key {
                         defined_key(
                             &key.name,
                             color::GREEN,
                             "Primary key",
-                            if use_taproot && !key.is_compatible_taproot {
+                            if use_taproot && !key.source.is_compatible_taproot() {
                                 Some("This device does not support Taproot")
                             } else {
                                 None
@@ -133,15 +137,15 @@ pub fn inheritance_template<'a>(
                 path(
                     color::WHITE,
                     None,
-                    sequence,
-                    false,
+                    recovery_path.sequence,
+                    recovery_path.warning,
                     1,
-                    vec![if let Some(key) = recovery_key {
+                    vec![if let Some(Some(key)) = recovery_path.keys.first() {
                         defined_key(
                             &key.name,
                             color::WHITE,
                             "Inheritance key",
-                            if use_taproot && !key.is_compatible_taproot {
+                            if use_taproot && !key.source.is_compatible_taproot() {
                                 Some("This device does not support Taproot")
                             } else {
                                 None

--- a/liana-gui/src/lianalite/client/backend/api.rs
+++ b/liana-gui/src/lianalite/client/backend/api.rs
@@ -121,9 +121,25 @@ pub struct ListWallets {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct Provider {
+    pub uuid: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ProviderKey {
+    #[serde(deserialize_with = "deser_fromstr")]
+    pub fingerprint: bip32::Fingerprint,
+    pub uuid: String,
+    pub token: String,
+    pub provider: Provider,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct WalletMetadata {
     pub ledger_hmacs: Vec<LedgerHmac>,
     pub fingerprint_aliases: Vec<FingerprintAlias>,
+    pub provider_keys: Vec<ProviderKey>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -336,10 +352,25 @@ pub mod payload {
     }
 
     #[derive(Serialize)]
+    pub struct Provider {
+        pub uuid: String,
+        pub name: String,
+    }
+
+    #[derive(Serialize)]
+    pub struct ProviderKey {
+        pub fingerprint: String,
+        pub uuid: String,
+        pub token: String,
+        pub provider: Provider,
+    }
+
+    #[derive(Serialize)]
     pub struct CreateWallet<'a> {
         pub name: &'a str,
         #[serde(serialize_with = "ser_to_string")]
         pub descriptor: &'a LianaDescriptor,
+        pub provider_keys: &'a Vec<ProviderKey>,
     }
 
     #[derive(Serialize)]

--- a/liana-gui/src/lianalite/client/backend/mod.rs
+++ b/liana-gui/src/lianalite/client/backend/mod.rs
@@ -148,11 +148,16 @@ impl BackendClient {
         &self,
         name: &str,
         descriptor: &LianaDescriptor,
+        provider_keys: &Vec<api::payload::ProviderKey>,
     ) -> Result<api::Wallet, DaemonError> {
         let response = self
             .request(Method::POST, &format!("{}/v1/wallets", self.url))
             .await
-            .json(&api::payload::CreateWallet { name, descriptor })
+            .json(&api::payload::CreateWallet {
+                name,
+                descriptor,
+                provider_keys,
+            })
             .send()
             .await?;
         if !response.status().is_success() {

--- a/liana-gui/src/lib.rs
+++ b/liana-gui/src/lib.rs
@@ -10,6 +10,7 @@ pub mod lianalite;
 pub mod loader;
 pub mod logger;
 pub mod node;
+pub mod services;
 pub mod signer;
 pub mod utils;
 

--- a/liana-gui/src/services/api.rs
+++ b/liana-gui/src/services/api.rs
@@ -1,0 +1,81 @@
+use serde::{de, Deserialize};
+
+use liana::miniscript::descriptor::DescriptorPublicKey;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+pub enum KeyKind {
+    SafetyNet,
+    Cosigner,
+}
+
+impl std::fmt::Display for KeyKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KeyKind::SafetyNet => write!(f, "Safety Net"),
+            KeyKind::Cosigner => write!(f, "Cosigner"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for KeyKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "safetynet" => Ok(KeyKind::SafetyNet),
+            "cosigner" => Ok(KeyKind::Cosigner),
+            s => Err(de::Error::custom(format!(
+                "invalid value for KeyKind: '{}'",
+                s
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyStatus {
+    NotFetched,
+    Fetched,
+    Redeemed,
+}
+
+impl<'de> Deserialize<'de> for KeyStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "not-fetched" => Ok(KeyStatus::NotFetched),
+            "fetched" => Ok(KeyStatus::Fetched),
+            "redeemed" => Ok(KeyStatus::Redeemed),
+            s => Err(de::Error::custom(format!(
+                "invalid value for KeyStatus: '{}'",
+                s
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Provider {
+    pub uuid: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Key {
+    pub provider: Provider,
+    pub uuid: String,
+    pub kind: KeyKind,
+    pub status: KeyStatus,
+    pub xpub: DescriptorPublicKey,
+}
+
+impl Key {
+    pub fn is_redeemed(&self) -> bool {
+        matches!(self.status, KeyStatus::Redeemed)
+    }
+}

--- a/liana-gui/src/services/mod.rs
+++ b/liana-gui/src/services/mod.rs
@@ -1,0 +1,97 @@
+pub mod api;
+
+use reqwest::{self, IntoUrl, Method, RequestBuilder};
+use serde_json::json;
+
+const KEYS_API_URL: &str = "https://keys.wizardsardine.com";
+
+#[derive(Debug, Clone)]
+pub enum Error {
+    Http(Option<u16>, String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Http(kind, e) => write!(f, "Http error: [{:?}] {}", kind, e),
+        }
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(error: reqwest::Error) -> Self {
+        Self::Http(None, error.to_string())
+    }
+}
+
+async fn check_response_status(response: reqwest::Response) -> Result<reqwest::Response, Error> {
+    if !response.status().is_success() {
+        return Err(Error::Http(
+            Some(response.status().into()),
+            response.text().await?,
+        ));
+    }
+    Ok(response)
+}
+
+fn request<U: reqwest::IntoUrl>(
+    http: &reqwest::Client,
+    method: reqwest::Method,
+    url: U,
+) -> reqwest::RequestBuilder {
+    let req = http
+        .request(method, url)
+        .header("Content-Type", "application/json")
+        .header("API-Version", "0.1");
+    tracing::debug!("Sending http request: {:?}", req);
+    req
+}
+
+#[derive(Debug, Clone)]
+pub struct Client(reqwest::Client);
+
+impl Default for Client {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Client {
+    pub fn new() -> Self {
+        let http = reqwest::Client::new();
+        Client(http)
+    }
+
+    async fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
+        request(&self.0, method, url)
+    }
+
+    pub async fn get_key_by_token(&self, token: String) -> Result<api::Key, Error> {
+        let response = self
+            .request(Method::GET, &format!("{}/v1/keys", KEYS_API_URL))
+            .await
+            .query(&[("token", token)])
+            .send()
+            .await?;
+        let response = check_response_status(response).await?;
+        let key = response.json().await?;
+        Ok(key)
+    }
+
+    pub async fn redeem_key(&self, uuid: String, token: String) -> Result<api::Key, Error> {
+        let response = self
+            .request(
+                Method::POST,
+                &format!("{}/v1/keys/{}/redeem", KEYS_API_URL, uuid),
+            )
+            .await
+            .json(&json!({
+                "token": token,
+            }))
+            .send()
+            .await?;
+        let response = check_response_status(response).await?;
+        let key = response.json().await?;
+        Ok(key)
+    }
+}

--- a/liana-ui/src/component/form.rs
+++ b/liana-ui/src/component/form.rs
@@ -93,6 +93,12 @@ where
         self
     }
 
+    /// Sets the [`Form`] with a warning message
+    pub fn maybe_warning(mut self, warning: Option<&'a str>) -> Self {
+        self.warning = warning;
+        self
+    }
+
     /// Sets the padding of the [`Form`].
     pub fn padding(mut self, units: u16) -> Self {
         self.input = self.input.padding(units);

--- a/liana-ui/src/component/hw.rs
+++ b/liana-ui/src/component/hw.rs
@@ -496,3 +496,82 @@ pub fn hot_signer<'a, T: 'a, F: Display>(
     )
     .padding(10)
 }
+
+pub fn selected_provider_key<'a, T: 'a, F: Display>(
+    fingerprint: F,
+    alias: impl Into<Cow<'a, str>> + Display,
+    key_kind: impl Into<Cow<'a, str>> + Display,
+    token: impl Into<Cow<'a, str>> + Display,
+) -> Container<'a, T> {
+    container(
+        row(vec![
+            column(vec![
+                Row::new()
+                    .spacing(5)
+                    .push(text::p1_bold(alias))
+                    .push(text::p1_regular(format!("#{}", fingerprint)))
+                    .into(),
+                Row::new()
+                    .spacing(5)
+                    .push(text::caption(format!("{key_kind} ({token})")))
+                    .into(),
+            ])
+            .width(Length::Fill)
+            .into(),
+            image::success_mark_icon().width(Length::Fixed(50.0)).into(),
+        ])
+        .align_y(Alignment::Center),
+    )
+    .padding(10)
+}
+
+pub fn unselected_provider_key<'a, T: 'a, F: Display>(
+    fingerprint: F,
+    alias: impl Into<Cow<'a, str>> + Display,
+    key_kind: impl Into<Cow<'a, str>> + Display,
+    token: impl Into<Cow<'a, str>> + Display,
+) -> Container<'a, T> {
+    container(
+        row(vec![column(vec![
+            Row::new()
+                .spacing(5)
+                .push(text::p1_bold(alias))
+                .push(text::p1_regular(format!("#{}", fingerprint)))
+                .into(),
+            Row::new()
+                .spacing(5)
+                .push(text::caption(format!("{key_kind} ({token})")))
+                .into(),
+        ])
+        .width(Length::Fill)
+        .into()])
+        .align_y(Alignment::Center),
+    )
+    .padding(10)
+}
+
+pub fn unsaved_provider_key<'a, T: 'a, F: Display>(
+    fingerprint: F,
+    key_kind: impl Into<Cow<'a, str>> + Display,
+    token: impl Into<Cow<'a, str>> + Display,
+) -> Container<'a, T> {
+    container(
+        row(vec![
+            column(vec![
+                Row::new()
+                    .spacing(5)
+                    .push(text::p1_regular(format!("#{}", fingerprint)))
+                    .into(),
+                Row::new()
+                    .spacing(5)
+                    .push(text::caption(format!("{key_kind} ({token})")))
+                    .into(),
+            ])
+            .width(Length::Fill)
+            .into(),
+            image::success_mark_icon().width(Length::Fixed(50.0)).into(), // it must be selected if unsaved
+        ])
+        .align_y(Alignment::Center),
+    )
+    .padding(10)
+}


### PR DESCRIPTION
This PR implements #1578 and #1579.

Please note the following:
- I've left the cosigner option enabled for initial testing as part of this PR, but will disable it afterwards (#1584 ).
- Using cosigner keys is currently possible in all templates, including the Simple Inheritance template, but given that there is only one key per path in this template, it would not be possible to continue with a cosigner key selected. I could disable the option to select cosigner keys in this template in a follow-up PR, but in any case there will be a warning so the user will be aware of the problem.
- Safety net paths can only be added in the Custom template for now.
- ~~This cannot yet be tested with Liana Connect.~~ Can be tested on Signet with Liana Connect.
- ~~The URL for fetching & redeeming keys is still localhost and I will update it once the service is ready.~~
- ~~The GUI layout needs to be refined as part of this PR.~~ No further GUI layout changes planned.

Please also note that I've unhelpfully squashed everything into a single commit. I hope to be able to split these out into smaller commits, but wanted to check the overall approach first and there may also be some conflicts with other PRs.

