### PR TITLE
fix: use correct path to daemon.toml in settings

### DIFF
--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -401,7 +401,11 @@ impl App {
         let network = cfg.bitcoin_config.network;
         let daemon = EmbeddedDaemon::start(cfg)?;
         self.daemon = Arc::new(daemon);
-        let mut daemon_config_path = datadir_path.network_directory(network).path().to_path_buf();
+        let mut daemon_config_path = datadir_path
+            .network_directory(network)
+            .lianad_data_directory(&self.wallet.id())
+            .path()
+            .to_path_buf();
         daemon_config_path.push("daemon.toml");
 
         let content =


### PR DESCRIPTION
This fixes #1743 by using the correct daemon config file path of the current wallet.