### PR TITLE
Add tiny-skia feature to iced dep

### DIFF
--- a/liana-gui/Cargo.toml
+++ b/liana-gui/Cargo.toml
@@ -22,7 +22,7 @@ liana-ui = { path = "../liana-ui" }
 backtrace = "0.3"
 hex = "0.4.3"
 
-iced = { version = "0.13.1", default-features = false, features = ["tokio", "svg", "qr_code", "image", "lazy", "wgpu", "advanced"] }
+iced = { version = "0.13.1", default-features = false, features = ["tokio", "svg", "qr_code", "image", "lazy", "wgpu", "advanced", "tiny-skia"] }
 iced_runtime = "0.13.1"
 
 # Used to verify RFC-compliance of an email


### PR DESCRIPTION
tiny-skia is an other renderer that does not
rely on wgpu. Iced uses it as a fallback in case
of wgpu problems.

The feature can be tested with:
`ICED_BACKEND=tiny-skia cargo run --release --bin liana-gui`

close #1676