### PR TITLE
Remove the link between gui config and lianad config

### DIFF
--- a/liana-gui/src/app/config.rs
+++ b/liana-gui/src/app/config.rs
@@ -6,10 +6,6 @@ use tracing_subscriber::filter;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
-    /// Path to lianad configuration file.
-    pub daemon_config_path: Option<PathBuf>,
-    /// Path to lianad_rpc socket file.
-    pub daemon_rpc_path: Option<PathBuf>,
     /// log level, can be "info", "debug", "trace".
     pub log_level: Option<String>,
     /// Use iced debug feature if true.
@@ -22,10 +18,8 @@ pub struct Config {
 pub const DEFAULT_FILE_NAME: &str = "gui.toml";
 
 impl Config {
-    pub fn new(daemon_config_path: PathBuf, start_internal_bitcoind: bool) -> Self {
+    pub fn new(start_internal_bitcoind: bool) -> Self {
         Self {
-            daemon_config_path: Some(daemon_config_path),
-            daemon_rpc_path: None,
             log_level: None,
             debug: None,
             start_internal_bitcoind,

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -143,7 +143,6 @@ impl Panels {
 
 pub struct App {
     cache: Cache,
-    config: Arc<Config>,
     wallet: Arc<Wallet>,
     daemon: Arc<dyn Daemon + Sync + Send>,
     internal_bitcoind: Option<Bitcoind>,
@@ -176,7 +175,6 @@ impl App {
             Self {
                 panels,
                 cache,
-                config,
                 daemon,
                 wallet,
                 internal_bitcoind,
@@ -361,10 +359,7 @@ impl App {
                 Task::none()
             }
             Message::LoadDaemonConfig(cfg) => {
-                let path = self.config.daemon_config_path.clone().expect(
-                    "Application config must have a daemon configuration file path at this point.",
-                );
-                let res = self.load_daemon_config(&path, *cfg);
+                let res = self.load_daemon_config(self.cache.datadir_path.clone(), *cfg);
                 self.update(Message::DaemonConfigLoaded(res))
             }
             Message::WalletUpdated(Ok(wallet)) => {
@@ -386,12 +381,16 @@ impl App {
 
     pub fn load_daemon_config(
         &mut self,
-        daemon_config_path: &PathBuf,
+        datadir_path: PathBuf,
         cfg: DaemonConfig,
     ) -> Result<(), Error> {
         Handle::current().block_on(async { self.daemon.stop().await })?;
+        let network = cfg.bitcoin_config.network;
         let daemon = EmbeddedDaemon::start(cfg)?;
         self.daemon = Arc::new(daemon);
+        let mut daemon_config_path = datadir_path;
+        daemon_config_path.push(network.to_string());
+        daemon_config_path.push("daemon.toml");
 
         let content =
             toml::to_string(&self.daemon.config()).map_err(|e| Error::Config(e.to_string()))?;

--- a/liana-gui/src/installer/mod.rs
+++ b/liana-gui/src/installer/mod.rs
@@ -380,7 +380,7 @@ pub async fn install_local_wallet(
         .map_err(|e| Error::Unexpected(format!("Failed to serialize daemon config: {}", e)))?;
 
     // create lianad configuration file
-    let daemon_config_path = create_and_write_file(
+    let _daemon_config_path = create_and_write_file(
         network_datadir_path.clone(),
         "daemon.toml",
         daemon_config.to_string().as_bytes(),
@@ -421,9 +421,6 @@ pub async fn install_local_wallet(
         network_datadir_path.clone(),
         gui_config::DEFAULT_FILE_NAME,
         toml::to_string(&gui_config::Config::new(
-            daemon_config_path.canonicalize().map_err(|e| {
-                Error::Unexpected(format!("Failed to canonicalize daemon config path: {}", e))
-            })?,
             // Installer started a bitcoind, it is expected that gui will start it on startup
             ctx.internal_bitcoind.is_some(),
         ))
@@ -497,8 +494,6 @@ pub async fn create_remote_wallet(
         network_datadir_path.clone(),
         gui_config::DEFAULT_FILE_NAME,
         toml::to_string(&gui_config::Config {
-            daemon_config_path: None,
-            daemon_rpc_path: None,
             log_level: Some("info".to_string()),
             debug: Some(false),
             start_internal_bitcoind: false,
@@ -613,8 +608,6 @@ pub async fn import_remote_wallet(
         network_datadir_path.clone(),
         gui_config::DEFAULT_FILE_NAME,
         toml::to_string(&gui_config::Config {
-            daemon_config_path: None,
-            daemon_rpc_path: None,
             log_level: Some("info".to_string()),
             debug: Some(false),
             start_internal_bitcoind: false,


### PR DESCRIPTION
This commit is part of preparatory work to support multiple wallets.

This commit introduces two breaking change:

The fields daemon_config_path and daemon_rpc_path are removed. The GUI will deduce these values from their expected location in the root data directory.

Because this link is removed, the gui flag --conf is not useful anymore as it cannot then find the location of the root data directory.