### PR TITLE
filter for confirmed coins when checking recovery paths

### DIFF
--- a/liana-gui/src/app/state/recovery.rs
+++ b/liana-gui/src/app/state/recovery.rs
@@ -244,7 +244,8 @@ fn recovery_paths(wallet: &Wallet, coins: &[Coin], blockheight: i32) -> Vec<Reco
             let (number_of_coins, total_amount) = coins
                 .iter()
                 .filter(|coin| {
-                    coin.spend_info.is_none()
+                    coin.block_height.is_some() // only confirmed coins are included in a recovery transaction
+                        && coin.spend_info.is_none()
                         && remaining_sequence(coin, blockheight as u32, sequence) <= 1
                 })
                 .fold(


### PR DESCRIPTION
This is to fix #1636 and consequently fixes #1102. This PR therefore replaces #1144.

A wallet containing an unconfirmed coin of timelock 1 will no longer show any recovery paths as available.

The recovery transaction created by `createrecovery` only includes confirmed coins and so we should only consider these coins when checking for available recovery paths. An unconfirmed coin could not be broadcast in a recovery transaction as it would not yet satisfy the timelock constraint.