### PR TITLE
Apply backup alias when importing backup in installer.

### DIFF
--- a/liana-gui/src/installer/mod.rs
+++ b/liana-gui/src/installer/mod.rs
@@ -316,11 +316,6 @@ impl Installer {
                     .expect("There is always a step")
                     .update(&mut self.hws, Message::Installed(wallet_id, Err(e)))
             }
-            Message::WalletFromBackup((ks, backup)) => {
-                self.context.keys = ks;
-                self.context.backup = Some(backup);
-                Task::none()
-            }
             _ => self
                 .steps
                 .get_mut(self.current)

--- a/liana-gui/src/installer/step/wallet_alias.rs
+++ b/liana-gui/src/installer/step/wallet_alias.rs
@@ -1,5 +1,6 @@
 use iced::Task;
 
+use liana::miniscript::bitcoin::Network;
 use liana_ui::{component::form, widget::*};
 
 use crate::{
@@ -15,9 +16,31 @@ pub struct WalletAlias {
 
 impl Step for WalletAlias {
     fn load_context(&mut self, ctx: &Context) {
-        if !ctx.wallet_alias.is_empty() {
-            self.wallet_alias.value = ctx.wallet_alias.clone();
-            self.wallet_alias.valid = true;
+        match (
+            ctx.wallet_alias.is_empty(),
+            self.wallet_alias.value.is_empty(),
+        ) {
+            // Alias from context is the first one to be set.
+            (false, _) => {
+                self.wallet_alias.value = ctx.wallet_alias.clone();
+                self.wallet_alias.valid = true;
+            }
+            // No alias at all, we set a default value.
+            (true, true) => {
+                self.wallet_alias.value = format!(
+                    "My Liana {} wallet",
+                    match ctx.network {
+                        Network::Bitcoin => "Bitcoin",
+                        Network::Signet => "Signet",
+                        Network::Testnet => "Testnet",
+                        Network::Regtest => "Regtest",
+                        _ => "",
+                    }
+                );
+                self.wallet_alias.valid = true;
+            }
+            // We keep the current value.
+            (true, false) => {}
         }
     }
 


### PR DESCRIPTION
- We add a default wallet alias if not value is set in the installer context.
- We add the wallet alias field to the backup file. 
  - While importing a backup in the installer, the backup wallet alias will be suggested to the user at the final step. 
  - While importing a backup in the wallet settings for an already installed wallet, we keep the current wallet alias and not override it by the backup one.