### PR TITLE
Update Home panel balances automatically

### DIFF
--- a/liana-gui/src/app/error.rs
+++ b/liana-gui/src/app/error.rs
@@ -6,7 +6,7 @@ use lianad::config::ConfigError;
 
 use crate::{
     app::{settings::SettingsError, wallet::WalletError},
-    daemon::DaemonError,
+    daemon::{utils::ListTransactionError, DaemonError},
     export::{self, RestoreBackupError},
 };
 
@@ -21,6 +21,7 @@ pub enum Error {
     Spend(SpendCreationError),
     ImportExport(export::Error),
     RestoreBackup(RestoreBackupError),
+    ListTransaction(ListTransactionError),
 }
 
 impl std::fmt::Display for Error {
@@ -63,6 +64,10 @@ impl std::fmt::Display for Error {
             Self::Desc(e) => write!(f, "Liana descriptor error: {}", e),
             Self::ImportExport(e) => write!(f, "{e}"),
             Self::RestoreBackup(e) => write!(f, "{e}"),
+            Self::ListTransaction(e) => match e {
+                ListTransactionError::Daemon(e) => write!(f, "Failed to list transactions: {}", e),
+                ListTransactionError::TxTimeMissing => write!(f, "Failed to list transactions: Transaction timestamp missing"),
+            }
         }
     }
 }
