### PR TITLE
refactor: update cache fields according to source

### DIFF
--- a/liana-gui/src/app/cache.rs
+++ b/liana-gui/src/app/cache.rs
@@ -13,14 +13,9 @@ use std::sync::Arc;
 pub struct Cache {
     pub datadir_path: LianaDirectory,
     pub network: Network,
-    pub blockheight: i32,
-    pub coins: Vec<Coin>,
-    pub rescan_progress: Option<f64>,
-    pub sync_progress: f64,
-    /// The most recent `last_poll_timestamp`.
-    pub last_poll_timestamp: Option<u32>,
     /// The `last_poll_timestamp` when starting the application.
     pub last_poll_at_startup: Option<u32>,
+    pub daemon_cache: DaemonCache,
 }
 
 /// only used for tests.
@@ -29,12 +24,54 @@ impl std::default::Default for Cache {
         Self {
             datadir_path: LianaDirectory::new(std::path::PathBuf::new()),
             network: Network::Bitcoin,
+            last_poll_at_startup: None,
+            daemon_cache: DaemonCache::default(),
+        }
+    }
+}
+
+impl Cache {
+    pub fn blockheight(&self) -> i32 {
+        self.daemon_cache.blockheight
+    }
+
+    pub fn coins(&self) -> &[Coin] {
+        &self.daemon_cache.coins
+    }
+
+    pub fn rescan_progress(&self) -> Option<f64> {
+        self.daemon_cache.rescan_progress
+    }
+
+    pub fn sync_progress(&self) -> f64 {
+        self.daemon_cache.sync_progress
+    }
+
+    pub fn last_poll_timestamp(&self) -> Option<u32> {
+        self.daemon_cache.last_poll_timestamp
+    }
+}
+
+/// The cache for dynamic daemon data.
+#[derive(Debug, Clone)]
+pub struct DaemonCache {
+    pub blockheight: i32,
+    pub coins: Vec<Coin>,
+    pub rescan_progress: Option<f64>,
+    pub sync_progress: f64,
+    /// The most recent `last_poll_timestamp`.
+    pub last_poll_timestamp: Option<u32>,
+}
+
+/// only used for tests.
+impl std::default::Default for DaemonCache {
+    fn default() -> Self {
+        Self {
             blockheight: 0,
             coins: Vec::new(),
             rescan_progress: None,
             sync_progress: 1.0,
             last_poll_timestamp: None,
-            last_poll_at_startup: None,
         }
     }
 }

--- a/liana-gui/src/app/message.rs
+++ b/liana-gui/src/app/message.rs
@@ -9,7 +9,7 @@ use liana::miniscript::bitcoin::{
 use lianad::config::Config as DaemonConfig;
 
 use crate::{
-    app::{cache::Cache, error::Error, view, wallet::Wallet},
+    app::{cache::DaemonCache, error::Error, view, wallet::Wallet},
     daemon::model::*,
     export::ImportExportMessage,
     hw::HardwareWalletMessage,
@@ -18,7 +18,8 @@ use crate::{
 #[derive(Debug)]
 pub enum Message {
     Tick,
-    UpdateCache(Result<Cache, Error>),
+    UpdateDaemonCache(Result<DaemonCache, Error>),
+    CacheUpdated,
     UpdatePanelCache(/* is current panel */ bool),
     View(view::Message),
     LoadDaemonConfig(Box<DaemonConfig>),

--- a/liana-gui/src/app/state/mod.rs
+++ b/liana-gui/src/app/state/mod.rs
@@ -216,7 +216,7 @@ impl State for Home {
                         self.remaining_sequence,
                     ) = coins_summary(
                         &coins,
-                        cache.blockheight as u32,
+                        cache.blockheight() as u32,
                         self.wallet.main_descriptor.first_timelock_value(),
                     );
                 }
@@ -260,9 +260,9 @@ impl State for Home {
                 let wallet_was_syncing = !self.sync_status.is_synced();
                 self.sync_status = sync_status(
                     daemon.backend(),
-                    cache.blockheight,
-                    cache.sync_progress,
-                    cache.last_poll_timestamp,
+                    cache.blockheight(),
+                    cache.sync_progress(),
+                    cache.last_poll_timestamp(),
                     cache.last_poll_at_startup,
                 );
                 // If this is the current panel, reload it if wallet is no longer syncing.

--- a/liana-gui/src/app/state/settings/bitcoind.rs
+++ b/liana-gui/src/app/state/settings/bitcoind.rs
@@ -80,7 +80,7 @@ impl BitcoindSettingsState {
                     daemon_is_external,
                 )
             }),
-            rescan_settings: RescanSetting::new(cache.rescan_progress),
+            rescan_settings: RescanSetting::new(cache.rescan_progress()),
         }
     }
 }
