### PR TITLE
fix: use scrollbar for node settings

### DIFF
--- a/liana-gui/src/app/view/settings.rs
+++ b/liana-gui/src/app/view/settings.rs
@@ -558,8 +558,24 @@ pub fn bitcoind<'a>(
                 v.clone()
             };
             Row::new()
-                .push(Container::new(text(k).bold().small()).width(Length::Fill))
-                .push(text(t).small())
+                .push(Container::new(text(k).bold().small()).width(Length::FillPortion(1)))
+                .push(
+                    Container::new(
+                        scrollable(
+                            Column::new()
+                                .push(Space::with_height(Length::Fixed(10.0)))
+                                .push(text(t).small())
+                                // Space between the text and the scrollbar
+                                .push(Space::with_height(Length::Fixed(10.0))),
+                        )
+                        .direction(scrollable::Direction::Horizontal(
+                            scrollable::Scrollbar::new().width(2).scroller_width(2),
+                        )),
+                    )
+                    .align_x(alignment::Horizontal::Right)
+                    .padding(10)
+                    .width(Length::FillPortion(3)),
+                )
                 .push(Space::with_width(10))
                 .push(
                     Button::new(icon::clipboard_icon())


### PR DESCRIPTION
This fixes an issue when viewing a long node setting value, such as the cookie path, on a reduced window size.

![image](https://github.com/user-attachments/assets/8c9bef9c-cc37-46a4-b501-81d4a8e4eda7)
