### PR TITLE
gui(settings): use consistent case

### DIFF
--- a/liana-gui/src/app/view/settings.rs
+++ b/liana-gui/src/app/view/settings.rs
@@ -107,7 +107,7 @@ pub fn list(cache: &Cache, is_remote_backend: bool) -> Element<Message> {
     );
 
     let import_export = settings_section(
-        "Import/export",
+        "Import/Export",
         None,
         icon::wallet_icon(),
         Message::Settings(SettingsMessage::ImportExportSection),
@@ -186,7 +186,7 @@ pub fn import_export<'a>(cache: &'a Cache, warning: Option<&Error>) -> Element<'
     );
 
     let export_wallet = settings_section(
-        "Back Up Wallet",
+        "Back up wallet",
         None,
         icon::backup_icon(),
         Message::Settings(SettingsMessage::ExportWallet),


### PR DESCRIPTION
Use consistent case in the settings:

- "Import/Export" for the section card to match the header on the corresponding page. The choice is to capitalise both words as the slash indicates either word could be treated as a title by itself.
- Use "Back up wallet" to match the case of the other options on that page.

![image](https://github.com/user-attachments/assets/ad3134d3-1700-4de8-be25-63335f3a91b2)
![image](https://github.com/user-attachments/assets/5f5590f2-ceaa-4e1c-b353-34dff826f65a)
