### PR TITLE
show rescan warning after restoring wallet from backup

### DIFF
--- a/liana-gui/src/app/menu.rs
+++ b/liana-gui/src/app/menu.rs
@@ -7,9 +7,16 @@ pub enum Menu {
     Transactions,
     TransactionPreSelected(Txid),
     Settings,
+    SettingsPreSelected(SettingsOption),
     Coins,
     CreateSpendTx,
     Recovery,
     RefreshCoins(Vec<OutPoint>),
     PsbtPreSelected(Txid),
+}
+
+/// Pre-selectable settings options.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsOption {
+    Node,
 }

--- a/liana-gui/src/app/state/mod.rs
+++ b/liana-gui/src/app/state/mod.rs
@@ -135,6 +135,7 @@ pub struct Home {
     selected_event: Option<(HistoryTransaction, usize)>,
     labels_edited: LabelsEdited,
     warning: Option<Error>,
+    show_rescan_warning: bool,
 }
 
 impl Home {
@@ -143,6 +144,7 @@ impl Home {
         coins: &[Coin],
         sync_status: SyncStatus,
         tip_height: i32,
+        show_rescan_warning: bool,
     ) -> Self {
         let (balance, unconfirmed_balance, expiring_coins, remaining_seq) = coins_summary(
             coins,
@@ -163,6 +165,7 @@ impl Home {
             warning: None,
             is_last_page: false,
             processing: false,
+            show_rescan_warning,
         }
     }
 }
@@ -191,6 +194,7 @@ impl State for Home {
                     self.is_last_page,
                     self.processing,
                     &self.sync_status,
+                    self.show_rescan_warning,
                 ),
             )
         }
@@ -276,6 +280,9 @@ impl State for Home {
                     self.warning = Some(e);
                 }
             },
+            Message::View(view::Message::HideRescanWarning) => {
+                self.show_rescan_warning = false;
+            }
             Message::View(view::Message::SelectPayment(outpoint)) => {
                 return Task::perform(
                     async move {

--- a/liana-gui/src/app/view/message.rs
+++ b/liana-gui/src/app/view/message.rs
@@ -24,6 +24,7 @@ pub enum Message {
     CreateRbf(CreateRbfMessage),
     ShowQrCode(usize),
     ImportExport(ImportExportMessage),
+    HideRescanWarning,
 }
 
 impl Close for Message {

--- a/liana-gui/src/daemon/mod.rs
+++ b/liana-gui/src/daemon/mod.rs
@@ -76,6 +76,21 @@ impl DaemonBackend {
     pub fn is_embedded(&self) -> bool {
         matches!(self, DaemonBackend::EmbeddedLianad(_))
     }
+
+    pub fn is_lianad(&self) -> bool {
+        matches!(
+            self,
+            DaemonBackend::EmbeddedLianad(_) | DaemonBackend::ExternalLianad
+        )
+    }
+
+    pub fn node_type(&self) -> Option<node::NodeType> {
+        if let DaemonBackend::EmbeddedLianad(node_type) = self {
+            *node_type
+        } else {
+            None
+        }
+    }
 }
 
 #[async_trait]

--- a/liana-gui/src/loader.rs
+++ b/liana-gui/src/loader.rs
@@ -103,6 +103,7 @@ pub enum Message {
             ),
             Error,
         >,
+        /* restored_from_backup */ bool,
     ),
     Started(StartedResult),
     Loaded(Result<(Arc<dyn Daemon + Sync + Send>, GetInfoResult), Error>),


### PR DESCRIPTION
This adds a warning on the home page if the wallet has been restored from a backup and the user is using a local bitcoind node.

This warning has a button to jump to the rescan page and another button to dismiss the warning, which is the only way to remove it (rescanning does not automatically remove it).

Whether the wallet was restored from a backup is not saved after closing the GUI, so this warning will only be shown in the same user session as that in which the wallet was restored.

The warning will not currently be shown when importing a descriptor.