### PR TITLE
gui: Improve visibility primary button text & fixes

### DIFF
--- a/liana-gui/src/app/view/receive.rs
+++ b/liana-gui/src/app/view/receive.rs
@@ -43,10 +43,15 @@ pub fn receive<'a>(
             Row::new()
                 .align_y(Alignment::Center)
                 .push(Container::new(h3("Receive")).width(Length::Fill))
-                .push(
-                    button::primary(Some(icon::plus_icon()), "Generate address")
-                        .on_press(Message::Next),
-                ),
+                .push({
+                    let (icon, label) = (Some(icon::plus_icon()), "Generate address");
+                    if addresses.is_empty() {
+                        button::primary(icon, label)
+                    } else {
+                        button::secondary(icon, label)
+                    }
+                    .on_press(Message::Next)
+                }),
         )
         .push(p1_bold("New and never used reception addresses"))
         .push(

--- a/liana-gui/src/app/view/transactions.rs
+++ b/liana-gui/src/app/view/transactions.rs
@@ -291,7 +291,7 @@ pub fn create_rbf_modal<'a>(
             }))
             .push_maybe(replacement_txid.map(|id| {
                 Row::new().push(
-                    button::secondary(None, "Go to replacement")
+                    button::primary(None, "Go to replacement")
                         .width(Length::Fixed(200.0))
                         .on_press(Message::Menu(Menu::PsbtPreSelected(id))),
                 )

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -1,16 +1,16 @@
+use super::text::text;
+use crate::font::MEDIUM;
 use crate::{theme, widget::*};
 use iced::alignment::{Horizontal, Vertical};
 use iced::widget::{button, container, row};
 
-use super::text::text;
-
 pub fn menu<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) -> Button<'a, T> {
-    button::Button::new(content_menu(icon.map(|i| i.style(theme::text::secondary)), t).padding(10))
+    Button::new(content_menu(icon.map(|i| i.style(theme::text::secondary)), t).padding(10))
         .style(theme::button::menu)
 }
 
 pub fn menu_active<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) -> Button<'a, T> {
-    button::Button::new(content_menu(icon.map(|i| i.style(theme::text::secondary)), t).padding(10))
+    Button::new(content_menu(icon.map(|i| i.style(theme::text::secondary)), t).padding(10))
         .style(theme::button::menu_pressed)
 }
 
@@ -22,33 +22,33 @@ fn content_menu<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) -> Container
 }
 
 pub fn alert<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) -> Button<'a, T> {
-    button::Button::new(content(icon, t)).style(theme::button::destructive)
+    Button::new(content(icon, text(t))).style(theme::button::destructive)
 }
 
 pub fn primary<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) -> Button<'a, T> {
-    button::Button::new(content(icon, t)).style(theme::button::primary)
+    Button::new(content(icon, text(t).font(MEDIUM))).style(theme::button::primary)
 }
 
 pub fn transparent<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) -> Button<'a, T> {
-    button::Button::new(content(icon, t)).style(theme::button::container)
+    Button::new(content(icon, text(t))).style(theme::button::container)
 }
 
 pub fn secondary<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) -> Button<'a, T> {
-    button::Button::new(content(icon, t)).style(theme::button::secondary)
+    Button::new(content(icon, text(t))).style(theme::button::secondary)
 }
 
 pub fn border<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) -> Button<'a, T> {
-    button::Button::new(content(icon, t)).style(theme::button::secondary)
+    Button::new(content(icon, text(t))).style(theme::button::secondary)
 }
 
 pub fn transparent_border<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) -> Button<'a, T> {
-    button(content(icon, t)).style(theme::button::container_border)
+    button(content(icon, text(t))).style(theme::button::container_border)
 }
 
-fn content<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) -> Container<'a, T> {
+fn content<'a, T: 'a>(icon: Option<Text<'a>>, text: Text<'a>) -> Container<'a, T> {
     match icon {
-        None => container(text(t)).align_x(Horizontal::Center).padding(5),
-        Some(i) => container(row![i, text(t)].spacing(10).align_y(Vertical::Center))
+        None => container(text).align_x(Horizontal::Center).padding(5),
+        Some(i) => container(row![i, text].spacing(10).align_y(Vertical::Center))
             .align_x(Horizontal::Center)
             .padding(5),
     }


### PR DESCRIPTION
The first commit fixes #1697.
The second set "Go to replacement" as primary.
The third make "Generate address" become secondary after generation.
Tell me if I should squash.

![image](https://github.com/user-attachments/assets/6cbf3573-0956-43e5-be70-f2e075f5c314)

![Capture d’écran du 2025-05-06 20-47-25](https://github.com/user-attachments/assets/8df30fb6-9ac8-4eb2-9756-9a1fecc921d9)

I've tried to make the icon thicker but doesn't work the same way. Maybe using a different font or an image would help to fixes this.