### PR TITLE
gui: store SignModal state and allow to open export modal after signing

### DIFF
--- a/liana-gui/src/app/state/psbt.rs
+++ b/liana-gui/src/app/state/psbt.rs
@@ -92,6 +92,9 @@ pub struct PsbtState {
     pub warning: Option<Error>,
     pub labels_edited: LabelsEdited,
     pub modal: Option<PsbtModal>,
+    // NOTE: sign_modal is used to store state of SignModal
+    // when another modal is selected
+    pub sign_modal: Option<PsbtModal>,
 }
 
 impl PsbtState {
@@ -102,6 +105,7 @@ impl PsbtState {
             labels_edited: LabelsEdited::default(),
             warning: None,
             modal: None,
+            sign_modal: None,
             tx,
             saved,
         }
@@ -165,19 +169,19 @@ impl PsbtState {
                 }
             }
             Message::View(view::Message::Spend(view::SpendTxMessage::Cancel)) => {
-                if let Some(PsbtModal::Sign(SignModal { display_modal, .. })) = &mut self.modal {
-                    *display_modal = false;
-                    return Task::none();
+                if matches!(self.modal, Some(PsbtModal::Sign(_))) {
+                    // store SignModal state
+                    self.sign_modal = self.modal.take();
                 }
-
                 self.modal = None;
             }
             Message::View(view::Message::Spend(view::SpendTxMessage::Delete)) => {
                 self.modal = Some(PsbtModal::Delete(DeleteModal::default()));
             }
             Message::View(view::Message::Spend(view::SpendTxMessage::Sign)) => {
-                if let Some(PsbtModal::Sign(SignModal { display_modal, .. })) = &mut self.modal {
-                    *display_modal = true;
+                if self.sign_modal.is_some() {
+                    // restore SignModal state
+                    self.modal = self.sign_modal.take();
                     return Task::none();
                 }
 
@@ -483,7 +487,6 @@ impl Modal for SignModal {
                     ..
                 }) = self.hws.list.get(i)
                 {
-                    self.display_modal = false;
                     self.signing.insert(*fingerprint);
                     let psbt = tx.psbt.clone();
                     let fingerprint = *fingerprint;
@@ -558,7 +561,7 @@ impl Modal for SignModal {
         Task::none()
     }
     fn view<'a>(&'a self, content: Element<'a, view::Message>) -> Element<'a, view::Message> {
-        let content = toast::Manager::new(
+        let content: Element<'a, view::Message> = toast::Manager::new(
             content,
             view::psbt::sign_action_toasts(self.error.as_ref(), &self.hws.list, &self.signing),
         )


### PR DESCRIPTION
This PR fixes #1681:
- `PsbtState::modal` was not properly reset after signing modal closed
- When `PsbtState::modal` is of type `SignModal` we store it's state, else we lost track of which key already signed.
- `SignModal::display_modal` is not useful anymore, as we store the modal state, and only "hidding" the modal not let display another modal (export modal for instance)