@@ -100,5 +105,11 @@ impl From<async_hwi::Error> for Error {
 impl From<SpendCreationError> for Error {
     fn from(error: SpendCreationError) -> Self {
         Error::Spend(error)
+    }
+}
+
+impl From<ListTransactionError> for Error {
+    fn from(value: ListTransactionError) -> Self {
+        Error::ListTransaction(value)
     }
 }

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -169,7 +169,7 @@ impl App {
             config.clone(),
             restored_from_backup,
         );
-        let cmd = panels.home.reload(daemon.clone(), wallet.clone());
+        let cmd = panels.home.reload(daemon.clone(), wallet.clone(), false);
         (
             Self {
                 panels,
@@ -267,7 +267,7 @@ impl App {
         self.panels.current = menu;
         self.panels
             .current_mut()
-            .reload(self.daemon.clone(), self.wallet.clone())
+            .reload(self.daemon.clone(), self.wallet.clone(), true)
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
@@ -355,8 +355,9 @@ impl App {
                         let home_reload = if (self.cache.coins != cache.coins)
                             && self.panels.current == Menu::Home
                         {
-                            let task =
-                                Task::perform(async {}, |_| Message::View(view::Message::Reload));
+                            let task = Task::perform(async {}, |_| {
+                                Message::View(view::Message::Reload(false))
+                            });
                             Some(task)
                         } else {
                             None

--- a/liana-gui/src/app/state/coins.rs
+++ b/liana-gui/src/app/state/coins.rs
@@ -157,6 +157,7 @@ impl State for CoinsPanel {
         &mut self,
         daemon: Arc<dyn Daemon + Sync + Send>,
         _wallet: Arc<Wallet>,
+        _reset: bool,
     ) -> Task<Message> {
         let daemon1 = daemon.clone();
         let daemon2 = daemon.clone();

--- a/liana-gui/src/app/state/receive.rs
+++ b/liana-gui/src/app/state/receive.rs
@@ -308,6 +308,7 @@ impl State for ReceivePanel {
         &mut self,
         daemon: Arc<dyn Daemon + Sync + Send>,
         wallet: Arc<Wallet>,
+        _reset: bool,
     ) -> Task<Message> {
         let data_dir = self.data_dir.clone();
         *self = Self::new(data_dir, wallet);

--- a/liana-gui/src/app/state/settings/mod.rs
+++ b/liana-gui/src/app/state/settings/mod.rs
@@ -77,7 +77,7 @@ impl State for SettingsState {
                 let wallet = self.wallet.clone();
                 self.setting
                     .as_mut()
-                    .map(|s| s.reload(daemon, wallet))
+                    .map(|s| s.reload(daemon, wallet, false))
                     .unwrap_or_else(Task::none)
             }
             Message::View(view::Message::Settings(
@@ -97,7 +97,7 @@ impl State for SettingsState {
                 let wallet = self.wallet.clone();
                 self.setting
                     .as_mut()
-                    .map(|s| s.reload(daemon, wallet))
+                    .map(|s| s.reload(daemon, wallet, false))
                     .unwrap_or_else(Task::none)
             }
             Message::View(view::Message::Settings(view::SettingsMessage::EditWalletSettings)) => {
@@ -112,7 +112,7 @@ impl State for SettingsState {
                 let wallet = self.wallet.clone();
                 self.setting
                     .as_mut()
-                    .map(|s| s.reload(daemon, wallet))
+                    .map(|s| s.reload(daemon, wallet, false))
                     .unwrap_or_else(Task::none)
             }
             Message::WalletUpdated(Ok(wallet)) => {
@@ -150,6 +150,7 @@ impl State for SettingsState {
         &mut self,
         _daemon: Arc<dyn Daemon + Sync + Send>,
         wallet: Arc<Wallet>,
+        _reset: bool,
     ) -> Task<Message> {
         self.setting = None;
         self.wallet = wallet;
@@ -343,6 +344,7 @@ impl State for AboutSettingsState {
         &mut self,
         daemon: Arc<dyn Daemon + Sync + Send>,
         _wallet: Arc<Wallet>,
+        _reset: bool,
     ) -> Task<Message> {
         Task::perform(
             async move { daemon.get_info().await.map_err(|e| e.into()) },

--- a/liana-gui/src/app/state/settings/wallet.rs
+++ b/liana-gui/src/app/state/settings/wallet.rs
@@ -318,6 +318,7 @@ impl State for WalletSettingsState {
         &mut self,
         daemon: Arc<dyn Daemon + Sync + Send>,
         wallet: Arc<Wallet>,
+        _reset: bool,
     ) -> Task<Message> {
         self.descriptor = wallet.main_descriptor.clone();
         self.keys_aliases = Self::keys_aliases(&wallet);
@@ -385,7 +386,7 @@ impl RegisterWalletModal {
         message: Message,
     ) -> Task<Message> {
         match message {
-            Message::View(view::Message::Reload) => {
+            Message::View(view::Message::Reload(_)) => {
                 self.chosen_hw = None;
                 self.warning = None;
                 Task::none()

--- a/liana-gui/src/app/state/spend/mod.rs
+++ b/liana-gui/src/app/state/spend/mod.rs
@@ -186,6 +186,7 @@ impl State for CreateSpendPanel {
         &mut self,
         daemon: Arc<dyn Daemon + Sync + Send>,
         wallet: Arc<Wallet>,
+        _reset: bool,
     ) -> Task<Message> {
         for step in self.steps.iter_mut() {
             step.reload_wallet(wallet.clone());

--- a/liana-gui/src/app/state/transactions.rs
+++ b/liana-gui/src/app/state/transactions.rs
@@ -153,8 +153,11 @@ impl State for TransactionsPanel {
                     self.warning = e.into();
                 }
             },
-            Message::View(view::Message::Reload) | Message::View(view::Message::Close) => {
-                return self.reload(daemon, self.wallet.clone());
+            Message::View(view::Message::Reload(reset)) => {
+                return self.reload(daemon, self.wallet.clone(), reset);
+            }
+            Message::View(view::Message::Close) => {
+                return self.reload(daemon, self.wallet.clone(), false);
             }
             Message::View(view::Message::Select(i)) => {
                 self.selected_tx = self.txs.get(i).cloned();
@@ -303,6 +306,7 @@ impl State for TransactionsPanel {
         &mut self,
         daemon: Arc<dyn Daemon + Sync + Send>,
         _wallet: Arc<Wallet>,
+        _reset: bool,
     ) -> Task<Message> {
         self.selected_tx = None;
         let now: u32 = SystemTime::now()

--- a/liana-gui/src/app/view/home.rs
+++ b/liana-gui/src/app/view/home.rs
@@ -67,11 +67,11 @@ pub fn home_view<'a>(
     unconfirmed_balance: &'a bitcoin::Amount,
     remaining_sequence: &Option<u32>,
     expiring_coins: &[bitcoin::OutPoint],
-    events: &'a [Payment],
-    is_last_page: bool,
+    payments: Vec<&'a Payment>,
     processing: bool,
     sync_status: &SyncStatus,
     show_rescan_warning: bool,
+    see_more: bool,
 ) -> Element<'a, Message> {
     Column::new()
         .push(h3("Balance"))
@@ -187,24 +187,24 @@ pub fn home_view<'a>(
             Column::new()
                 .spacing(10)
                 .push(h4_bold("Last payments"))
-                .push(events.iter().fold(Column::new().spacing(10), |col, event| {
-                    if event.kind != PaymentKind::SendToSelf {
-                        col.push(event_list_view(event))
-                    } else {
-                        col
-                    }
-                }))
-                .push_maybe(if !is_last_page && !events.is_empty() {
+                .push(
+                    payments
+                        .iter()
+                        .fold(Column::new().spacing(10), |col, event| {
+                            if event.kind != PaymentKind::SendToSelf {
+                                col.push(event_list_view(event))
+                            } else {
+                                col
+                            }
+                        }),
+                )
+                .push_maybe(if see_more {
                     Some(
                         Container::new(
                             Button::new(
-                                text(if processing {
-                                    "Fetching ..."
-                                } else {
-                                    "See more"
-                                })
-                                .width(Length::Fill)
-                                .align_x(alignment::Horizontal::Center),
+                                text("See more")
+                                    .width(Length::Fill)
+                                    .align_x(alignment::Horizontal::Center),
                             )
                             .width(Length::Fill)
                             .padding(15)

--- a/liana-gui/src/app/view/message.rs
+++ b/liana-gui/src/app/view/message.rs
@@ -7,7 +7,7 @@ pub trait Close {
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    Reload,
+    Reload(bool /* reset */),
     Clipboard(String),
     Menu(Menu),
     Close,

--- a/liana-gui/src/app/view/mod.rs
+++ b/liana-gui/src/app/view/mod.rs
@@ -46,7 +46,7 @@ pub fn sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message> {
     let home_button = if *menu == Menu::Home {
         row!(
             button::menu_active(Some(home_icon()), "Home")
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar(),
         )
@@ -59,7 +59,7 @@ pub fn sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message> {
     let transactions_button = if *menu == Menu::Transactions {
         row!(
             button::menu_active(Some(history_icon()), "Transactions")
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar()
         )
@@ -72,7 +72,7 @@ pub fn sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message> {
     let coins_button = if *menu == Menu::Coins {
         row!(
             button::menu_active(Some(coins_icon()), "Coins")
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar()
         )
@@ -86,7 +86,7 @@ pub fn sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message> {
     let psbt_button = if *menu == Menu::PSBTs {
         row!(
             button::menu_active(Some(history_icon()), "PSBTs")
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar()
         )
@@ -99,7 +99,7 @@ pub fn sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message> {
     let spend_button = if *menu == Menu::CreateSpendTx {
         row!(
             button::menu_active(Some(send_icon()), "Send")
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar()
         )
@@ -112,7 +112,7 @@ pub fn sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message> {
     let receive_button = if *menu == Menu::Receive {
         row!(
             button::menu_active(Some(receive_icon()), "Receive")
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar()
         )
@@ -125,7 +125,7 @@ pub fn sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message> {
     let recovery_button = if *menu == Menu::Recovery {
         row!(
             button::menu_active(Some(recovery_icon()), "Recovery")
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar()
         )
@@ -190,7 +190,7 @@ pub fn small_sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message
     let home_button = if *menu == Menu::Home {
         row!(
             button::menu_active_small(home_icon())
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar(),
         )
@@ -203,7 +203,7 @@ pub fn small_sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message
     let transactions_button = if *menu == Menu::Transactions {
         row!(
             button::menu_active_small(history_icon())
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar()
         )
@@ -216,7 +216,7 @@ pub fn small_sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message
     let coins_button = if *menu == Menu::Coins {
         row!(
             button::menu_active_small(coins_icon())
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar()
         )
@@ -230,7 +230,7 @@ pub fn small_sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message
     let psbt_button = if *menu == Menu::PSBTs {
         row!(
             button::menu_active_small(history_icon())
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar()
         )
@@ -243,7 +243,7 @@ pub fn small_sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message
     let spend_button = if *menu == Menu::CreateSpendTx {
         row!(
             button::menu_active_small(send_icon())
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar()
         )
@@ -256,7 +256,7 @@ pub fn small_sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message
     let receive_button = if *menu == Menu::Receive {
         row!(
             button::menu_active_small(receive_icon())
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar()
         )
@@ -269,7 +269,7 @@ pub fn small_sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message
     let recovery_button = if *menu == Menu::Recovery {
         row!(
             button::menu_active_small(recovery_icon())
-                .on_press(Message::Reload)
+                .on_press(Message::Reload(true))
                 .width(iced::Length::Fill),
             menu_green_bar()
         )

--- a/liana-gui/src/app/view/warning.rs
+++ b/liana-gui/src/app/view/warning.rs
@@ -51,6 +51,7 @@ impl From<&Error> for WarningMessage {
             Error::Spend(e) => WarningMessage(format!("Spend creation error: '{}'.", e)),
             Error::ImportExport(e) => WarningMessage(format!("{e}")),
             Error::RestoreBackup(e) => WarningMessage(format!("Failed to restore backup: {e}")),
+            e @ Error::ListTransaction(_) => WarningMessage(e.to_string()),
         }
     }
 }

--- a/liana-gui/src/daemon/mod.rs
+++ b/liana-gui/src/daemon/mod.rs
@@ -1,6 +1,7 @@
 pub mod client;
 pub mod embedded;
 pub mod model;
+pub mod utils;
 
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;

--- a/liana-gui/src/daemon/utils.rs
+++ b/liana-gui/src/daemon/utils.rs
@@ -1,0 +1,142 @@
+use std::{collections::HashMap, sync::Arc};
+
+use chrono::{Duration, Utc};
+use liana::miniscript::bitcoin::Txid;
+
+use crate::{export, services::connect::client::backend::api::DEFAULT_LIMIT};
+
+use super::{model::HistoryTransaction, Daemon, DaemonBackend, DaemonError};
+
+#[derive(Debug)]
+pub enum ListTransactionError {
+    Daemon(DaemonError),
+    TxTimeMissing,
+}
+
+impl From<DaemonError> for ListTransactionError {
+    fn from(value: DaemonError) -> Self {
+        ListTransactionError::Daemon(value)
+    }
+}
+
+impl From<ListTransactionError> for export::Error {
+    fn from(value: ListTransactionError) -> Self {
+        match value {
+            ListTransactionError::Daemon(e) => export::Error::Daemon(e.to_string()),
+            ListTransactionError::TxTimeMissing => export::Error::TxTimeMissing,
+        }
+    }
+}
+
+pub enum FetchProgress {
+    Progress(f32),
+    Ended,
+}
+
+impl From<FetchProgress> for export::Progress {
+    fn from(value: FetchProgress) -> Self {
+        match value {
+            FetchProgress::Progress(p) => export::Progress::Progress(p),
+            FetchProgress::Ended => export::Progress::Ended,
+        }
+    }
+}
+
+pub async fn list_confirmed_transactions<F>(
+    daemon: Arc<dyn Daemon + Sync + Send>,
+    notif: F,
+    send_notif: bool,
+    limit: Option<usize>,
+) -> Result<Vec<HistoryTransaction>, ListTransactionError>
+where
+    F: Fn(FetchProgress) + Send,
+{
+    // look 2 hour forward
+    // https://github.com/bitcoin/bitcoin/blob/62bd61de110b057cbfd6e31e4d0b727d93119c72/src/chain.h#L29
+    let mut end = ((Utc::now() + Duration::hours(2)).timestamp()) as u32;
+
+    let total_txs = if send_notif {
+        let total_txs = daemon
+            .list_confirmed_txs(0, end, u32::MAX as u64)
+            .await?
+            .transactions
+            .len();
+        if total_txs == 0 {
+            notif(FetchProgress::Ended);
+            return Ok(vec![]);
+        } else {
+            notif(FetchProgress::Progress(5.0));
+        }
+        Some(total_txs)
+    } else {
+        None
+    };
+
+    let max = match daemon.backend() {
+        DaemonBackend::RemoteBackend => DEFAULT_LIMIT as u64,
+        _ => u32::MAX as u64,
+    };
+
+    // store txs in a map to avoid duplicates
+    let mut map = HashMap::<Txid, HistoryTransaction>::new();
+    let mut fetch_limit = max;
+
+    loop {
+        let history_txs = daemon.list_history_txs(0, end, fetch_limit).await?;
+        let dl = map.len() + history_txs.len();
+        if let (Some(total_txs), true) = (total_txs, send_notif) {
+            if dl > 0 {
+                let progress = (dl as f32) / (total_txs as f32) * 80.0;
+                notif(FetchProgress::Progress(progress));
+            }
+        }
+        // all txs have been fetched
+        if history_txs.is_empty() {
+            break;
+        }
+        if history_txs.len() == fetch_limit as usize {
+            let first = if let Some(t) = history_txs.first().expect("checked").time {
+                t
+            } else {
+                return Err(ListTransactionError::TxTimeMissing);
+            };
+            let last = if let Some(t) = history_txs.last().expect("checked").time {
+                t
+            } else {
+                return Err(ListTransactionError::TxTimeMissing);
+            };
+            // limit too low, all tx are in the same timestamp
+            // we must increase limit and retry
+            if first == last {
+                fetch_limit += DEFAULT_LIMIT as u64;
+                continue;
+            } else {
+                // add txs to map
+                for tx in history_txs {
+                    let txid = tx.txid;
+                    map.insert(txid, tx);
+                }
+                fetch_limit = max;
+                end = first.min(last);
+                if let Some(limit) = limit {
+                    if map.len() >= limit {
+                        break;
+                    }
+                }
+                continue;
+            }
+        } else
+        // history_txs.len() < fetch_limit  => no more poll requested
+        {
+            // add txs to map
+            for tx in history_txs {
+                let txid = tx.txid;
+                map.insert(txid, tx);
+            }
+            break;
+        }
+    }
+
+    let txs: Vec<_> = map.into_values().collect();
+    Ok(txs)
+}

--- a/liana-gui/src/utils/sandbox.rs
+++ b/liana-gui/src/utils/sandbox.rs
@@ -44,7 +44,7 @@ impl<S: State + 'static> Sandbox<S> {
         cache: &Cache,
         wallet: Arc<Wallet>,
     ) -> Self {
-        let cmd = self.state.reload(daemon.clone(), wallet);
+        let cmd = self.state.reload(daemon.clone(), wallet, false);
         if let Some(mut stream) = into_stream(cmd) {
             while let Some(action) = stream.next().await {
                 if let Action::Output(msg) = action {

--- a/lianad/src/commands/mod.rs
+++ b/lianad/src/commands/mod.rs
@@ -1443,14 +1443,14 @@ pub struct ListRevealedAddressesResult {
     pub continue_from: Option<ChildNumber>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LCSpendInfo {
     pub txid: bitcoin::Txid,
     /// The block height this spending transaction was confirmed at.
     pub height: Option<i32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ListCoinsEntry {
     #[serde(
         serialize_with = "ser_amount",


### PR DESCRIPTION
The `Home` panel balances were originally not updated when new coins were received, this PR fix this.

Payment list is now updated as follow:
 - If user click on `Home` button, the payment list is folded to maxi 20 displayed entries.
 - on auto update, if the payment list have been expanded , payments will be fetched up tothe max previously displayed count, that means payment list not folded.
 