### PR TITLE
Hint user if the key of signing device is not part of the wallet descriptor

### DIFF
--- a/liana-gui/src/installer/step/descriptor/editor/key.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/key.rs
@@ -459,6 +459,7 @@ impl super::DescriptorEditModal for EditXpubModal {
                             hw.fingerprint() == chosen_signer,
                             self.processing,
                             hw.fingerprint() == chosen_signer,
+                            None,
                             self.device_must_support_tapminiscript,
                         ))
                     }

--- a/liana-gui/src/installer/step/descriptor/mod.rs
+++ b/liana-gui/src/installer/step/descriptor/mod.rs
@@ -306,10 +306,11 @@ impl Step for RegisterDescriptor {
         email: Option<&'a str>,
     ) -> Element<'a, Message> {
         let desc = self.descriptor.as_ref().unwrap();
+
         view::register_descriptor(
             progress,
             email,
-            desc.to_string(),
+            desc,
             &hws.list,
             &self.registered,
             self.error.as_ref(),

--- a/liana-ui/src/component/hw.rs
+++ b/liana-ui/src/component/hw.rs
@@ -1,6 +1,7 @@
 use crate::{color, component::text, icon, image, theme, widget::*};
 use iced::{
-    widget::{column, container, row, tooltip},
+    alignment::Vertical,
+    widget::{column, container, row, tooltip, Space},
     Alignment, Length,
 };
 use std::borrow::Cow;
@@ -129,24 +130,28 @@ pub fn unrelated_hardware_wallet<'a, T: 'a, K: Display, V: Display, F: Display>(
     version: Option<V>,
     fingerprint: F,
 ) -> Container<'a, T> {
+    let key = column(vec![
+        text::p1_regular(format!("#{}", fingerprint)).into(),
+        Row::new()
+            .spacing(5)
+            .push(text::caption(kind.to_string()))
+            .push_maybe(version.map(|v| text::caption(v.to_string())))
+            .into(),
+    ]);
     container(
-        tooltip::Tooltip::new(
-            container(
-                column(vec![
-                    text::p1_regular(format!("#{}", fingerprint)).into(),
-                    Row::new()
-                        .spacing(5)
-                        .push(text::caption(kind.to_string()))
-                        .push_maybe(version.map(|v| text::caption(v.to_string())))
-                        .into(),
-                ])
-                .width(Length::Fill),
-            )
-            .width(Length::Fill)
-            .padding(10),
-            "This signer does not have a key in this wallet.",
-            tooltip::Position::Bottom,
+        container(
+            Row::new()
+                .push(key)
+                .push(Space::with_width(15))
+                .push(Space::with_width(Length::Fill))
+                .push(text::text(
+                    "This signing device is not related to this Liana wallet.",
+                ))
+                .push(Space::with_width(Length::Fill))
+                .align_y(Vertical::Center),
         )
+        .width(Length::Fill)
+        .padding(10)
         .style(theme::card::simple),
     )
     .width(Length::Fill)

--- a/liana/src/descriptors/mod.rs
+++ b/liana/src/descriptors/mod.rs
@@ -1,6 +1,7 @@
 use miniscript::{
     bitcoin::{
-        self, bip32,
+        self,
+        bip32::{self, Fingerprint},
         constants::WITNESS_SCALE_FACTOR,
         psbt::{Input as PsbtIn, Output as PsbtOut, Psbt},
         secp256k1,
@@ -208,6 +209,12 @@ impl LianaDescriptor {
                 false
             }
         })
+    }
+
+    /// Whether a key matching this fingerprint is part of this descriptor
+    pub fn contains_fingerprint(&self, fg: Fingerprint) -> bool {
+        self.multi_desc
+            .for_any_key(|k| k.master_fingerprint() == fg)
     }
 
     /// Get the descriptor for receiving addresses.

--- a/liana/src/descriptors/mod.rs
+++ b/liana/src/descriptors/mod.rs
@@ -2209,5 +2209,15 @@ mod tests {
         LianaDescriptor::from_str("wsh(0)").unwrap_err();
     }
 
+    #[test]
+    fn descriptor_contains_fingerprint() {
+        let descr = LianaDescriptor::from_str("wsh(or_d(multi(3,[aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/0/<0;1>/*,[aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/0/<0;1>/*,[aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/0/<0;1>/*),and_v(v:thresh(2,pkh([aabb0011/48'/0'/0'/2']xpub6Eze7yAT3Y1wGrnzedCNVYDXUqa9NmHVWck5emBaTbXtURbe1NWZbK9bsz1TiVE7Cz341PMTfYgFw1KdLWdzcM1UMFTcdQfCYhhXZ2HJvTW/1/<0;1>/*),a:pkh([aabb0012/48'/0'/0'/2']xpub6Bw79HbNSeS2xXw1sngPE3ehnk1U3iSPCgLYzC9LpN8m9nDuaKLZvkg8QXxL5pDmEmQtYscmUD8B9MkAAZbh6vxPzNXMaLfGQ9Sb3z85qhR/1/<0;1>/*),a:pkh([aabb0013/48'/0'/0'/2']xpub67zuTXF9Ln4731avKTBSawoVVNRuMfmRvkL7kLUaLBRqma9ZqdHBJg9qx8cPUm3oNQMiXT4TmGovXNoQPuwg17RFcVJ8YrnbcooN7pxVJqC/1/<0;1>/*)),older(26352))))").unwrap();
+
+        assert!(descr.contains_fingerprint(Fingerprint::from_str("aabb0011").unwrap()));
+        assert!(descr.contains_fingerprint(Fingerprint::from_str("aabb0012").unwrap()));
+        assert!(descr.contains_fingerprint(Fingerprint::from_str("aabb0013").unwrap()));
+        assert!(!descr.contains_fingerprint(Fingerprint::from_str("aabb0014").unwrap()));
+    }
+
     // TODO: test error conditions of deserialization.
 }


### PR DESCRIPTION
This PR:
- [x] Add `LianaDescriptor::contains_fingerprint()` method

- [x] make more explicit when a signing device is not part of the wallet descriptor

before (user had to hover the button to see the tooltip):
![image](https://github.com/user-attachments/assets/c61a95a0-a9b2-4f85-8245-e5490c7e37af)

after:
![image](https://github.com/user-attachments/assets/1d17775e-6c26-4eeb-83a7-c8621d44c54c)
 
- [x] Hint the user in the installer if the plugged device is not part of the created/imported descriptor:

![image](https://github.com/user-attachments/assets/e22f0180-513e-48d5-b293-00677e328285)
