### PR TITLE
Reword warning for non-unique provider key kind

### DIFF
--- a/liana-gui/src/installer/step/descriptor/editor/key.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/key.rs
@@ -266,7 +266,10 @@ impl super::DescriptorEditModal for EditXpubModal {
                                         && existing.source.provider_key_kind()
                                             != key.source.provider_key_kind()
                                 }) {
-                                    Some("Two keys with the same fingerprint must have the same provider key kind.".to_string())
+                                    Some(
+                                        "Fetched key has already been added to the wallet."
+                                            .to_string(),
+                                    )
                                 } else {
                                     None
                                 };


### PR DESCRIPTION
This simplifies the warning message for the user in case a fetched provider key (more precisely, any key with the same fingerprint) has already been added to the wallet (as a different key kind).