### PR TITLE
[wip] lianad: add store_transactions() command

### DIFF
--- a/liana-gui/src/daemon/client/mod.rs
+++ b/liana-gui/src/daemon/client/mod.rs
@@ -165,6 +165,11 @@ impl<C: Client + Send + Sync + Debug> Daemon for Lianad<C> {
         )
     }
 
+    async fn store_transactions(&self, txs: &[Transaction]) -> Result<(), DaemonError> {
+        self.call("storetransactions", Some(vec![json!(txs)]))?;
+        Ok(())
+    }
+
     async fn list_txs(&self, txids: &[Txid]) -> Result<ListTransactionsResult, DaemonError> {
         self.call("listtransactions", Some(vec![txids]))
     }

--- a/liana-gui/src/daemon/embedded.rs
+++ b/liana-gui/src/daemon/embedded.rs
@@ -125,6 +125,14 @@ impl Daemon for EmbeddedDaemon {
             .await
     }
 
+    async fn store_transactions(&self, txs: &[Transaction]) -> Result<(), DaemonError> {
+        self.command(|daemon| {
+            daemon.store_transactions(txs);
+            Ok(())
+        })
+        .await
+    }
+
     async fn list_txs(&self, txids: &[Txid]) -> Result<ListTransactionsResult, DaemonError> {
         self.command(|daemon| Ok(daemon.list_transactions(txids)))
             .await

--- a/liana-gui/src/daemon/mod.rs
+++ b/liana-gui/src/daemon/mod.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 
 use async_trait::async_trait;
 
+use liana::miniscript::bitcoin::Transaction;
 use liana::miniscript::bitcoin::{
     address, bip32::Fingerprint, psbt::Psbt, secp256k1, Address, Network, OutPoint, Txid,
 };
@@ -110,6 +111,7 @@ pub trait Daemon: Debug {
         _end: u32,
         _limit: u64,
     ) -> Result<model::ListTransactionsResult, DaemonError>;
+    async fn store_transactions(&self, txs: &[Transaction]) -> Result<(), DaemonError>;
     async fn create_recovery(
         &self,
         address: Address<address::NetworkUnchecked>,

--- a/liana-gui/src/lianalite/client/backend/mod.rs
+++ b/liana-gui/src/lianalite/client/backend/mod.rs
@@ -1081,6 +1081,10 @@ impl Daemon for BackendWalletClient {
         Ok(spend_txs)
     }
 
+    async fn store_transactions(&self, _txs: &[Transaction]) -> Result<(), DaemonError> {
+        todo!()
+    }
+
     /// Implemented by LianaLite backend
     async fn update_wallet_metadata(
         &self,

--- a/lianad/src/commands/mod.rs
+++ b/lianad/src/commands/mod.rs
@@ -1070,6 +1070,11 @@ impl DaemonControl {
         ListTransactionsResult { transactions }
     }
 
+    /// Store transactions in database, ignoring any that already exist.
+    pub fn store_transactions(&self, txs: &[bitcoin::Transaction]) {
+        self.db.connection().new_txs(txs);
+    }
+
     /// Create a transaction that sweeps all coins for which a timelocked recovery path is
     /// currently available to a provided address with the provided feerate.
     ///

--- a/lianad/src/jsonrpc/api.rs
+++ b/lianad/src/jsonrpc/api.rs
@@ -10,7 +10,7 @@ use std::{
     str::FromStr,
 };
 
-use miniscript::bitcoin::{self, psbt::Psbt, Txid};
+use miniscript::bitcoin::{self, psbt::Psbt, Transaction, Txid};
 
 fn create_spend(control: &DaemonControl, params: Params) -> Result<serde_json::Value, Error> {
     let destinations = params
@@ -266,6 +266,26 @@ fn list_transactions(control: &DaemonControl, params: Params) -> Result<serde_js
     Ok(serde_json::json!(&control.list_transactions(&txids)))
 }
 
+fn store_transactions(control: &DaemonControl, params: Params) -> Result<serde_json::Value, Error> {
+    let txs: Vec<bitcoin::Transaction> = params
+        .get(0, "transactions")
+        .ok_or_else(|| Error::invalid_params("Missing 'transactions' parameter."))?
+        .as_array()
+        .and_then(|arr| {
+            arr.iter()
+                .map(|entry| {
+                    entry.as_str().and_then(|e| {
+                        let tx: Result<Transaction, _> =
+                            bitcoin::consensus::encode::deserialize_hex(e);
+                        tx.ok()
+                    })
+                })
+                .collect()
+        })
+        .ok_or_else(|| Error::invalid_params("Invalid 'transactions' parameter."))?;
+    Ok(serde_json::json!(&control.store_transactions(&txs)))
+}
+
 fn start_rescan(control: &mut DaemonControl, params: Params) -> Result<serde_json::Value, Error> {
     let timestamp: u32 = params
         .get(0, "timestamp")
@@ -425,6 +445,14 @@ pub fn handle_request(control: &mut DaemonControl, req: Request) -> Result<Respo
                 )
             })?;
             list_transactions(control, params)?
+        }
+        "storetransactions" => {
+            let params = req.params.ok_or_else(|| {
+                Error::invalid_params(
+                    "The 'storetransactions' command requires 1 parameter: 'transactions'",
+                )
+            })?;
+            store_transactions(control, params)?
         }
         "startrescan" => {
             let params = req


### PR DESCRIPTION
this feature have been dropped from the backup/restore feature, putting it in a separate PR in case we want to import transactions in case of offline liana feature