### PR TITLE
fix update wallet alias in wallet settings

### DIFF
--- a/liana-gui/src/app/state/settings/wallet.rs
+++ b/liana-gui/src/app/state/settings/wallet.rs
@@ -563,15 +563,7 @@ pub async fn update_aliases(
     wallet.keys_aliases = keys_aliases.into_iter().collect();
 
     daemon
-        .update_wallet_metadata(
-            if wallet_alias.is_some() && wallet.alias != wallet_alias {
-                wallet_alias
-            } else {
-                None
-            },
-            &wallet.keys_aliases,
-            &wallet.hardware_wallets,
-        )
+        .update_wallet_metadata(wallet_alias, &wallet.keys_aliases, &wallet.hardware_wallets)
         .await?;
 
     Ok(Arc::new(wallet))


### PR DESCRIPTION
L522 the wallet was populated with its new alias
and the check L567 was always false.

wallet_alias is None if we do not have to update it, so better pass the variable directly.