### PR TITLE
fix: cache coins when first loading GUI with Liana Connect

### DIFF
--- a/liana-gui/src/app/cache.rs
+++ b/liana-gui/src/app/cache.rs
@@ -1,6 +1,11 @@
-use crate::daemon::model::Coin;
+use crate::daemon::{
+    model::{Coin, ListCoinsResult},
+    Daemon, DaemonError,
+};
 use liana::miniscript::bitcoin::Network;
+use lianad::commands::CoinStatus;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct Cache {
@@ -30,4 +35,13 @@ impl std::default::Default for Cache {
             last_poll_at_startup: None,
         }
     }
+}
+
+/// Get the coins that should be cached.
+pub async fn coins_to_cache(
+    daemon: Arc<dyn Daemon + Sync + Send>,
+) -> Result<ListCoinsResult, DaemonError> {
+    daemon
+        .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
+        .await
 }

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -318,9 +318,7 @@ impl App {
                         daemon.is_alive(&datadir_path, network).await?;
 
                         let info = daemon.get_info().await?;
-                        let coins = daemon
-                            .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
-                            .await?;
+                        let coins = cache::coins_to_cache(daemon).await?;
                         Ok(Cache {
                             datadir_path,
                             coins: coins.coins,

--- a/liana-gui/src/loader.rs
+++ b/liana-gui/src/loader.rs
@@ -18,7 +18,6 @@ use liana_ui::{
     widget::*,
 };
 use lianad::{
-    commands::CoinStatus,
     config::{BitcoinBackend, Config, ConfigError},
     StartupError,
 };
@@ -28,7 +27,7 @@ use crate::backup::Backup;
 use crate::export::RestoreBackupError;
 use crate::{
     app::{
-        cache::Cache,
+        cache::{coins_to_cache, Cache},
         config::Config as GUIConfig,
         wallet::{Wallet, WalletError},
     },
@@ -429,10 +428,7 @@ pub async fn load_application(
         .load_from_settings(&datadir_path, network)?
         .load_hotsigners(&datadir_path, network)?;
 
-    let coins = daemon
-        .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
-        .await
-        .map(|res| res.coins)?;
+    let coins = coins_to_cache(daemon.clone()).await.map(|res| res.coins)?;
 
     let cache = Cache {
         datadir_path,

--- a/liana-gui/src/main.rs
+++ b/liana-gui/src/main.rs
@@ -19,7 +19,7 @@ extern crate serde_json;
 
 use liana::miniscript::bitcoin;
 use liana_ui::{component::text, font, image, theme, widget::Element};
-use lianad::config::Config as DaemonConfig;
+use lianad::{commands::ListCoinsResult, config::Config as DaemonConfig};
 
 use liana_gui::{
     app::{self, cache::Cache, config::default_datadir, wallet::Wallet, App},
@@ -272,7 +272,7 @@ impl GUI {
                     self.state = State::Installer(Box::new(install));
                     command.map(|msg| Message::Install(Box::new(msg)))
                 }
-                login::Message::Run(Ok((backend_client, wallet))) => {
+                login::Message::Run(Ok((backend_client, wallet, coins))) => {
                     let config = app::Config::from_file(
                         &l.datadir
                             .join(l.network.to_string())
@@ -288,6 +288,7 @@ impl GUI {
                     let (app, command) = create_app_with_remote_backend(
                         backend_client,
                         wallet,
+                        coins,
                         l.datadir.clone(),
                         l.network,
                         config,
@@ -463,6 +464,7 @@ impl GUI {
 pub fn create_app_with_remote_backend(
     remote_backend: BackendWalletClient,
     wallet: api::Wallet,
+    coins: ListCoinsResult,
     datadir: PathBuf,
     network: bitcoin::Network,
     config: app::Config,
@@ -498,7 +500,7 @@ pub fn create_app_with_remote_backend(
     App::new(
         Cache {
             network,
-            coins: Vec::new(),
+            coins: coins.coins,
             rescan_progress: None,
             sync_progress: 1.0, // Remote backend is always synced
             datadir_path: datadir.clone(),


### PR DESCRIPTION
With this PR, coins will be cached when first loading a GUI that is using Liana Connect as the backend.

The cache refreshes less often for Liana Connect (every 2 mins), which means there can be a discrepancy between the coins loaded on a page and those in the cache, especially when first loading the GUI with no coins cached.

This can be seen when choosing to refresh a coin in the Coins panel. After selecting the coin and the refresh option, the Self-Send page is displayed with coins listed, but the coin that was previously selected in the Coins panel won't be selected here unless the cache has already refreshed. By caching coins at the start, it makes such a scenario less likely to occur when using Liana Connect.