@@ -138,7 +138,7 @@ impl State for BitcoindSettingsState {
                 self.rescan_settings.processing = false;
             }
             Message::UpdatePanelCache(_) => {
-                self.rescan_settings.processing = cache.rescan_progress.is_some_and(|p| p < 1.0);
+                self.rescan_settings.processing = cache.rescan_progress().is_some_and(|p| p < 1.0);
             }
             Message::View(view::Message::Settings(view::SettingsMessage::BitcoindSettings(
                 msg,
@@ -385,7 +385,7 @@ impl BitcoindSettings {
             view::settings::bitcoind_edit(
                 is_configured_node_type,
                 self.bitcoin_config.network,
-                cache.blockheight,
+                cache.blockheight(),
                 &self.addr,
                 &self.rpc_auth_vals,
                 &self.selected_auth_type,
@@ -396,8 +396,8 @@ impl BitcoindSettings {
                 is_configured_node_type,
                 self.bitcoin_config.network,
                 &self.bitcoind_config,
-                cache.blockheight,
-                Some(cache.blockheight != 0),
+                cache.blockheight(),
+                Some(cache.blockheight() != 0),
                 can_edit && !self.daemon_is_external && !self.bitcoind_is_internal,
             )
         }
@@ -501,7 +501,7 @@ impl ElectrumSettings {
             view::settings::electrum_edit(
                 is_configured_node_type,
                 self.bitcoin_config.network,
-                cache.blockheight,
+                cache.blockheight(),
                 &self.addr,
                 self.processing,
                 self.electrum_config.validate_domain,
@@ -511,8 +511,8 @@ impl ElectrumSettings {
                 is_configured_node_type,
                 self.bitcoin_config.network,
                 &self.electrum_config,
-                cache.blockheight,
-                Some(cache.blockheight != 0),
+                cache.blockheight(),
+                Some(cache.blockheight() != 0),
                 can_edit && !self.daemon_is_external,
             )
         }
@@ -646,7 +646,7 @@ impl RescanSetting {
             &self.year,
             &self.month,
             &self.day,
-            cache.rescan_progress,
+            cache.rescan_progress(),
             self.success,
             self.processing,
             can_edit,

--- a/liana-gui/src/app/view/coins.rs
+++ b/liana-gui/src/app/view/coins.rs
@@ -36,7 +36,7 @@ pub fn coins_view<'a>(
                         col.push(coin_list_view(
                             coin,
                             timelock,
-                            cache.blockheight as u32,
+                            cache.blockheight() as u32,
                             i,
                             selected.contains(&i),
                             labels,

--- a/liana-gui/src/app/view/mod.rs
+++ b/liana-gui/src/app/view/mod.rs
@@ -172,7 +172,7 @@ pub fn sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message> {
                 Container::new(
                     Column::new()
                         .spacing(10)
-                        .push_maybe(cache.rescan_progress.map(|p| {
+                        .push_maybe(cache.rescan_progress().map(|p| {
                             Container::new(text(format!("  Rescan...{:.2}%  ", p * 100.0)))
                                 .padding(5)
                                 .style(theme::pill::simple)
@@ -317,7 +317,7 @@ pub fn small_sidebar<'a>(menu: &Menu, cache: &'a Cache) -> Container<'a, Message
                 Container::new(
                     Column::new()
                         .spacing(10)
-                        .push_maybe(cache.rescan_progress.map(|p| {
+                        .push_maybe(cache.rescan_progress().map(|p| {
                             Container::new(text(format!("{:.2}%  ", p * 100.0)))
                                 .padding(5)
                                 .style(theme::pill::simple)

--- a/liana-gui/src/app/view/spend/mod.rs
+++ b/liana-gui/src/app/view/spend/mod.rs
@@ -316,7 +316,7 @@ pub fn create_spend_tx<'a>(
                                         coin,
                                         coins_labels,
                                         timelock,
-                                        cache.blockheight as u32,
+                                        cache.blockheight() as u32,
                                         *selected,
                                     ))
                                 },

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -12,7 +12,7 @@ use lianad::commands::ListCoinsResult;
 use crate::{
     app::{
         self,
-        cache::Cache,
+        cache::{Cache, DaemonCache},
         settings::{update_settings_file, WalletSettings},
         wallet::Wallet,
         App,
@@ -351,14 +351,17 @@ pub fn create_app_with_remote_backend(
     App::new(
         Cache {
             network,
-            coins: coins.coins,
-            rescan_progress: None,
-            sync_progress: 1.0, // Remote backend is always synced
             datadir_path: liana_dir.clone(),
-            blockheight: wallet.tip_height.unwrap_or(0),
             // We ignore last poll fields for remote backend.
-            last_poll_timestamp: None,
             last_poll_at_startup: None,
+            daemon_cache: DaemonCache {
+                coins: coins.coins,
+                rescan_progress: None,
+                sync_progress: 1.0, // Remote backend is always synced
+                blockheight: wallet.tip_height.unwrap_or(0),
+                // We ignore last poll fields for remote backend.
+                last_poll_timestamp: None,
+            },
         },
         Arc::new(
             Wallet::new(wallet.descriptor)

--- a/liana-gui/src/loader.rs
+++ b/liana-gui/src/loader.rs
@@ -23,6 +23,7 @@ use lianad::{
 };
 
 use crate::app;
+use crate::app::cache::DaemonCache;
 use crate::app::settings::WalletSettings;
 use crate::backup::Backup;
 use crate::dir::LianaDirectory;
@@ -434,16 +435,18 @@ pub async fn load_application(
 
     let coins = coins_to_cache(daemon.clone()).await.map(|res| res.coins)?;
 
+    // Both last poll fields start with the same value.
     let cache = Cache {
         datadir_path,
         network: info.network,
-        blockheight: info.block_height,
-        coins,
-        sync_progress: info.sync,
-        // Both last poll fields start with the same value.
-        last_poll_timestamp: info.last_poll_timestamp,
         last_poll_at_startup: info.last_poll_timestamp,
-        ..Default::default()
+        daemon_cache: DaemonCache {
+            blockheight: info.block_height,
+            coins,
+            sync_progress: info.sync,
+            last_poll_timestamp: info.last_poll_timestamp,
+            ..Default::default()
+        },
     };
 
     Ok((Arc::new(wallet), cache, daemon, internal_bitcoind, backup))


### PR DESCRIPTION
This PR is a preparatory step towards #1798.

If we want to cache values from different sources and update frequencies, e.g. when adding fiat prices, I think it will be convenient to group and update them independently of each other.

This PR adds a `DaemonCache` struct within `Cache` for storing and updating dynamic daemon values only.

The `UpdateDaemonCache` message replaces `UpdateCache` to update these daemon cache values only.

The new `CacheUpdated` message will be called when any fields within the cache have been updated, e.g. daemon values, fiat price values, etc.

