### PR TITLE
Prepare datadir for multiple wallet support

### DIFF
--- a/liana-gui/src/backup.rs
+++ b/liana-gui/src/backup.rs
@@ -128,7 +128,7 @@ impl Backup {
         let mut proprietary = serde_json::Map::new();
         proprietary.insert(LIANA_VERSION_KEY.to_string(), liana_version().into());
 
-        let config = extract_daemon_config(&ctx);
+        let config = extract_daemon_config(&ctx).map_err(|e| Error::Daemon(e.to_string()))?;
         if let Ok(config) = serde_json::to_value(config) {
             proprietary.insert(CONFIG_KEY.to_string(), config);
         }

--- a/liana-gui/src/installer/context.rs
+++ b/liana-gui/src/installer/context.rs
@@ -60,7 +60,7 @@ pub struct Context {
     pub descriptor: Option<LianaDescriptor>,
     pub keys: HashMap<bitcoin::bip32::Fingerprint, KeySetting>,
     pub hws: Vec<(DeviceKind, bitcoin::bip32::Fingerprint, Option<[u8; 32]>)>,
-    pub data_dir: PathBuf,
+    pub root_directory: PathBuf,
     pub network: bitcoin::Network,
     pub hw_is_used: bool,
     // In case a user entered a mnemonic,
@@ -76,7 +76,7 @@ pub struct Context {
 impl Context {
     pub fn new(
         network: bitcoin::Network,
-        data_dir: PathBuf,
+        root_directory: PathBuf,
         remote_backend: RemoteBackend,
     ) -> Self {
         Self {
@@ -89,7 +89,7 @@ impl Context {
             keys: HashMap::new(),
             bitcoin_backend: None,
             descriptor: None,
-            data_dir,
+            root_directory,
             network,
             hw_is_used: false,
             recovered_signer: None,

--- a/liana-gui/src/installer/step/node/bitcoind.rs
+++ b/liana-gui/src/installer/step/node/bitcoind.rs
@@ -531,7 +531,7 @@ impl Step for InternalBitcoindStep {
         if self.exe_path.is_none() {
             // Check if current managed bitcoind version is already installed.
             // For new installations, we ignore any previous managed bitcoind versions that might be installed.
-            let exe_path = bitcoind::internal_bitcoind_exe_path(&ctx.data_dir, VERSION);
+            let exe_path = bitcoind::internal_bitcoind_exe_path(&ctx.root_directory, VERSION);
             if exe_path.exists() {
                 self.exe_path = Some(exe_path)
             } else if self.exe_download.is_none() {

--- a/liana-gui/src/main.rs
+++ b/liana-gui/src/main.rs
@@ -317,6 +317,7 @@ impl GUI {
                         if remove_log {
                             self.logger.remove_install_log_file(i.datadir.clone());
                         }
+
                         let (loader, command) = Loader::new(
                             i.datadir.clone(),
                             cfg,

--- a/lianad/src/bin/cli.rs
+++ b/lianad/src/bin/cli.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_os = "windows"))]
 
-use lianad::config::{config_folder_path, Config};
+use lianad::config::Config;
 
 use std::{
     env,
@@ -89,17 +89,9 @@ fn socket_file(conf_file: Option<PathBuf>) -> PathBuf {
         process::exit(1);
     });
     let data_dir = config
-        .data_dir
-        .unwrap_or_else(|| config_folder_path().unwrap());
-    let data_dir = data_dir.to_str().expect("Datadir is valid unicode");
-
-    [
-        data_dir,
-        config.bitcoin_config.network.to_string().as_str(),
-        "lianad_rpc",
-    ]
-    .iter()
-    .collect()
+        .data_directory()
+        .expect("Wallet datadir is not properly defined");
+    data_dir.lianad_rpc_socket_path()
 }
 
 fn trimmed(mut vec: Vec<u8>, bytes_read: usize) -> Vec<u8> {

--- a/lianad/src/datadir.rs
+++ b/lianad/src/datadir.rs
@@ -1,0 +1,47 @@
+use std::path::{Path, PathBuf};
+
+pub struct DataDirectory(PathBuf);
+
+impl DataDirectory {
+    pub fn new(p: PathBuf) -> Self {
+        DataDirectory(p)
+    }
+}
+
+impl DataDirectory {
+    pub fn exists(&self) -> bool {
+        self.0.as_path().exists()
+    }
+    pub fn init(&self) -> Result<(), std::io::Error> {
+        #[cfg(unix)]
+        return {
+            use std::fs::DirBuilder;
+            use std::os::unix::fs::DirBuilderExt;
+
+            let mut builder = DirBuilder::new();
+            builder.mode(0o700).recursive(true).create(self.path())
+        };
+
+        // TODO: permissions on Windows..
+        #[cfg(not(unix))]
+        return { std::fs::create_dir_all(self.path()) };
+    }
+    pub fn path(&self) -> &Path {
+        self.0.as_path()
+    }
+    pub fn sqlite_db_file_path(&self) -> PathBuf {
+        let mut dir = self.0.clone();
+        dir.push("lianad.sqlite3");
+        dir
+    }
+    pub fn lianad_watchonly_wallet_path(&self) -> PathBuf {
+        let mut dir = self.0.clone();
+        dir.push("lianad_watchonly_wallet");
+        dir
+    }
+    pub fn lianad_rpc_socket_path(&self) -> PathBuf {
+        let mut dir = self.0.clone();
+        dir.push("lianad_rpc");
+        dir
+    }
+}

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -308,6 +308,33 @@ def lianad_multisig(bitcoin_backend, directory):
 
     lianad.cleanup()
 
+@pytest.fixture
+def lianad_multisig_legacy_datadir(bitcoin_backend, directory):
+    datadir = os.path.join(directory, "lianad")
+    os.makedirs(datadir, exist_ok=True)
+
+    # A 3-of-4 that degrades into a 2-of-5 after 10 blocks
+    csv_value = 10
+    signer = MultiSigner(4, {csv_value: 5}, is_taproot=USE_TAPROOT)
+    main_desc = Descriptor.from_str(multisig_desc(signer, csv_value, USE_TAPROOT, 3, 2))
+
+    lianad = Lianad(
+        datadir,
+        signer,
+        main_desc,
+        bitcoin_backend,
+        legacy_datadir=True
+    )
+
+    try:
+        lianad.start()
+        yield lianad
+    except Exception:
+        lianad.cleanup()
+        raise
+
+    lianad.cleanup()
+
 
 @pytest.fixture
 def lianad_multisig_2_of_2(bitcoin_backend, directory):

--- a/tests/test_framework/lianad.py
+++ b/tests/test_framework/lianad.py
@@ -31,6 +31,7 @@ class Lianad(TailableProc):
         signer,
         multi_desc,
         bitcoin_backend,
+        legacy_datadir=False
     ):
         TailableProc.__init__(self, datadir, verbose=VERBOSE)
 
@@ -44,12 +45,17 @@ class Lianad(TailableProc):
 
         self.conf_file = os.path.join(datadir, "config.toml")
         self.cmd_line = [LIANAD_PATH, "--conf", f"{self.conf_file}"]
-        socket_path = os.path.join(os.path.join(datadir, "regtest"), "lianad_rpc")
+        data_directory = os.path.join(datadir, "regtest")
+        socket_path = os.path.join(data_directory, "lianad_rpc")
         self.rpc = UnixDomainSocketRpc(socket_path)
         self.bitcoin_backend = bitcoin_backend
 
         with open(self.conf_file, "w") as f:
-            f.write(f"data_dir = '{datadir}'\n")
+            if legacy_datadir:
+                f.write(f"data_dir = '{datadir}'\n")
+            else:
+                f.write(f"data_directory = '{data_directory}'\n")
+
             f.write(f"log_level = '{LOG_LEVEL}'\n")
 
             f.write(f'main_descriptor = "{multi_desc}"\n')

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -278,9 +278,9 @@ def test_coinbase_deposit(lianad, bitcoind):
     BITCOIN_BACKEND_TYPE is not BitcoinBackendType.Bitcoind,
     reason="Only bitcoind backend was available for older lianad versions.",
 )
-def test_migration(lianad_multisig, bitcoind):
+def test_migration(lianad_multisig_legacy_datadir, bitcoind):
     """Test we can start a newer lianad on a datadir created by an older lianad."""
-    lianad = lianad_multisig
+    lianad = lianad_multisig_legacy_datadir
 
     # Set the old binary and re-create the datadir.
     lianad.cmd_line[0] = OLD_LIANAD_PATH


### PR DESCRIPTION
A new field data_directory is introduced in lianad configuration, it resolves directly to the path of the wallet datadir without the per network reasoning. The previous data_dir field is kept for backward compatibility for already generated configuration file.