### PR TITLE
liana-ui: add warning to form::Value

### DIFF
--- a/liana-gui/src/app/settings.rs
+++ b/liana-gui/src/app/settings.rs
@@ -342,6 +342,7 @@ impl KeySetting {
     pub fn to_form(&self) -> form::Value<String> {
         form::Value {
             value: self.name.clone(),
+            warning: None,
             valid: true,
         }
     }

--- a/liana-gui/src/app/state/label.rs
+++ b/liana-gui/src/app/state/label.rs
@@ -38,6 +38,7 @@ impl LabelsEdited {
                                 item,
                                 form::Value {
                                     valid,
+                                    warning: None,
                                     value: value.clone(),
                                 },
                             );

--- a/liana-gui/src/app/state/settings/bitcoind.rs
+++ b/liana-gui/src/app/state/settings/bitcoind.rs
@@ -245,6 +245,7 @@ impl BitcoindSettings {
                 RpcAuthValues {
                     cookie_path: form::Value {
                         valid: true,
+                        warning: None,
                         value: path.to_str().unwrap().to_string(),
                     },
                     user: form::Value::default(),
@@ -257,10 +258,12 @@ impl BitcoindSettings {
                     cookie_path: form::Value::default(),
                     user: form::Value {
                         valid: true,
+                        warning: None,
                         value: user.clone(),
                     },
                     password: form::Value {
                         valid: true,
+                        warning: None,
                         value: password.clone(),
                     },
                 },
@@ -284,6 +287,7 @@ impl BitcoindSettings {
             selected_auth_type,
             addr: form::Value {
                 valid: true,
+                warning: None,
                 value: addr,
             },
         }
@@ -423,6 +427,7 @@ impl ElectrumSettings {
             processing: false,
             addr: form::Value {
                 valid: true,
+                warning: None,
                 value: addr,
             },
         }

--- a/liana-gui/src/app/state/settings/wallet.rs
+++ b/liana-gui/src/app/state/settings/wallet.rs
@@ -65,6 +65,7 @@ impl WalletSettingsState {
             keys_aliases: Self::keys_aliases(&wallet),
             wallet_alias: form::Value {
                 value: wallet.alias.clone().unwrap_or_default(),
+                warning: None,
                 valid: true,
             },
             wallet,
@@ -86,6 +87,7 @@ impl WalletSettingsState {
                     fg,
                     form::Value {
                         value: name,
+                        warning: None,
                         valid: true,
                     },
                 )

--- a/liana-gui/src/app/state/transactions.rs
+++ b/liana-gui/src/app/state/transactions.rs
@@ -388,6 +388,7 @@ impl CreateRbfModal {
             descendant_txids,
             feerate_val: form::Value {
                 valid: true,
+                warning: None,
                 value: min_feerate_vb.to_string(),
             },
             // For cancel, we let `rbfpsbt` set the feerate.

--- a/liana-gui/src/installer/step/backend.rs
+++ b/liana-gui/src/installer/step/backend.rs
@@ -250,6 +250,7 @@ impl Step for RemoteBackendLogin {
                     self.step = ConnectionStep::EnterEmail {
                         email: form::Value {
                             value: email.clone(),
+                            warning: None,
                             valid: true,
                         },
                     };

--- a/liana-gui/src/installer/step/descriptor/editor/key.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/key.rs
@@ -73,8 +73,6 @@ pub struct EditXpubModal {
 
     form_name: form::Value<String>,
     form_xpub: form::Value<String>,
-    // TODO: Define new `form::Value` type with `Option<String>` instead of `bool` so that we can
-    // store `form_token_warning` directly in `form_token`.
     form_token: form::Value<String>,
     form_token_warning: Option<String>,
     /// The `KeySourceKind` corresponding to the required form for entering a new key.
@@ -115,10 +113,12 @@ impl EditXpubModal {
             other_path_keys,
             form_name: form::Value {
                 valid: true,
+                warning: None,
                 value: key.as_ref().map(|k| k.name.clone()).unwrap_or_default(),
             },
             form_xpub: form::Value {
                 valid: true,
+                warning: None,
                 value: key
                     .as_ref()
                     .filter(|k| k.source.is_manual())
@@ -127,6 +127,7 @@ impl EditXpubModal {
             },
             form_token: form::Value {
                 valid: true,
+                warning: None,
                 value: key
                     .as_ref()
                     .and_then(|k| k.source.token().cloned())

--- a/liana-gui/src/installer/step/descriptor/editor/mod.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/mod.rs
@@ -520,6 +520,7 @@ impl EditSequenceModal {
             path_index,
             sequence: form::Value {
                 value: path_sequence.as_u16().to_string(),
+                warning: None,
                 valid: true,
             },
         }

--- a/liana-ui/src/component/form.rs
+++ b/liana-ui/src/component/form.rs
@@ -7,6 +7,7 @@ use crate::{color, component::text, theme, widget::*};
 #[derive(Debug, Clone)]
 pub struct Value<T> {
     pub value: T,
+    pub warning: Option<&'static str>,
     pub valid: bool,
 }
 
@@ -14,6 +15,7 @@ impl std::default::Default for Value<String> {
     fn default() -> Self {
         Self {
             value: "".to_string(),
+            warning: None,
             valid: true,
         }
     }
@@ -41,7 +43,7 @@ where
     {
         Self {
             input: text_input::TextInput::new(placeholder, &value.value).on_input(on_change),
-            warning: None,
+            warning: value.warning,
             valid: value.valid,
         }
     }


### PR DESCRIPTION
This PR add a `warning` field to `form::Value`, so the warning can be accessed also from outside the view scope. This field will be "inherited" by the `form::Form`.

This PR "closes" a TODO in `EditXpubModal`, but I decided to go with a separate `warning` field as it can be useful to display a warning even if a value is considered valid.

Note: as this change do not modify the usage from within the view scope, usages of `form::Form` have not been updated.