### PR TITLE
Improve timelock duration selection and display

### DIFF
--- a/liana-gui/src/installer/view/editor/mod.rs
+++ b/liana-gui/src/installer/view/editor/mod.rs
@@ -524,7 +524,7 @@ fn example_xpub(network: Network) -> String {
 }
 
 /// returns y,m,d,h,m
-pub fn duration_from_sequence(sequence: u16) -> (u32, u32, u32, u32, u32) {
+fn duration_from_sequence(sequence: u16) -> (u32, u32, u32, u32, u32) {
     let mut n_minutes = sequence as u32 * 10;
     let n_years = n_minutes / 525960;
     n_minutes -= n_years * 525960;
@@ -536,6 +536,44 @@ pub fn duration_from_sequence(sequence: u16) -> (u32, u32, u32, u32, u32) {
     n_minutes -= n_hours * 60;
 
     (n_years, n_months, n_days, n_hours, n_minutes)
+}
+
+/// Formats a Bitcoin sequence duration into readable units with smart truncation.
+///
+/// Converts block count to (value, unit) tuples and truncates precision based on duration:
+/// - ≥ 1440 blocks (~10d): show up to days (e.g., "1m 10d")
+/// - 144-1439 blocks (~1-10d): show up to hours (e.g., "2d 5h")
+/// - < 144 blocks: show all units (e.g., "3h 45mn")
+///
+/// `short_format`: true = "y/m/d/h/mn", false = "year/month/day/hour/minute"
+pub fn format_sequence_duration(sequence: u16, short_format: bool) -> Vec<(u32, &'static str)> {
+    let (n_years, n_months, n_days, n_hours, n_minutes) = duration_from_sequence(sequence);
+
+    let mut formatted_duration = if short_format {
+        vec![
+            (n_years, "y"),
+            (n_months, "m"),
+            (n_days, "d"),
+            (n_hours, "h"),
+            (n_minutes, "mn"),
+        ]
+    } else {
+        vec![
+            (n_years, "year"),
+            (n_months, "month"),
+            (n_days, "day"),
+            (n_hours, "hour"),
+            (n_minutes, "minute"),
+        ]
+    };
+
+    if sequence >= 1440 {
+        formatted_duration.truncate(3);
+    } else if sequence >= 144 {
+        formatted_duration.truncate(4);
+    }
+
+    formatted_duration
 }
 
 pub fn edit_sequence_modal<'a>(sequence: &form::Value<String>) -> Element<'a, Message> {
@@ -566,23 +604,8 @@ pub fn edit_sequence_modal<'a>(sequence: &form::Value<String>) -> Element<'a, Me
 
     if sequence.valid {
         if let Ok(sequence) = u16::from_str(&sequence.value) {
-            let (n_years, n_months, n_days, n_hours, n_minutes) = duration_from_sequence(sequence);
-            let mut units_to_show = vec![
-                (n_years, "year"),
-                (n_months, "month"),
-                (n_days, "day"),
-                (n_hours, "hour"),
-                (n_minutes, "minute"),
-            ];
-            if sequence >= 1440 {
-                // >= 10 days: show until days
-                units_to_show.truncate(3);
-            } else if sequence >= 144 {
-                // 1-10 days: show until hours
-                units_to_show.truncate(4);
-            } // < 1 day: show all
             col = col
-                .push(units_to_show.iter().fold(
+                .push(format_sequence_duration(sequence, false).iter().fold(
                     Row::new().spacing(5).push(text("~ ").bold()),
                     |row, (n, unit)| {
                         row.push_maybe(if *n > 0 {

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -40,7 +40,7 @@ use crate::{
         message::{self, DefineBitcoind, DefineNode, Message},
         prompt,
         step::{DownloadState, InstallState},
-        view::editor::duration_from_sequence,
+        view::editor::format_sequence_duration,
         Error,
     },
     node::{
@@ -1616,29 +1616,22 @@ pub fn defined_sequence<'a>(
     sequence: PathSequence,
     warning: Option<PathWarning>,
 ) -> Element<'a, message::DefinePath> {
-    let (n_years, n_months, n_days, n_hours, n_minutes) = duration_from_sequence(sequence.as_u16());
     let duration_row = Row::new()
         .padding(5)
         .spacing(5)
         .align_y(Alignment::Center)
         .push(text(
-            [
-                (n_years, "y"),
-                (n_months, "m"),
-                (n_days, "d"),
-                (n_hours, "h"),
-                (n_minutes, "mn"),
-            ]
-            .iter()
-            .filter_map(|(n, unit)| {
-                if *n > 0 {
-                    Some(format!("{}{}", n, unit))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<String>>()
-            .join(" "),
+            format_sequence_duration(sequence.as_u16(), true)
+                .iter()
+                .filter_map(|(n, unit)| {
+                    if *n > 0 {
+                        Some(format!("{}{}", n, unit))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<String>>()
+                .join(" "),
         ));
     Container::new(
         Column::new()


### PR DESCRIPTION
The first commit adds monthly steps to the timelock selection slider and adapts time estimation precision.
The second is a tiny GUI improvement.

Here few examples : 

![Capture d’écran du 2025-06-29 19-22-16](https://github.com/user-attachments/assets/3d037390-f22e-4213-8210-c9daa3c882a8)
![Capture d’écran du 2025-06-29 19-22-12](https://github.com/user-attachments/assets/ceaff667-8066-4ef6-8ade-51a0828fbb44)
![Capture d’écran du 2025-06-29 19-22-01](https://github.com/user-attachments/assets/aa9fd978-08c9-4cd7-99cd-532b648f1add)
![Capture d’écran du 2025-06-29 19-21-56](https://github.com/user-attachments/assets/cffa46a2-d320-4b69-91e1-7afd14ffdb54)
![Capture d’écran du 2025-06-29 19-21-34](https://github.com/user-attachments/assets/1abe5639-04ab-4ac8-aa3c-5e581071dd7f)
