### PR TITLE
lianad: ensure consistent derivation index management

### DIFF
--- a/lianad/src/database/mod.rs
+++ b/lianad/src/database/mod.rs
@@ -30,9 +30,9 @@ use miniscript::bitcoin::{self, bip32, psbt::Psbt, secp256k1, Address, Network, 
 pub struct Wallet {
     /// Timestamp at wallet creation time.
     pub timestamp: u32,
-    /// Derivation index for the next receiving address.
+    /// Derivation index for the last used/revealed receiving address.
     pub receive_index: bip32::ChildNumber,
-    /// Derivation index for the next change address.
+    /// Derivation index for the last used/revealed change address.
     pub change_index: bip32::ChildNumber,
     /// Timestamp to start rescanning from, if any.
     pub rescan_timestamp: Option<u32>,
@@ -73,20 +73,20 @@ pub trait DatabaseConnection {
     /// Update our best chain seen.
     fn update_tip(&mut self, tip: &BlockChainTip);
 
-    /// Get the derivation index for the next receiving address
+    /// Get the derivation index for the last used/revealed receiving address
     fn receive_index(&mut self) -> bip32::ChildNumber;
 
-    /// Set the derivation index for the next receiving address
+    /// Set the derivation index for the last used/revealed receiving address
     fn set_receive_index(
         &mut self,
         index: bip32::ChildNumber,
         secp: &secp256k1::Secp256k1<secp256k1::VerifyOnly>,
     );
 
-    /// Get the derivation index for the next change address
+    /// Get the derivation index for the last used/revealed change address
     fn change_index(&mut self) -> bip32::ChildNumber;
 
-    /// Set the derivation index for the next change address
+    /// Set the derivation index for the last used/revealed change address
     fn set_change_index(
         &mut self,
         index: bip32::ChildNumber,

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -166,29 +166,35 @@ def test_update_derivation_indexes(lianad):
 def test_getaddress(lianad):
     res = lianad.rpc.getnewaddress()
     assert "address" in res
+    # The first new wallet address has index 1
+    assert res["derivation_index"] == 1
     # We'll get a new one at every call
     assert res["address"] != lianad.rpc.getnewaddress()["address"]
     # new address has derivation_index higher than the previous one
     assert lianad.rpc.getnewaddress()["derivation_index"] == res["derivation_index"] + 2
     info = lianad.rpc.getinfo()
-    assert info["receive_index"] == res["derivation_index"] + 3
+    assert info["receive_index"] == res["derivation_index"] + 2  # 3 == 1 + 2
     assert info["change_index"] == 0
 
 
 def test_listaddresses(lianad):
-    list = lianad.rpc.listaddresses(2, 5)
+    list1 = lianad.rpc.listaddresses(2, 5)
     list2 = lianad.rpc.listaddresses(start_index=2, count=5)
-    assert list == list2
-    assert "addresses" in list
-    addr = list["addresses"]
+    assert list1 == list2
+    assert "addresses" in list1
+    addr = list1["addresses"]
     assert addr[0]["index"] == 2
     assert addr[-1]["index"] == 6
 
-    list3 = lianad.rpc.listaddresses()  # start_index = 0, receive_index = 0
+    list3 = (
+        lianad.rpc.listaddresses()
+    )  # start_index = 0, receive_index = 0 (returns 1 "used" address for index 0)
     _ = lianad.rpc.getnewaddress()  # start_index = 0, receive_index = 1
     _ = lianad.rpc.getnewaddress()  # start_index = 0, receive_index = 2
+    # list4 returns all indexes from 0 up to last used.
+    # The first new address has index 1, so returned indexes are 0, 1, 2:
     list4 = lianad.rpc.listaddresses()
-    assert len(list4["addresses"]) == len(list3["addresses"]) + 2 == 2
+    assert len(list4["addresses"]) == len(list3["addresses"]) + 2 == 3
     list5 = lianad.rpc.listaddresses(0)
     assert list4 == list5
 
@@ -548,7 +554,13 @@ def test_create_spend(lianad, bitcoind):
     assert len(spend_psbt.o) == 4
     assert len(spend_psbt.tx.vout) == 4
 
-    assert lianad.rpc.getinfo()["change_index"] == 15
+    # 15 new receive addresses have been generated (starting at index 1),
+    # so last used value is 15:
+    assert lianad.rpc.getinfo()["receive_index"] == 15
+    # For each received coin, the change index has also been updated by the poller
+    # (see https://github.com/wizardsardine/liana/issues/1333), so is also 15.
+    # Then `createspend` will use the next index for change and update the DB value accordingly:
+    assert lianad.rpc.getinfo()["change_index"] == 16
 
     # The transaction must contain the spent transaction for each input for P2WSH. But not for Taproot.
     # We don't make assumptions about the ordering of PSBT inputs.

--- a/tests/test_spend.py
+++ b/tests/test_spend.py
@@ -231,9 +231,20 @@ def test_send_to_self(lianad, bitcoind):
         lianad.rpc.getnewaddress()["address"]: 0.04,
         lianad.rpc.getnewaddress()["address"]: 0.05,
     }
+    info = lianad.rpc.getinfo()
+    # We've generated 3 receive addresses, starting at index 1, so last used is 3.
+    assert info["receive_index"] == 3
+    # No change addresses used, so last index is 0.
+    assert info["change_index"] == 0
     deposit_txid = bitcoind.rpc.sendmany("", destinations)
     bitcoind.generate_block(1, wait_for_mempool=deposit_txid)
     wait_for(lambda: len(lianad.rpc.listcoins()["coins"]) == 3)
+
+    info = lianad.rpc.getinfo()
+    assert info["receive_index"] == 3
+    # Change index has been updated by poller, even though none used
+    # (see https://github.com/wizardsardine/liana/issues/1333):
+    assert info["change_index"] == 3
 
     # Then create a send-to-self transaction (by not providing any destination) that
     # sweeps them all.
@@ -242,6 +253,12 @@ def test_send_to_self(lianad, bitcoind):
     res = lianad.rpc.createspend({}, outpoints, specified_feerate)
     spend_psbt = PSBT.from_base64(res["psbt"])
     assert len(spend_psbt.o) == len(spend_psbt.tx.vout) == 1
+
+    info = lianad.rpc.getinfo()
+    # Send to self didn't use any receive addresses...
+    assert info["receive_index"] == 3
+    # ... but it did use a new change address:
+    assert info["change_index"] == 4
 
     # Note they may ask for an impossible send-to-self. In this case we'll report missing amount.
     huge_feerate = 50_000 if USE_TAPROOT else 40_500
@@ -267,16 +284,19 @@ def test_send_to_self(lianad, bitcoind):
     )
     wait_for(lambda: len(list(unspent_coins())) == 1)
 
-    # We've used 3 receive addresses and so the DB receive index must be 3.
-    assert len(lianad.rpc.listaddresses()["addresses"]) == 3
+    info = lianad.rpc.getinfo()
+    # The poller has updated the receive index based on the change index
+    # (see https://github.com/wizardsardine/liana/issues/1333):
+    assert info["receive_index"] == 4
+    assert info["change_index"] == 4
     # Create a new spend to the receive address with index 3.
     recv_addr = lianad.rpc.listaddresses(3, 1)["addresses"][0]["receive"]
     res = lianad.rpc.createspend(
         {recv_addr: 11_965_000 if USE_TAPROOT else 11_955_000}, [], 2
     )
     assert "psbt" in res
-    # Max(receive_index, change_index) is now 4:
-    assert len(lianad.rpc.listaddresses()["addresses"]) == 4
+    # Max(receive_index, change_index) is now 4, so we return addresses 0, 1, 2, 3, 4:
+    assert len(lianad.rpc.listaddresses()["addresses"]) == 5
     # But the spend has no change:
     psbt = PSBT.from_base64(res["psbt"])
     assert len(psbt.o) == 1


### PR DESCRIPTION
The database should store the last used/revealed derivation index.
Docstrings have been updated accordingly.
Getting a new address requires that the database value first be incremented.
When listing addresses without specifying a count, all used/revealed addresses should be returned.

backport of #1605 