### PR TITLE
Add testnet4 support

### DIFF
--- a/liana-gui/src/app/state/settings/bitcoind.rs
+++ b/liana-gui/src/app/state/settings/bitcoind.rs
@@ -579,6 +579,14 @@ impl RescanSetting {
                                 date
                             }
                         }
+                        Network::Testnet4 => {
+                            if date < TESTNET4_GENESIS_BLOCK_TIMESTAMP {
+                                info!("Date {} prior to genesis block, using genesis block timestamp {}", date, TESTNET4_GENESIS_BLOCK_TIMESTAMP);
+                                TESTNET4_GENESIS_BLOCK_TIMESTAMP
+                            } else {
+                                date
+                            }
+                        }
                         Network::Signet => {
                             if date < SIGNET_GENESIS_BLOCK_TIMESTAMP {
                                 info!("Date {} prior to genesis block, using genesis block timestamp {}", date, SIGNET_GENESIS_BLOCK_TIMESTAMP);
@@ -642,4 +650,5 @@ impl RescanSetting {
 /// Use bitcoin-cli getblock $(bitcoin-cli getblockhash 0) | jq .time
 const MAINNET_GENESIS_BLOCK_TIMESTAMP: i64 = 1231006505;
 const TESTNET3_GENESIS_BLOCK_TIMESTAMP: i64 = 1296688602;
+const TESTNET4_GENESIS_BLOCK_TIMESTAMP: i64 = 1659741361;
 const SIGNET_GENESIS_BLOCK_TIMESTAMP: i64 = 1598918400;

--- a/liana-gui/src/installer/step/descriptor/editor/key.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/key.rs
@@ -564,6 +564,10 @@ mod tests {
             "48'/1'/0'/2'"
         );
         assert_eq!(
+            default_derivation_path(Network::Testnet4).to_string(),
+            "48'/1'/0'/2'"
+        );
+        assert_eq!(
             default_derivation_path(Network::Signet).to_string(),
             "48'/1'/0'/2'"
         );

--- a/liana-gui/src/installer/step/node/bitcoind.rs
+++ b/liana-gui/src/installer/step/node/bitcoind.rs
@@ -102,7 +102,7 @@ impl Download {
 /// Default prune value used by internal bitcoind.
 pub const PRUNE_DEFAULT: u32 = 15_000;
 /// Default ports used by bitcoind across all networks.
-pub const BITCOIND_DEFAULT_PORTS: [u16; 8] = [8332, 8333, 18332, 18333, 18443, 18444, 38332, 38333];
+pub const BITCOIND_DEFAULT_PORTS: [u16; 10] = [8332, 8333, 18332, 18333, 18443, 18444, 48332, 48333, 38332, 38333];
 
 #[derive(Debug)]
 pub enum InstallState {
@@ -242,6 +242,7 @@ fn bitcoind_default_address(network: &Network) -> String {
     match network {
         Network::Bitcoin => "127.0.0.1:8332".to_string(),
         Network::Testnet => "127.0.0.1:18332".to_string(),
+        Network::Testnet4 => "127.0.0.1:48332".to_string(),
         Network::Regtest => "127.0.0.1:18443".to_string(),
         Network::Signet => "127.0.0.1:38332".to_string(),
         _ => "127.0.0.1:8332".to_string(),

--- a/liana-gui/src/launcher.rs
+++ b/liana-gui/src/launcher.rs
@@ -16,9 +16,10 @@ use lianad::config::ConfigError;
 
 use crate::{app, installer::UserFlow};
 
-const NETWORKS: [Network; 4] = [
+const NETWORKS: [Network; 5] = [
     Network::Bitcoin,
     Network::Testnet,
+    Network::Testnet4,
     Network::Signet,
     Network::Regtest,
 ];
@@ -214,6 +215,7 @@ impl Launcher {
                                                                 Network::Bitcoin => "Bitcoin",
                                                                 Network::Signet => "Signet",
                                                                 Network::Testnet => "Testnet",
+                                                                Network::Testnet4 => "Testnet4",
                                                                 Network::Regtest => "Regtest",
                                                                 _ => "",
                                                             }

--- a/liana-gui/src/node/bitcoind.rs
+++ b/liana-gui/src/node/bitcoind.rs
@@ -126,6 +126,7 @@ pub fn bitcoind_network_dir(network: &Network) -> Option<String> {
             return None;
         }
         Network::Testnet => "testnet3",
+        Network::Testnet4 => "testnet4",
         Network::Regtest => "regtest",
         Network::Signet => "signet",
         _ => panic!("Directory required for this network is unknown."),

--- a/liana-ui/src/component/mod.rs
+++ b/liana-ui/src/component/mod.rs
@@ -37,6 +37,7 @@ pub fn network_banner<'a, T: 'a>(network: Network) -> Container<'a, T> {
                 text::text(match network {
                     Network::Signet => "SIGNET WALLET",
                     Network::Testnet => "TESTNET WALLET",
+                    Network::Testnet4 => "TESTNET4 WALLET",
                     Network::Regtest => "REGTEST WALLET",
                     _ => unreachable!(),
                 })

--- a/lianad/src/bitcoin/d/mod.rs
+++ b/lianad/src/bitcoin/d/mod.rs
@@ -718,6 +718,7 @@ impl BitcoinD {
         let bip70_net = match config_network {
             bitcoin::Network::Bitcoin => "main",
             bitcoin::Network::Testnet => "test",
+            bitcoin::Network::Testnet4 => "testnet4",
             bitcoin::Network::Regtest => "regtest",
             bitcoin::Network::Signet => "signet",
             _ => "Unknown network, undefined at the time of writing",

--- a/lianad/src/config.rs
+++ b/lianad/src/config.rs
@@ -132,7 +132,7 @@ pub struct ElectrumConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BitcoinConfig {
-    /// The network we are operating on, one of "bitcoin", "testnet", "regtest", "signet"
+    /// The network we are operating on, one of "bitcoin", "testnet", "testnet4", "regtest", "signet"
     pub network: Network,
     /// The poll interval for the Bitcoin interface
     #[serde(


### PR DESCRIPTION
This should closes #1119.

I've seen #1482 but as within the bitcoin crate Testnet3 is called Testnet I'd wait for your confirmation that within Liana you want to call it testnet3 instead of testnet. But it can also be done in another PR.