### PR TITLE
flake.nix: devshells include toolchain

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -155,6 +155,7 @@
             xorg.libXcursor
             xorg.libXi
             xorg.libXrandr
+            toolchain
           ];
 
           LD_LIBRARY_PATH =


### PR DESCRIPTION
on x86_64-linux, this was necessary to get cargo into the path so as to be able to execute things like `cargo build ...`.

When trying to test out the latest release candidate from NixOS (x86_64-linux), running `nix develop` did not drop me into a devshell with cargo available. The fix here may not have been the best way to remedy that, but it did work, and then I was able to test the latest code by:
1. `nix develop` to get into the devshell
2. `cargo build --release`
3. `target/release/liana-gui --datadir ./test_alice`