### PR TITLE
feat: add `listrevealedaddresses` command

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -12,6 +12,7 @@ Commands must be sent as valid JSONRPC 2.0 requests, ending with a `\n`.
 | [`updatederivationindexes`](#updatederivationindexes)       | Update last generated addresses derivation indexes            |
 | [`getnewaddress`](#getnewaddress)                           | Get a new receiving address                                   |
 | [`listaddresses`](#listaddresses)                           | List addresses given start_index and count                    |
+| [`listrevealedaddresses`](#listrevealedaddresses)           | List revealed addresses (both used and unused)                |
 | [`listcoins`](#listcoins)                                   | List all wallet transaction outputs.                          |
 | [`createspend`](#createspend)                               | Create a new Spend transaction                                |
 | [`updatespend`](#updatespend)                               | Store a created Spend transaction                             |
@@ -139,6 +140,40 @@ If no value is passed for `count` the maximum generated index between receive an
 | `receive`     | string            | Receive address                                             |
 | `change`      | string            | Change address                                              |
 
+
+### `listrevealedaddresses`
+
+List revealed receive or change addresses, optionally filtering for those that are unused by any of the current coins in the wallet.
+
+Addresses are returned in order of descending derivation index.
+
+If `start_index` is omitted or `null`, then addresses will be returned starting from the last revealed address.
+Otherwise, addresses will be returned starting from the specified derivation index.
+
+#### Request
+
+| Field           | Type              | Description                                                                             |
+| --------------- | ----------------- | --------------------------------------------------------------------------------------- |
+| `is_change`     | bool              | Whether to return change or otherwise receive addresses.                                |
+| `exclude_used`  | bool              | Whether to exclude those addresses that have been used by a current coin in the wallet. |
+| `limit`         | integer           | The maximum number of addresses to list.                                                |
+| `start_index`   | integer(optional) | For pagination, pass the `continue_from` value from the previous response.              |
+
+#### Response
+
+The response contains two fields:
+- `addresses`: an array of revealed addresses, with the structure given below.
+- `continue_from`: used for pagination of results. If not `null`, this indicates that there may be additional addresses that can be listed and
+this value can be passed to the next request as `start_index` to continue with the next page of results.
+
+Each element in the `addresses` array has the following fields:
+
+| Field         | Type             | Description                                                                  |
+| ------------- | ---------------- | ---------------------------------------------------------------------------- |
+| `index`       | integer          | Derivation index.                                                            |
+| `address`     | string           | Address.                                                                     |
+| `used_count`  | integer          | The number of current coins in the wallet that are using this address.       |
+| `label`       | string or null   | Address label, if any.                                                       |
 
 ### `listcoins`
 

--- a/lianad/src/jsonrpc/api.rs
+++ b/lianad/src/jsonrpc/api.rs
@@ -199,6 +199,50 @@ fn list_addresses(
     Ok(serde_json::json!(&res))
 }
 
+fn list_revealed_addresses(
+    control: &DaemonControl,
+    params: Params,
+) -> Result<serde_json::Value, Error> {
+    let is_change = params
+        .get(0, "is_change")
+        .ok_or_else(|| Error::invalid_params("Missing 'is_change' parameter."))?
+        .as_bool()
+        .ok_or_else(|| Error::invalid_params("Invalid 'is_change' parameter."))?;
+    let exclude_used = params
+        .get(1, "exclude_used")
+        .ok_or_else(|| Error::invalid_params("Missing 'exclude_used' parameter."))?
+        .as_bool()
+        .ok_or_else(|| Error::invalid_params("Invalid 'exclude_used' parameter."))?;
+    let limit = params
+        .get(2, "limit")
+        .ok_or_else(|| Error::invalid_params("Missing 'limit' parameter."))?
+        .as_u64()
+        .and_then(|l| l.try_into().ok())
+        .ok_or_else(|| Error::invalid_params("Invalid 'limit' parameter."))?;
+    // A missing value and `null` are both mapped to `None`.
+    let start_index = if let Some(ind) = params.get(3, "start_index") {
+        if ind.as_null().is_some() {
+            None
+        } else {
+            let ind_u32: u32 = ind
+                .as_u64()
+                .and_then(|ind_u64| ind_u64.try_into().ok())
+                .ok_or_else(|| Error::invalid_params("Invalid 'start_index' parameter."))?;
+            Some(ind_u32)
+        }
+    } else {
+        None
+    };
+
+    let res = &control.list_revealed_addresses(
+        is_change,
+        exclude_used,
+        limit,
+        start_index.map(|ind| ind.into()),
+    )?;
+    Ok(serde_json::json!(&res))
+}
+
 fn update_deriv_indexes(
     control: &DaemonControl,
     params: Params,
@@ -492,6 +536,14 @@ pub fn handle_request(control: &mut DaemonControl, req: Request) -> Result<Respo
         "listaddresses" => {
             let params = req.params;
             list_addresses(control, params)?
+        }
+        "listrevealedaddresses" => {
+            let params = req.params.ok_or_else(|| {
+                Error::invalid_params(
+                    "The 'listrevealedaddresses' command requires 3 parameters: 'is_change', 'exclude_used' and 'limit'",
+                )
+            })?;
+            list_revealed_addresses(control, params)?
         }
         "listconfirmed" => {
             let params = req.params.ok_or_else(|| {

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -308,6 +308,7 @@ def lianad_multisig(bitcoin_backend, directory):
 
     lianad.cleanup()
 
+
 @pytest.fixture
 def lianad_multisig_legacy_datadir(bitcoin_backend, directory):
     datadir = os.path.join(directory, "lianad")
@@ -318,13 +319,7 @@ def lianad_multisig_legacy_datadir(bitcoin_backend, directory):
     signer = MultiSigner(4, {csv_value: 5}, is_taproot=USE_TAPROOT)
     main_desc = Descriptor.from_str(multisig_desc(signer, csv_value, USE_TAPROOT, 3, 2))
 
-    lianad = Lianad(
-        datadir,
-        signer,
-        main_desc,
-        bitcoin_backend,
-        legacy_datadir=True
-    )
+    lianad = Lianad(datadir, signer, main_desc, bitcoin_backend, legacy_datadir=True)
 
     try:
         lianad.start()

--- a/tests/test_framework/lianad.py
+++ b/tests/test_framework/lianad.py
@@ -26,12 +26,7 @@ from test_framework.serializations import (
 
 class Lianad(TailableProc):
     def __init__(
-        self,
-        datadir,
-        signer,
-        multi_desc,
-        bitcoin_backend,
-        legacy_datadir=False
+        self, datadir, signer, multi_desc, bitcoin_backend, legacy_datadir=False
     ):
         TailableProc.__init__(self, datadir, verbose=VERBOSE)
 


### PR DESCRIPTION
This implements #1678.

The command parameters differ slightly from those described in the issue:
- instead of a `keychain` enum parameter, I used  `is_change` to control whether receive or change addresses are returned.
- I used an optional `continue_from` parameter to control pagination. The value to pass in the next request is provided by the previous response. If no value is provided in the response, there are no more addresses to list. If no value is set in the request, the addresses will be returned starting from the last revealed address.

Setting the positional argument for `continue_after` as `null` will be treated the same as omitting it (for other RPC commands, a `null` value results in a parsing error).
