### PR TITLE
fix: ensure spend (& recovery) panel steps use latest fingerprint aliases

### DIFF
--- a/liana-gui/src/app/state/spend/mod.rs
+++ b/liana-gui/src/app/state/spend/mod.rs
@@ -185,8 +185,11 @@ impl State for CreateSpendPanel {
     fn reload(
         &mut self,
         daemon: Arc<dyn Daemon + Sync + Send>,
-        _wallet: Arc<Wallet>,
+        wallet: Arc<Wallet>,
     ) -> Task<Message> {
+        for step in self.steps.iter_mut() {
+            step.reload_wallet(wallet.clone());
+        }
         let daemon1 = daemon.clone();
         let daemon2 = daemon.clone();
         let coin_statuses_1 = if self.draft.is_recovery() {

--- a/liana-gui/src/app/state/spend/step.rs
+++ b/liana-gui/src/app/state/spend/step.rs
@@ -78,6 +78,7 @@ pub trait Step {
     fn apply(&self, _draft: &mut TransactionDraft) {}
     fn interrupt(&mut self) {}
     fn load(&mut self, _coins: &[Coin], _tip_height: i32, _draft: &TransactionDraft) {}
+    fn reload_wallet(&mut self, _wallet: Arc<Wallet>) {}
     fn subscription(&self) -> Subscription<Message> {
         Subscription::none()
     }
@@ -975,6 +976,10 @@ impl Step for SaveSpend {
         ));
     }
 
+    fn reload_wallet(&mut self, wallet: Arc<Wallet>) {
+        self.wallet = wallet;
+    }
+
     fn interrupt(&mut self) {
         if let Some((psbt_state, _)) = &mut self.spend {
             psbt_state.interrupt()
@@ -1061,6 +1066,10 @@ impl SelectRecoveryPath {
 impl Step for SelectRecoveryPath {
     fn load(&mut self, coins: &[Coin], tip_height: i32, _draft: &TransactionDraft) {
         self.load_from_coins_and_tip_height(coins, tip_height);
+    }
+
+    fn reload_wallet(&mut self, wallet: Arc<Wallet>) {
+        self.wallet = wallet;
     }
 
     fn view<'a>(&'a self, cache: &'a Cache) -> Element<'a, view::Message> {


### PR DESCRIPTION
This fixes one of the items from #1664, but it's a little different from the other items there so I felt a separate PR would be better.

This fixes an issue for the Recovery panel that was introduced by #1658, but which was already present in the Send panel. If, while creating a regular spend, the user edits the fingerprint aliases, these updated aliases would not have shown in the signing info of the draft PSBT. For a recovery, this issue arises on the first step when selecting a recovery path, where the aliases are shown for each key required on that path.

The issue arises because the `wallet` field of individual steps was not being updated.

Now, the `wallet` will be stored by `CreateSpendPanel` and used by `load()` when moving between steps. Furthermore, the `WalletUpdated` message will be used to update the current step directly.