### PR TITLE
fix import backup for existing wallet

### DIFF
--- a/liana-gui/src/app/state/settings/mod.rs
+++ b/liana-gui/src/app/state/settings/mod.rs
@@ -269,8 +269,15 @@ impl State for ImportExportSettingsState {
             }
             Message::View(view::Message::Settings(view::SettingsMessage::ImportWallet)) => {
                 if self.modal.is_none() {
-                    let modal =
-                        ExportModal::new(Some(daemon), ImportExportType::ImportBackup(None, None));
+                    let modal = ExportModal::new(
+                        Some(daemon),
+                        ImportExportType::ImportBackup {
+                            network_dir: cache.datadir_path.network_directory(cache.network),
+                            wallet: self.wallet.clone(),
+                            overwrite_labels: None,
+                            overwrite_aliases: None,
+                        },
+                    );
                     launch!(self, modal, false);
                 }
             }

--- a/liana-gui/src/app/state/settings/wallet.rs
+++ b/liana-gui/src/app/state/settings/wallet.rs
@@ -289,8 +289,15 @@ impl State for WalletSettingsState {
             }
             Message::View(view::Message::Settings(view::SettingsMessage::ImportWallet)) => {
                 if self.modal.is_none() {
-                    let modal =
-                        ExportModal::new(Some(daemon), ImportExportType::ImportBackup(None, None));
+                    let modal = ExportModal::new(
+                        Some(daemon),
+                        ImportExportType::ImportBackup {
+                            network_dir: cache.datadir_path.network_directory(cache.network),
+                            wallet: self.wallet.clone(),
+                            overwrite_labels: None,
+                            overwrite_aliases: None,
+                        },
+                    );
                     let launch = modal.launch(false);
                     self.modal = Modal::ImportExport(modal);
                     launch

--- a/liana-gui/src/app/view/export.rs
+++ b/liana-gui/src/app/view/export.rs
@@ -86,7 +86,11 @@ pub fn export_modal<'a, Message: From<ImportExportMessage> + Clone + 'static>(
         )),
     );
     let (msg, button) = match import_export_type {
-        ImportExportType::ImportBackup(labels, aliases) => match (labels, aliases) {
+        ImportExportType::ImportBackup {
+            overwrite_labels,
+            overwrite_aliases,
+            ..
+        } => match (overwrite_labels, overwrite_aliases) {
             (Some(_), _) => labels_btn,
 
             (_, Some(_)) => aliases_btn,


### PR DESCRIPTION
We pass the wallet to the import_backup method
so the wallet id is used to find the correct wallet settings to update in the settings file.