### PR TITLE
feat: move recovery from settings to own menu

### DIFF
--- a/liana-gui/src/app/view/mod.rs
+++ b/liana-gui/src/app/view/mod.rs
@@ -26,7 +26,8 @@ use liana_ui::{
     color,
     component::{button, text::*},
     icon::{
-        coins_icon, cross_icon, history_icon, home_icon, receive_icon, send_icon, settings_icon,
+        coins_icon, cross_icon, history_icon, home_icon, receive_icon, recovery_icon, send_icon,
+        settings_icon,
     },
     image::*,
     theme,
@@ -121,6 +122,19 @@ pub fn sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message> {
             .width(iced::Length::Fill))
     };
 
+    let recovery_button = if *menu == Menu::Recovery {
+        row!(
+            button::menu_active(Some(recovery_icon()), "Recovery")
+                .on_press(Message::Reload)
+                .width(iced::Length::Fill),
+            menu_green_bar()
+        )
+    } else {
+        row!(button::menu(Some(recovery_icon()), "Recovery")
+            .on_press(Message::Menu(Menu::Recovery))
+            .width(iced::Length::Fill))
+    };
+
     let settings_button = if *menu == Menu::Settings {
         row!(
             button::menu_active(Some(settings_icon()), "Settings")
@@ -163,6 +177,7 @@ pub fn sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message> {
                                 .padding(5)
                                 .style(theme::pill::simple)
                         }))
+                        .push(recovery_button)
                         .push(settings_button),
                 )
                 .height(Length::Shrink),

--- a/liana-gui/src/app/view/recovery.rs
+++ b/liana-gui/src/app/view/recovery.rs
@@ -12,7 +12,7 @@ use liana::miniscript::bitcoin::{
 
 use liana_ui::{
     component::{amount::*, button, form, text::*},
-    icon, theme,
+    theme,
     widget::*,
 };
 
@@ -37,26 +37,11 @@ pub fn recovery<'a>(
 ) -> Element<'a, Message> {
     let no_recovery_paths = recovery_paths.is_empty();
     dashboard(
-        &Menu::Settings,
+        &Menu::Recovery,
         cache,
         warning,
         Column::new()
-            .push(
-                Row::new()
-                    .spacing(10)
-                    .align_y(Alignment::Center)
-                    .push(
-                        Button::new(text("Settings").size(30).bold())
-                            .style(theme::button::transparent)
-                            .on_press(Message::Menu(Menu::Settings)),
-                    )
-                    .push(icon::chevron_right().size(30))
-                    .push(
-                        Button::new(text("Recovery").size(30).bold())
-                            .style(theme::button::transparent)
-                            .on_press(Message::Menu(Menu::Recovery)),
-                    ),
-            )
+            .push(Container::new(h3("Recovery")).width(Length::Fill))
             .push(Space::with_height(Length::Fixed(20.0)))
             .push(
                 Row::new()

--- a/liana-gui/src/app/view/settings.rs
+++ b/liana-gui/src/app/view/settings.rs
@@ -143,13 +143,6 @@ pub fn list(cache: &Cache, is_remote_backend: bool) -> Element<Message> {
         Message::Settings(SettingsMessage::ImportExportSection),
     );
 
-    let recovery = settings_section(
-        "Recovery",
-        Some("In case of loss of the main key, the recovery key can move the funds after a certain time."),
-        icon::recovery_icon(),
-        Message::Menu(Menu::Recovery),
-    );
-
     let about = settings_section(
         "About",
         None,
@@ -168,7 +161,6 @@ pub fn list(cache: &Cache, is_remote_backend: bool) -> Element<Message> {
             .push(if !is_remote_backend { node } else { backend })
             .push(wallet)
             .push(import_export)
-            .push(recovery)
             .push(about),
     )
 }


### PR DESCRIPTION
This is to resolve #1640.

The tooltip has been removed for now as the menu buttons don't currently support adding an icon with tooltip, but a tooltip can be re-added later if required (#1647).