### PR TITLE
Disable signing devices that should not or cannot spend

### DIFF
--- a/liana-gui/src/app/view/hw.rs
+++ b/liana-gui/src/app/view/hw.rs
@@ -13,6 +13,7 @@ pub fn hw_list_view(
     hw: &HardwareWallet,
     signed: bool,
     signing: bool,
+    can_sign: bool,
 ) -> Element<Message> {
     let mut bttn = Button::new(match hw {
         HardwareWallet::Supported {
@@ -40,6 +41,8 @@ pub fn hw_list_view(
                     alias.as_ref(),
                     "The wallet descriptor is not registered on the device.\n You can register it in the settings.",
                 )
+            } else if !can_sign {
+                hw::disabled_hardware_wallet(kind, version.as_ref(), fingerprint, "This signing device is not part of this spending path.")
             } else {
                 hw::supported_hardware_wallet(kind, version.as_ref(), fingerprint, alias.as_ref())
             }
@@ -71,7 +74,7 @@ pub fn hw_list_view(
     })
     .style(theme::button::secondary)
     .width(Length::Fill);
-    if !signing {
+    if can_sign && !signing {
         if let HardwareWallet::Supported { registered, .. } = hw {
             if *registered != Some(false) {
                 bttn = bttn.on_press(Message::SelectHardwareWallet(i));

--- a/liana-gui/src/app/view/psbt.rs
+++ b/liana-gui/src/app/view/psbt.rs
@@ -1041,20 +1041,16 @@ pub fn sign_action<'a>(
                         .push(hws.iter().enumerate().fold(
                             Column::new().spacing(10),
                             |col, (i, hw)| {
-                                let can_sign = hw.fingerprint().map_or(false, |f| {
-                                    descriptor.contains_fingerprint_in_path(f, recovery_timelock)
-                                });
-                                col.push(hw_list_view(
-                                    i,
-                                    hw,
-                                    hw.fingerprint()
-                                        .map(|f| signed.contains(&f))
-                                        .unwrap_or(false),
-                                    hw.fingerprint()
-                                        .map(|f| signing.contains(&f))
-                                        .unwrap_or(false),
-                                    can_sign,
-                                ))
+                                let (signed, signing, can_sign) =
+                                    hw.fingerprint().map_or((false, false, false), |f| {
+                                        (
+                                            signed.contains(&f),
+                                            signing.contains(&f),
+                                            descriptor
+                                                .contains_fingerprint_in_path(f, recovery_timelock),
+                                        )
+                                    });
+                                col.push(hw_list_view(i, hw, signed, signing, can_sign))
                             },
                         ))
                         .push_maybe({

--- a/liana-gui/src/daemon/model.rs
+++ b/liana-gui/src/daemon/model.rs
@@ -204,6 +204,10 @@ impl SpendTx {
             .find(|&path| path.sigs_count >= path.threshold)
     }
 
+    pub fn recovery_timelock(&self) -> Option<u16> {
+        self.sigs.recovery_paths().keys().max().cloned()
+    }
+
     pub fn signers(&self) -> HashSet<Fingerprint> {
         let mut signers = HashSet::new();
         for fg in self.sigs.primary_path().signed_pubkeys.keys() {

--- a/liana-ui/src/component/hw.rs
+++ b/liana-ui/src/component/hw.rs
@@ -125,10 +125,11 @@ pub fn unimplemented_method_hardware_wallet<'a, T: 'a, K: Display, V: Display, F
     .width(Length::Fill)
 }
 
-pub fn unrelated_hardware_wallet<'a, T: 'a, K: Display, V: Display, F: Display>(
+pub fn disabled_hardware_wallet<'a, T: 'a, K: Display, V: Display, F: Display>(
     kind: K,
     version: Option<V>,
     fingerprint: F,
+    label: &'static str,
 ) -> Container<'a, T> {
     let key = column(vec![
         text::p1_regular(format!("#{}", fingerprint)).into(),
@@ -144,9 +145,7 @@ pub fn unrelated_hardware_wallet<'a, T: 'a, K: Display, V: Display, F: Display>(
                 .push(key)
                 .push(Space::with_width(15))
                 .push(Space::with_width(Length::Fill))
-                .push(text::text(
-                    "This signing device is not related to this Liana wallet.",
-                ))
+                .push(text::text(label))
                 .push(Space::with_width(Length::Fill))
                 .align_y(Vertical::Center),
         )
@@ -155,6 +154,19 @@ pub fn unrelated_hardware_wallet<'a, T: 'a, K: Display, V: Display, F: Display>(
         .style(theme::card::simple),
     )
     .width(Length::Fill)
+}
+
+pub fn unrelated_hardware_wallet<'a, T: 'a, K: Display, V: Display, F: Display>(
+    kind: K,
+    version: Option<V>,
+    fingerprint: F,
+) -> Container<'a, T> {
+    disabled_hardware_wallet(
+        kind,
+        version,
+        fingerprint,
+        "This signing device is not related to this Liana wallet.",
+    )
 }
 
 pub fn processing_hardware_wallet<'a, T: 'a, K: Display, V: Display, F: Display>(
@@ -484,20 +496,31 @@ pub fn unselected_hot_signer<'a, T: 'a, F: Display>(
 pub fn hot_signer<'a, T: 'a, F: Display>(
     fingerprint: F,
     alias: Option<impl Into<Cow<'a, str>> + Display>,
+    can_sign: bool,
 ) -> Container<'a, T> {
     Container::new(
-        column(vec![
-            Row::new()
-                .spacing(5)
-                .push_maybe(alias.map(|a| text::p1_bold(a)))
-                .push(text::p1_regular(format!("#{}", fingerprint)))
-                .into(),
-            Row::new()
-                .spacing(5)
-                .push(text::caption("This computer"))
-                .into(),
-        ])
-        .width(Length::Fill),
+        Row::new()
+            .push(column(vec![
+                Row::new()
+                    .spacing(5)
+                    .push_maybe(alias.map(|a| text::p1_bold(a)))
+                    .push(text::p1_regular(format!("#{}", fingerprint)))
+                    .into(),
+                Row::new()
+                    .spacing(5)
+                    .push(text::caption("This computer"))
+                    .into(),
+            ]))
+            .push(Space::with_width(Length::Fixed(20.0)))
+            .push_maybe(if !can_sign {
+                Some(text::text(
+                    "This hot signer is not part of this spending path.",
+                ))
+            } else {
+                None
+            })
+            .push(Space::with_width(Length::Fill))
+            .align_y(Vertical::Center),
     )
     .padding(10)
 }

--- a/liana/src/descriptors/analysis.rs
+++ b/liana/src/descriptors/analysis.rs
@@ -9,6 +9,7 @@ use miniscript::{
     RelLockTime, ScriptContext, Threshold,
 };
 
+use miniscript::bitcoin::bip32::Fingerprint;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     convert::TryFrom,
@@ -367,6 +368,11 @@ impl PathInfo {
                 .map_err(|e| LianaPolicyError::InvalidPolicy(miniscript::Error::Threshold(e)))?,
             ),
         })
+    }
+
+    /// Determine whether the fingerprint is part of this path.
+    pub fn contains_fingerprint(&self, fingerprint: Fingerprint) -> bool {
+        self.thresh_origins().1.contains_key(&fingerprint)
     }
 }
 


### PR DESCRIPTION
Inspired by #1607 this shoud closes #1041.

Notice that I added the wanted logic also for the recovery spending. That means you can only select a signing device related to the primary path for usual spend. But for recovery spending you can only select a signing device related to the recovery_path.

You can see here both examples :

![Capture d’écran du 2025-04-25 17-32-39](https://github.com/user-attachments/assets/3c137161-a108-4313-be03-4ec1c27c24ab)

![Capture d’écran du 2025-04-25 17-30-53](https://github.com/user-attachments/assets/71ea7cd0-cc45-4dcc-b00a-66b3243408bc)
