### PR TITLE
refac: remove patch field from Version

### DIFF
--- a/liana-gui/src/backup.rs
+++ b/liana-gui/src/backup.rs
@@ -36,7 +36,7 @@ const SETTINGS_KEY: &str = "settings";
 const LIANA_VERSION_KEY: &str = "liana_version";
 
 pub fn liana_version() -> String {
-    format!("{}.{}.{}", VERSION.major, VERSION.minor, VERSION.patch)
+    format!("{}.{}", VERSION.major, VERSION.minor)
 }
 
 fn now() -> u64 {

--- a/liana-gui/src/lib.rs
+++ b/liana-gui/src/lib.rs
@@ -20,7 +20,6 @@ use lianad::Version;
 pub const VERSION: Version = Version {
     major: 11,
     minor: 0,
-    patch: 0,
 };
 
 #[cfg(test)]

--- a/lianad/src/lib.rs
+++ b/lianad/src/lib.rs
@@ -71,19 +71,17 @@ pub fn setup_panic_hook() {
 pub struct Version {
     pub major: u32,
     pub minor: u32,
-    pub patch: u32,
 }
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+        write!(f, "{}.{}", self.major, self.minor)
     }
 }
 
 pub const VERSION: Version = Version {
     major: 11,
     minor: 0,
-    patch: 0,
 };
 
 #[derive(Debug)]

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -26,7 +26,7 @@ MAX_DERIV = 2**31 - 1
 def test_getinfo(lianad):
     res = lianad.rpc.getinfo()
     assert "timestamp" in res.keys()
-    assert res["version"] == "11.0.0"
+    assert res["version"] == "11.0"
     assert res["network"] == "regtest"
     wait_for(lambda: lianad.rpc.getinfo()["block_height"] == 101)
     res = lianad.rpc.getinfo()


### PR DESCRIPTION
backport of #1749 

The Version struct is used across the software
to display the release version. A release version
does not include patch number as we increment
only the major and the minor during a new release.

For very small patch that does not change the
API and does not require a new release, then the crates Cargo.toml version patch number will be incremented.