### PR TITLE
fix settings: missing update_aliases for backup restore

### DIFF
--- a/liana-gui/src/app/state/settings/mod.rs
+++ b/liana-gui/src/app/state/settings/mod.rs
@@ -9,7 +9,7 @@ use iced::Task;
 use liana_ui::{component::form, widget::Element};
 
 use bitcoind::BitcoindSettingsState;
-use wallet::WalletSettingsState;
+use wallet::{update_aliases, WalletSettingsState};
 
 use crate::{
     app::{
@@ -223,7 +223,19 @@ impl State for ImportExportSettingsState {
                 self.modal = None;
             }
             Message::View(view::Message::ImportExport(m)) => {
-                if let Some(modal) = self.modal.as_mut() {
+                if let ImportExportMessage::UpdateAliases(aliases) = m {
+                    return Task::perform(
+                        update_aliases(
+                            cache.datadir_path.clone(),
+                            cache.network,
+                            self.wallet.clone(),
+                            None,
+                            aliases.into_iter().map(|(fg, ks)| (fg, ks.name)).collect(),
+                            daemon,
+                        ),
+                        Message::WalletUpdated,
+                    );
+                } else if let Some(modal) = self.modal.as_mut() {
                     return modal.update(m);
                 };
             }

--- a/liana-gui/src/app/state/settings/wallet.rs
+++ b/liana-gui/src/app/state/settings/wallet.rs
@@ -516,9 +516,10 @@ pub async fn update_aliases(
     keys_aliases: Vec<(Fingerprint, String)>,
     daemon: Arc<dyn Daemon + Sync + Send>,
 ) -> Result<Arc<Wallet>, Error> {
-    let mut wallet = wallet.as_ref().clone().with_alias(wallet_alias.clone());
+    let mut wallet = wallet.as_ref().clone();
 
     if let Some(wallet_alias) = wallet_alias.as_ref() {
+        wallet = wallet.with_alias(Some(wallet_alias.clone()));
         let network_dir = data_dir.network_directory(network);
         let wallet_id = wallet.id();
         update_settings_file(&network_dir, |mut settings| {


### PR DESCRIPTION
While restoring a backup at the import/export panel, the message to update the wallet keys aliases was not handled and although the aliases are stored in the settings file, the wallet was not "reloaded" through the Message::WalletUpdated result. The consequence was while opening the wallet section, users found the aliases not updated by the backup (even if the file was updated).

The change in the update_aliases is to update the wallet alias only if the function require the change by passing
`Some(alias)` in arg.