### PR TITLE
Make user finish signing process before opening new modal

### DIFF
--- a/liana-gui/src/app/state/spend/step.rs
+++ b/liana-gui/src/app/state/spend/step.rs
@@ -1018,6 +1018,11 @@ impl Step for SaveSpend {
             &psbt_state.wallet.keys_aliases,
             psbt_state.labels_edited.cache(),
             cache.network,
+            if let Some(psbt::PsbtModal::Sign(m)) = &psbt_state.modal {
+                m.is_signing()
+            } else {
+                false
+            },
             psbt_state.warning.as_ref(),
         );
         if let Some(modal) = &psbt_state.modal {

--- a/liana-gui/src/app/view/psbt.rs
+++ b/liana-gui/src/app/view/psbt.rs
@@ -46,6 +46,7 @@ pub fn psbt_view<'a>(
     key_aliases: &'a HashMap<Fingerprint, String>,
     labels_editing: &'a HashMap<String, form::Value<String>>,
     network: Network,
+    currently_signing: bool,
     warning: Option<&Error>,
 ) -> Element<'a, Message> {
     dashboard(
@@ -72,7 +73,12 @@ pub fn psbt_view<'a>(
                     }),
             )
             .push(spend_header(tx, labels_editing))
-            .push(spend_overview_view(tx, desc_info, key_aliases))
+            .push(spend_overview_view(
+                tx,
+                desc_info,
+                key_aliases,
+                currently_signing,
+            ))
             .push(
                 Column::new()
                     .spacing(20)
@@ -96,7 +102,11 @@ pub fn psbt_view<'a>(
                     .push(
                         button::secondary(None, "Delete")
                             .width(Length::Fixed(200.0))
-                            .on_press(Message::Spend(SpendTxMessage::Delete)),
+                            .on_press_maybe(if currently_signing {
+                                None
+                            } else {
+                                Some(Message::Spend(SpendTxMessage::Delete))
+                            }),
                     )
                     .width(Length::Fill)
             } else {
@@ -105,7 +115,11 @@ pub fn psbt_view<'a>(
                     .push(
                         button::secondary(None, "Save")
                             .width(Length::Fixed(150.0))
-                            .on_press(Message::Spend(SpendTxMessage::Save)),
+                            .on_press_maybe(if currently_signing {
+                                None
+                            } else {
+                                Some(Message::Spend(SpendTxMessage::Save))
+                            }),
                     )
                     .width(Length::Fill)
             })
@@ -321,6 +335,7 @@ pub fn spend_overview_view<'a>(
     tx: &'a SpendTx,
     desc_info: &'a LianaPolicy,
     key_aliases: &'a HashMap<Fingerprint, String>,
+    currently_signing: bool,
 ) -> Element<'a, Message> {
     Column::new()
         .spacing(20)
@@ -343,14 +358,22 @@ pub fn spend_overview_view<'a>(
                                                     Some(icon::backup_icon()),
                                                     "Export",
                                                 )
-                                                .on_press(Message::ExportPsbt),
+                                                .on_press_maybe(if currently_signing {
+                                                    None
+                                                } else {
+                                                    Some(Message::ExportPsbt)
+                                                }),
                                             )
                                             .push(
                                                 button::secondary(
                                                     Some(icon::restore_icon()),
                                                     "Import",
                                                 )
-                                                .on_press(Message::ImportPsbt),
+                                                .on_press_maybe(if currently_signing {
+                                                    None
+                                                } else {
+                                                    Some(Message::ImportPsbt)
+                                                }),
                                             ),
                                     )
                                     .align_y(Alignment::Center),

--- a/liana-gui/src/app/view/spend/mod.rs
+++ b/liana-gui/src/app/view/spend/mod.rs
@@ -37,6 +37,7 @@ pub fn spend_view<'a>(
     key_aliases: &'a HashMap<Fingerprint, String>,
     labels_editing: &'a HashMap<String, form::Value<String>>,
     network: Network,
+    currently_signing: bool,
     warning: Option<&Error>,
 ) -> Element<'a, Message> {
     let is_recovery = tx
@@ -75,7 +76,12 @@ pub fn spend_view<'a>(
                     },
                 ))
             })
-            .push(psbt::spend_overview_view(tx, desc_info, key_aliases))
+            .push(psbt::spend_overview_view(
+                tx,
+                desc_info,
+                key_aliases,
+                currently_signing,
+            ))
             .push(
                 Column::new()
                     .spacing(20)
@@ -99,7 +105,11 @@ pub fn spend_view<'a>(
                     .push(
                         button::secondary(None, "Delete")
                             .width(Length::Fixed(200.0))
-                            .on_press(Message::Spend(SpendTxMessage::Delete)),
+                            .on_press_maybe(if currently_signing {
+                                None
+                            } else {
+                                Some(Message::Spend(SpendTxMessage::Delete))
+                            }),
                     )
                     .width(Length::Fill)
             } else {
@@ -107,13 +117,21 @@ pub fn spend_view<'a>(
                     .push(
                         button::secondary(None, "< Previous")
                             .width(Length::Fixed(150.0))
-                            .on_press(Message::Previous),
+                            .on_press_maybe(if currently_signing {
+                                None
+                            } else {
+                                Some(Message::Previous)
+                            }),
                     )
                     .push(Space::with_width(Length::Fill))
                     .push(
                         button::secondary(None, "Save")
                             .width(Length::Fixed(150.0))
-                            .on_press(Message::Spend(SpendTxMessage::Save)),
+                            .on_press_maybe(if currently_signing {
+                                None
+                            } else {
+                                Some(Message::Spend(SpendTxMessage::Save))
+                            }),
                     )
                     .width(Length::Fill)
             }),


### PR DESCRIPTION
This Pr is to mitigate three issues:
close #1719 
close #1685
and try to prevent a little bit the problem of impossible cancellation of the signing Task by disabling any other buttons and making aware of the user that he has to finish it (reject of approve).
Sadly it is not the case for the sidebar menu button, so if user start the signing process and quit by switching panel, he may still have the problem of the signing task blocking in the background and may be surprised by the impossibility of iced to close properly.

Proper signing task cancellation will require a change in the async-hwi library: https://github.com/wizardsardine/async-hwi/issues/108

![20250523_16h55m19s_grim](https://github.com/user-attachments/assets/8b92b975-29d1-4281-b8a9-b6a4a63495fe)
![20250523_16h54m17s_grim](https://github.com/user-attachments/assets/3ac8cf39-da75-42af-8390-cc5db77e8722)
