### PR TITLE
refactor: add trait for formatting amount as string

### DIFF
--- a/liana-gui/src/app/view/spend/mod.rs
+++ b/liana-gui/src/app/view/spend/mod.rs
@@ -438,7 +438,7 @@ pub fn recipient_view<'a>(
                     .push_maybe(if is_max_selected {
                         let amount_txt = Amount::from_str_in(&amount.value, Denomination::Bitcoin)
                             .ok()
-                            .map(amount_as_string)
+                            .map(|a| a.to_formatted_string())
                             .unwrap_or(amount.value.clone());
                         Some(
                             Container::new(

--- a/liana-ui/src/component/amount.rs
+++ b/liana-ui/src/component/amount.rs
@@ -3,6 +3,16 @@ use iced::Color;
 
 use crate::{color, component::text::*, widget::*};
 
+pub trait DisplayAmount {
+    fn to_formatted_string(&self) -> String;
+}
+
+impl DisplayAmount for Amount {
+    fn to_formatted_string(&self) -> String {
+        format_f64_as_string(self.to_btc(), " ", 8, true)
+    }
+}
+
 /// Amount with default size and colors.
 pub fn amount<'a, T: 'a>(a: &Amount) -> Row<'a, T> {
     amount_with_size(a, P1_SIZE)
@@ -27,31 +37,48 @@ pub fn amount_with_size_and_colors<'a, T: 'a>(
     color_before: Color,
     color_after: Option<Color>,
 ) -> Row<'a, T> {
-    render_amount(amount_as_string(*a), size, color_before, color_after)
+    render_amount(a.to_formatted_string(), size, color_before, color_after)
 }
 
 pub fn unconfirmed_amount_with_size<'a, T: 'a>(a: &Amount, size: u16) -> Row<'a, T> {
-    render_unconfirmed_amount(amount_as_string(*a), size)
+    render_unconfirmed_amount(a.to_formatted_string(), size)
 }
 
 //
 // Helpers
 //
 
-// Format a BTC amount as a string for display.
-pub fn amount_as_string(a: Amount) -> String {
-    let amount = a.to_btc().to_string();
+/// Formats an f64 as a string with a custom separator and number of decimals,
+/// padding the decimal part with zeros if needed.
+/// If `sep_decimals` is true, the separator is also applied to the decimal part,
+/// grouping from the right.
+pub fn format_f64_as_string(
+    value: f64,
+    sep: &str,
+    num_decimals: usize,
+    sep_decimals: bool,
+) -> String {
+    // Format with the requested number of decimals.
+    let amount = format!("{:.*}", num_decimals, value);
 
-    // Reformat the integer portion of the amount with space separation.
+    // Split into integer and fractional parts.
     let (integer, fraction) = match amount.split_once('.') {
         Some((i, f)) => (i, f),
-        None => (amount.as_str(), "00000000"),
+        None => (amount.as_str(), ""), // num_decimals must be 0
     };
 
-    let integer = format_amount_number_part(integer);
-    let fraction = format_amount_number_part(&format!("{:0<8}", fraction));
+    let integer = format_amount_number_part(integer, sep);
 
-    format!("{integer}.{fraction}")
+    if num_decimals > 0 {
+        let fraction = if sep_decimals {
+            format_amount_number_part(fraction, sep)
+        } else {
+            fraction.to_string()
+        };
+        format!("{integer}.{fraction}")
+    } else {
+        integer
+    }
 }
 
 // Format a "part" of a number string with spaces to fit display requirements.
@@ -61,7 +88,7 @@ pub fn amount_as_string(a: Amount) -> String {
 // Ex:
 //   1000 => 1 000
 //   100000 => 100 000
-fn format_amount_number_part(s: &str) -> String {
+fn format_amount_number_part(s: &str, sep: &str) -> String {
     let mut part = s
         .chars()
         .collect::<Vec<_>>()
@@ -70,7 +97,7 @@ fn format_amount_number_part(s: &str) -> String {
         .collect::<Vec<_>>();
     part.reverse();
 
-    part.join(" ")
+    part.join(sep)
 }
 
 // Helper functions split a string at the first occurence of a non-zero integer (where
@@ -136,19 +163,93 @@ mod tests {
     fn test_amount_as_str() {
         assert_eq!(
             "0.00 799 800",
-            amount_as_string(bitcoin::Amount::from_btc(0.00799800).unwrap())
+            bitcoin::Amount::from_btc(0.00799800)
+                .unwrap()
+                .to_formatted_string()
         );
         assert_eq!(
             "1 000.00 799 800",
-            amount_as_string(bitcoin::Amount::from_btc(1000.00799800).unwrap())
+            bitcoin::Amount::from_btc(1000.00799800)
+                .unwrap()
+                .to_formatted_string()
         );
         assert_eq!(
             "1 000.00 000 000",
-            amount_as_string(bitcoin::Amount::from_btc(1000.0).unwrap())
+            bitcoin::Amount::from_btc(1000.0)
+                .unwrap()
+                .to_formatted_string()
         );
         assert_eq!(
             "0.00 012 340",
-            amount_as_string(bitcoin::Amount::from_btc(0.00012340).unwrap())
+            bitcoin::Amount::from_btc(0.00012340)
+                .unwrap()
+                .to_formatted_string()
         )
+    }
+
+    #[test]
+    fn test_format_f64_as_string() {
+        assert_eq!(
+            format_f64_as_string(1234567.12345678, " ", 8, false),
+            "1 234 567.12345678"
+        );
+        assert_eq!(
+            format_f64_as_string(1234567.12345678, " ", 8, true),
+            "1 234 567.12 345 678"
+        );
+
+        assert_eq!(
+            format_f64_as_string(1234567.12345678, ",", 2, false),
+            "1,234,567.12"
+        );
+        assert_eq!(
+            format_f64_as_string(1234567.12345678, ",", 2, true),
+            "1,234,567.12"
+        );
+
+        assert_eq!(
+            format_f64_as_string(1234567.12345678, ",", 4, false),
+            "1,234,567.1235"
+        );
+        assert_eq!(
+            format_f64_as_string(1234567.12345678, ",", 4, true),
+            "1,234,567.1,235"
+        );
+
+        assert_eq!(format_f64_as_string(0.000132, " ", 8, false), "0.00013200");
+        assert_eq!(format_f64_as_string(0.000132, " ", 8, true), "0.00 013 200");
+
+        assert_eq!(format_f64_as_string(0.0, " ", 8, false), "0.00000000");
+        assert_eq!(format_f64_as_string(0.0, " ", 8, true), "0.00 000 000");
+
+        assert_eq!(
+            format_f64_as_string(1000.00799800, " ", 8, false),
+            "1 000.00799800"
+        );
+        assert_eq!(
+            format_f64_as_string(1000.00799800, " ", 8, true),
+            "1 000.00 799 800"
+        );
+
+        assert_eq!(
+            format_f64_as_string(1000.0, " ", 8, false),
+            "1 000.00000000"
+        );
+        assert_eq!(
+            format_f64_as_string(1000.0, " ", 8, true),
+            "1 000.00 000 000"
+        );
+
+        assert_eq!(format_f64_as_string(1234567.0, " ", 0, false), "1 234 567");
+        assert_eq!(format_f64_as_string(1234567.0, " ", 0, true), "1 234 567");
+
+        assert_eq!(format_f64_as_string(1234567.0, ",", 0, false), "1,234,567");
+        assert_eq!(format_f64_as_string(1234567.0, ",", 0, true), "1,234,567");
+
+        assert_eq!(format_f64_as_string(0.0, " ", 0, false), "0");
+        assert_eq!(format_f64_as_string(0.0, " ", 0, true), "0");
+
+        assert_eq!(format_f64_as_string(0.0, ",", 0, false), "0");
+        assert_eq!(format_f64_as_string(0.0, ",", 0, true), "0");
     }
 }


### PR DESCRIPTION
This is a preparatory PR towards #1798.

It adds a `DisplayAmount` trait for formatting a number as a string and implements this for a bitcoin `Amount` using a general `format_f64_as_string` function. 

The trait and function will be useful for displaying fiat amounts with different formatting options than those used for BTC. I felt adding a trait would be useful for defining shared UI components for both BTC and fiat amounts if required.