### PR TITLE
feat: Show fiat price on Home page

### DIFF
--- a/liana-gui/src/app/cache.rs
+++ b/liana-gui/src/app/cache.rs
@@ -4,10 +4,17 @@ use crate::{
         Daemon, DaemonError,
     },
     dir::LianaDirectory,
+    services::fiat::{
+        api::{GetPriceResult, PriceApi, PriceApiError},
+        client::PriceClient,
+        Currency, PriceSource,
+    },
 };
 use liana::miniscript::bitcoin::Network;
 use lianad::commands::CoinStatus;
 use std::sync::Arc;
+
+pub const FIAT_PRICE_UPDATE_INTERVAL_SECS: u64 = 300;
 
 #[derive(Debug, Clone)]
 pub struct Cache {
@@ -16,6 +23,7 @@ pub struct Cache {
     /// The `last_poll_timestamp` when starting the application.
     pub last_poll_at_startup: Option<u32>,
     pub daemon_cache: DaemonCache,
+    pub fiat_price: Option<FiatPrice>,
 }
 
 /// only used for tests.
@@ -26,6 +34,7 @@ impl std::default::Default for Cache {
             network: Network::Bitcoin,
             last_poll_at_startup: None,
             daemon_cache: DaemonCache::default(),
+            fiat_price: None,
         }
     }
 }
@@ -83,4 +92,23 @@ pub async fn coins_to_cache(
     daemon
         .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
         .await
+}
+
+/// Represents a fiat price fetched from the API.
+#[derive(Debug, Clone)]
+pub struct FiatPrice {
+    pub res: Result<GetPriceResult, PriceApiError>, // also store error in case we want to display it to user
+    pub currency: Currency,
+    pub source: PriceSource,
+    pub requested_at: u64,
+}
+
+pub async fn get_fiat_price(source: PriceSource, currency: Currency) -> FiatPrice {
+    let client = PriceClient::default_from_source(source);
+    FiatPrice {
+        res: client.get_price(currency).await,
+        currency,
+        source: client.source,
+        requested_at: crate::utils::now().as_secs(),
+    }
 }

--- a/liana-gui/src/app/error.rs
+++ b/liana-gui/src/app/error.rs
@@ -8,6 +8,7 @@ use crate::{
     app::{settings::SettingsError, wallet::WalletError},
     daemon::DaemonError,
     export::{self, RestoreBackupError},
+    services::fiat::api::PriceApiError,
 };
 
 #[derive(Debug)]
@@ -21,6 +22,7 @@ pub enum Error {
     Spend(SpendCreationError),
     ImportExport(export::Error),
     RestoreBackup(RestoreBackupError),
+    FiatPrice(PriceApiError),
 }
 
 impl std::fmt::Display for Error {
@@ -63,6 +65,7 @@ impl std::fmt::Display for Error {
             Self::Desc(e) => write!(f, "Liana descriptor error: {}", e),
             Self::ImportExport(e) => write!(f, "{e}"),
             Self::RestoreBackup(e) => write!(f, "{e}"),
+            Self::FiatPrice(e) => write!(f, "Fiat price error: {}", e),
         }
     }
 }

--- a/liana-gui/src/app/message.rs
+++ b/liana-gui/src/app/message.rs
@@ -9,10 +9,16 @@ use liana::miniscript::bitcoin::{
 use lianad::config::Config as DaemonConfig;
 
 use crate::{
-    app::{cache::DaemonCache, error::Error, view, wallet::Wallet},
+    app::{
+        cache::{DaemonCache, FiatPrice},
+        error::Error,
+        view,
+        wallet::Wallet,
+    },
     daemon::model::*,
     export::ImportExportMessage,
     hw::HardwareWalletMessage,
+    services::fiat::{api::ListCurrenciesResult, PriceSource},
 };
 
 #[derive(Debug)]
@@ -20,6 +26,7 @@ pub enum Message {
     Tick,
     UpdateDaemonCache(Result<DaemonCache, Error>),
     CacheUpdated,
+    Fiat(FiatMessage),
     UpdatePanelCache(/* is current panel */ bool),
     View(view::Message),
     LoadDaemonConfig(Box<DaemonConfig>),
@@ -62,4 +69,18 @@ impl From<ImportExportMessage> for Message {
     fn from(value: ImportExportMessage) -> Self {
         Message::View(view::Message::ImportExport(value))
     }
+}
+
+#[derive(Debug)]
+pub enum FiatMessage {
+    GetPrice,
+    GetPriceResult(FiatPrice),
+    ListCurrencies(PriceSource),
+    ListCurrenciesResult(
+        PriceSource,
+        /* timestamp */ u64,
+        Result<ListCurrenciesResult, Error>,
+    ),
+    SaveChanges,
+    ValidateCurrencySetting,
 }

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -38,6 +38,7 @@ use crate::{
         cache::{Cache, DaemonCache},
         error::Error,
         menu::Menu,
+        message::FiatMessage,
         settings::WalletId,
         wallet::Wallet,
     },
@@ -175,7 +176,18 @@ impl App {
             config.clone(),
             restored_from_backup,
         );
-        let cmd = panels.home.reload(daemon.clone(), wallet.clone());
+        let mut cmds = vec![];
+        cmds.push(panels.home.reload(daemon.clone(), wallet.clone()));
+        // If the fiat price setting is enabled, fetch the fiat price when app starts.
+        if wallet
+            .fiat_price_setting
+            .as_ref()
+            .is_some_and(|sett| sett.is_enabled)
+        {
+            cmds.push(Task::perform(async move {}, |_| {
+                Message::Fiat(FiatMessage::GetPrice)
+            }));
+        }
         (
             Self {
                 panels,
@@ -184,7 +196,7 @@ impl App {
                 wallet,
                 internal_bitcoind,
             },
-            cmd,
+            Task::batch(cmds),
         )
     }
 
@@ -277,7 +289,7 @@ impl App {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        Subscription::batch(vec![
+        let mut subs = vec![
             time::every(Duration::from_secs(
                 match sync_status(
                     self.daemon.backend(),
@@ -308,7 +320,29 @@ impl App {
             ))
             .map(|_| Message::Tick),
             self.panels.current().subscription(),
-        ])
+        ];
+        // Add fiat price subscription if enabled.
+        if let Some(sett) = self
+            .wallet
+            .fiat_price_setting
+            .as_ref()
+            .filter(|sett| sett.is_enabled)
+        {
+            // Force a new subscription to be created if the source or currency changes. This way, the first tick
+            // will occur `FIAT_PRICE_UPDATE_INTERVAL_SECS` seconds after the initial cache entry for this pair.
+            if self
+                .cache
+                .fiat_price
+                .as_ref()
+                .is_some_and(|price| price.source == sett.source && price.currency == sett.currency)
+            {
+                subs.push(
+                    time::every(Duration::from_secs(cache::FIAT_PRICE_UPDATE_INTERVAL_SECS))
+                        .map(|_| Message::Fiat(FiatMessage::GetPrice)),
+                )
+            }
+        }
+        Subscription::batch(subs)
     }
 
     pub fn stop(&mut self) {
@@ -349,6 +383,42 @@ impl App {
                     },
                     Message::UpdateDaemonCache,
                 )
+            }
+            Message::Fiat(FiatMessage::GetPrice) => {
+                if let Some(price_setting) = self
+                    .wallet
+                    .fiat_price_setting
+                    .as_ref()
+                    .filter(|sett| sett.is_enabled)
+                    .cloned()
+                {
+                    tracing::debug!(
+                        "Getting fiat price in {} from {}",
+                        price_setting.currency,
+                        price_setting.source,
+                    );
+                    return Task::perform(
+                        async move {
+                            cache::get_fiat_price(price_setting.source, price_setting.currency)
+                                .await
+                        },
+                        |fiat_price| Message::Fiat(FiatMessage::GetPriceResult(fiat_price)),
+                    );
+                }
+                Task::none()
+            }
+            Message::Fiat(FiatMessage::GetPriceResult(fiat_price)) => {
+                if let Err(e) = fiat_price.res.as_ref() {
+                    tracing::error!(
+                        "Failed to get fiat price in {} from {}: {}",
+                        fiat_price.currency,
+                        fiat_price.source,
+                        e
+                    );
+                }
+                // We update the cache with the result even if there was an error.
+                self.cache.fiat_price = Some(fiat_price);
+                Task::perform(async {}, |_| Message::CacheUpdated)
             }
             Message::UpdateDaemonCache(res) => {
                 match res {

--- a/liana-gui/src/app/settings/fiat.rs
+++ b/liana-gui/src/app/settings/fiat.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+use crate::services::fiat::{Currency, PriceSource};
+use crate::utils::serde::{deser_fromstr, serialize_display};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct PriceSetting {
+    #[serde(
+        deserialize_with = "deser_fromstr",
+        serialize_with = "serialize_display"
+    )]
+    pub source: PriceSource,
+    #[serde(
+        deserialize_with = "deser_fromstr",
+        serialize_with = "serialize_display"
+    )]
+    pub currency: Currency,
+    pub is_enabled: bool,
+}

--- a/liana-gui/src/app/settings/mod.rs
+++ b/liana-gui/src/app/settings/mod.rs
@@ -1,5 +1,7 @@
 //! Settings is the module to handle the GUI settings file.
 //! The settings file is used by the GUI to store useful information.
+pub mod fiat;
+
 use std::collections::HashMap;
 
 use async_fd_lock::LockWrite;
@@ -18,6 +20,7 @@ use crate::{
     dir::NetworkDirectory,
     hw::HardwareWalletConfig,
     services::{self, connect::client::backend},
+    utils::serde::ok_or_none,
 };
 
 pub const SETTINGS_FILE_NAME: &str = "settings.json";
@@ -147,6 +150,10 @@ pub struct WalletSettings {
     /// Start internal bitcoind executable.
     /// if None, the app must refer to the gui.toml start_internal_bitcoind field.
     pub start_internal_bitcoind: Option<bool>,
+    // If the settings file contains a currency or source that is no longer supported, the price
+    // setting will be set to None during deserialization and the user will need to reconfigure it.
+    #[serde(default, deserialize_with = "ok_or_none")]
+    pub fiat_price: Option<fiat::PriceSetting>,
 }
 
 impl WalletSettings {

--- a/liana-gui/src/app/state/mod.rs
+++ b/liana-gui/src/app/state/mod.rs
@@ -27,6 +27,7 @@ use super::{
 
 pub const HISTORY_EVENT_PAGE_SIZE: u64 = 20;
 
+use crate::app::cache::FiatPrice;
 use crate::daemon::model::{coin_is_owned, LabelsLoader};
 use crate::daemon::{
     model::{remaining_sequence, Coin, HistoryTransaction, Payment},
@@ -69,6 +70,23 @@ pub fn redirect(menu: Menu) -> Task<Message> {
     Task::perform(async { menu }, |menu| {
         Message::View(view::Message::Menu(menu))
     })
+}
+
+/// Returns fiat price if the wallet setting is enabled and the cached price matches the setting.
+pub fn fiat_price_for_wallet(wallet: &Wallet, cache: &Cache) -> Option<FiatPrice> {
+    let mut fiat_price = None;
+    if let Some(sett) = wallet
+        .fiat_price_setting
+        .as_ref()
+        .filter(|sett| sett.is_enabled)
+    {
+        if let Some(price) = cache.fiat_price.as_ref() {
+            if price.source == sett.source && price.currency == sett.currency {
+                fiat_price = Some(price.clone());
+            }
+        }
+    }
+    fiat_price
 }
 
 /// Returns the confirmed and unconfirmed balances from `coins`, as well
@@ -170,6 +188,7 @@ impl Home {
 
 impl State for Home {
     fn view<'a>(&'a self, cache: &'a Cache) -> Element<'a, view::Message> {
+        let fiat_price = fiat_price_for_wallet(&self.wallet, cache);
         if let Some((tx, output_index)) = &self.selected_event {
             view::home::payment_view(
                 cache,
@@ -187,6 +206,7 @@ impl State for Home {
                     &self.balance,
                     &self.unconfirmed_balance,
                     &self.remaining_sequence,
+                    fiat_price,
                     &self.expiring_coins,
                     &self.events,
                     self.is_last_page,

--- a/liana-gui/src/app/state/settings/general.rs
+++ b/liana-gui/src/app/state/settings/general.rs
@@ -1,0 +1,292 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use iced::Task;
+use liana::miniscript::bitcoin::Network;
+use liana_ui::widget::Element;
+
+use crate::app::cache::Cache;
+use crate::app::error::Error;
+use crate::app::message::{FiatMessage, Message};
+use crate::app::settings::fiat::PriceSetting;
+use crate::app::settings::update_settings_file;
+use crate::app::state::State;
+use crate::app::view;
+use crate::app::wallet::Wallet;
+use crate::daemon::Daemon;
+use crate::dir::LianaDirectory;
+use crate::services::fiat::api::PriceApi;
+use crate::services::fiat::client::PriceClient;
+use crate::services::fiat::currency::Currency;
+use crate::services::fiat::source::PriceSource;
+use crate::utils::now;
+
+/// Time to live of the list of available currencies for a given `PriceSource`.
+const CURRENCIES_LIST_TTL_SECS: u64 = 3_600; // 1 hour
+
+async fn update_price_setting(
+    data_dir: LianaDirectory,
+    network: Network,
+    wallet: Arc<Wallet>,
+    new_price_setting: PriceSetting,
+) -> Result<Arc<Wallet>, Error> {
+    let mut wallet = wallet.as_ref().clone();
+    wallet = wallet.with_fiat_price_setting(Some(new_price_setting.clone()));
+    let network_dir = data_dir.network_directory(network);
+    let wallet_id = wallet.id();
+    update_settings_file(&network_dir, |mut settings| {
+        if let Some(wallet_setting) = settings
+            .wallets
+            .iter_mut()
+            .find(|w| w.wallet_id() == wallet_id)
+        {
+            wallet_setting.fiat_price = Some(new_price_setting);
+        }
+        settings
+    })
+    .await?;
+    Ok(Arc::new(wallet))
+}
+
+// Returns the wallet's fiat `PriceSetting` or the default value if not set. We only
+// expect it to be `None` if `Wallet::or_default_fiat_price_setting` left it so.
+fn wallet_price_setting_or_default(wallet: &Wallet) -> PriceSetting {
+    wallet
+        .fiat_price_setting
+        .as_ref()
+        .cloned()
+        .unwrap_or_default()
+}
+
+pub struct GeneralSettingsState {
+    wallet: Arc<Wallet>,
+    new_price_setting: PriceSetting,
+    currencies_list: HashMap<PriceSource, (/* timestamp */ u64, Vec<Currency>)>,
+    error: Option<Error>,
+}
+
+impl From<GeneralSettingsState> for Box<dyn State> {
+    fn from(s: GeneralSettingsState) -> Box<dyn State> {
+        Box::new(s)
+    }
+}
+
+impl GeneralSettingsState {
+    pub fn new(wallet: Arc<Wallet>) -> Self {
+        let new_price_setting = wallet_price_setting_or_default(&wallet);
+        Self {
+            wallet,
+            new_price_setting,
+            currencies_list: HashMap::new(),
+            error: None,
+        }
+    }
+}
+
+impl State for GeneralSettingsState {
+    fn view<'a>(&'a self, cache: &'a Cache) -> Element<'a, view::Message> {
+        view::settings::general::general_section(
+            cache,
+            &self.new_price_setting,
+            self.currencies_list
+                .get(&self.new_price_setting.source)
+                .map(|(_, list)| &list[..])
+                .unwrap_or(&[]),
+            self.error.as_ref(),
+        )
+    }
+    fn reload(
+        &mut self,
+        _daemon: Arc<dyn Daemon + Sync + Send>,
+        wallet: Arc<Wallet>,
+    ) -> iced::Task<Message> {
+        self.new_price_setting = wallet_price_setting_or_default(&wallet);
+        self.wallet = wallet;
+        if self.new_price_setting.is_enabled {
+            let source = self.new_price_setting.source;
+            return Task::perform(async move { source }, |source| {
+                Message::Fiat(FiatMessage::ListCurrencies(source))
+            });
+        } else if self.wallet.fiat_price_setting.is_none() {
+            // If the wallet does not have a fiat price setting, save the default disabled setting
+            // to indicate that the user has seen the setting option (and a notification is no longer required).
+            tracing::info!(
+                "Fiat price setting is missing for wallet '{}'. Saving default setting.",
+                self.wallet.id()
+            );
+            return Task::perform(async move {}, |_| Message::Fiat(FiatMessage::SaveChanges));
+        }
+        Task::none()
+    }
+
+    fn update(
+        &mut self,
+        _daemon: Arc<dyn Daemon + Sync + Send>,
+        cache: &Cache,
+        message: Message,
+    ) -> Task<Message> {
+        match message {
+            Message::WalletUpdated(res) => {
+                match res {
+                    Ok(wallet) => {
+                        self.error = None;
+                        // Get the fiat price if the setting is enabled and has changed.
+                        // This check should be done before updating self.wallet.
+                        let get_price = self.new_price_setting.is_enabled
+                            && Some(&self.new_price_setting)
+                                != self.wallet.fiat_price_setting.as_ref();
+                        self.new_price_setting = wallet_price_setting_or_default(&wallet); // no change expected since wallet was updated with new price setting
+                        self.wallet = wallet;
+                        if get_price {
+                            return Task::perform(async move {}, |_| {
+                                Message::Fiat(FiatMessage::GetPrice)
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        self.error = Some(e);
+                    }
+                }
+                Task::none()
+            }
+            Message::Fiat(FiatMessage::SaveChanges) => {
+                if self.error.is_none()
+                    && Some(&self.new_price_setting) != self.wallet.fiat_price_setting.as_ref()
+                {
+                    tracing::info!(
+                        "Saving fiat price setting for wallet '{}': {:?}",
+                        self.wallet.id(),
+                        self.new_price_setting
+                    );
+                    let wallet = self.wallet.clone();
+                    let price_setting = self.new_price_setting.clone();
+                    let network = cache.network;
+                    let datadir_path = cache.datadir_path.clone();
+                    return Task::perform(
+                        async move {
+                            update_price_setting(datadir_path, network, wallet, price_setting).await
+                        },
+                        Message::WalletUpdated,
+                    );
+                }
+                Task::none()
+            }
+            Message::Fiat(FiatMessage::ValidateCurrencySetting) => {
+                if let Some((_, list)) = self.currencies_list.get(&self.new_price_setting.source) {
+                    self.error = None;
+                    // If the currently selected currency is not in the list of available currencies,
+                    // set it to the default currency if eligible or otherwise the first available currency.
+                    if !list.contains(&self.new_price_setting.currency) {
+                        if list.contains(&Currency::default()) {
+                            self.new_price_setting.currency = Currency::default();
+                        } else if let Some(curr) = list.first() {
+                            self.new_price_setting.currency = *curr;
+                        } else {
+                            self.error = Some(Error::Unexpected(
+                                "No available currencies in the list.".to_string(),
+                            ));
+                            return Task::none();
+                        }
+                    }
+                    return Task::perform(async move {}, |_| {
+                        Message::Fiat(FiatMessage::SaveChanges)
+                    });
+                }
+                Task::none()
+            }
+            Message::Fiat(FiatMessage::ListCurrenciesResult(source, requested_at, res)) => {
+                match res {
+                    Ok(list) => {
+                        self.error = None;
+                        // Update the currencies list only if the requested_at is newer than the existing one.
+                        if !self
+                            .currencies_list
+                            .get(&source)
+                            .is_some_and(|(old, _)| *old > requested_at)
+                        {
+                            tracing::debug!(
+                                "Updating currencies list for source '{}' as requested at {}.",
+                                source,
+                                requested_at,
+                            );
+                            self.currencies_list
+                                .insert(source, (requested_at, list.currencies));
+                        }
+                        return Task::perform(async move {}, |_| {
+                            Message::Fiat(FiatMessage::ValidateCurrencySetting)
+                        });
+                    }
+                    Err(e) => {
+                        self.error = Some(e);
+                    }
+                }
+                Task::none()
+            }
+            Message::Fiat(FiatMessage::ListCurrencies(source)) => {
+                if self.new_price_setting.is_enabled {
+                    // Update the currencies list if the cached list is stale.
+                    let now = now().as_secs();
+                    match self.currencies_list.get(&source) {
+                        Some((old, _)) if now.saturating_sub(*old) <= CURRENCIES_LIST_TTL_SECS => {
+                            return Task::perform(async move {}, |_| {
+                                Message::Fiat(FiatMessage::ValidateCurrencySetting)
+                            });
+                        }
+                        _ => {
+                            return Task::perform(
+                                async move {
+                                    let client = PriceClient::default_from_source(source);
+                                    (
+                                        source,
+                                        now,
+                                        client.list_currencies().await.map_err(Error::FiatPrice),
+                                    )
+                                },
+                                |(source, now, res)| {
+                                    Message::Fiat(FiatMessage::ListCurrenciesResult(
+                                        source, now, res,
+                                    ))
+                                },
+                            );
+                        }
+                    }
+                }
+                Task::none()
+            }
+            Message::View(view::Message::Settings(view::SettingsMessage::Fiat(msg))) => {
+                match msg {
+                    view::FiatMessage::Enable(is_enabled) => {
+                        self.new_price_setting.is_enabled = is_enabled;
+                        if self.new_price_setting.is_enabled {
+                            let source = self.new_price_setting.source;
+                            return Task::perform(async move { source }, |source| {
+                                Message::Fiat(FiatMessage::ListCurrencies(source))
+                            });
+                        } else {
+                            return Task::perform(async move {}, |_| {
+                                Message::Fiat(FiatMessage::SaveChanges)
+                            });
+                        }
+                    }
+                    view::FiatMessage::SourceEdited(source) => {
+                        self.new_price_setting.source = source;
+                        if self.new_price_setting.is_enabled {
+                            let source = self.new_price_setting.source;
+                            return Task::perform(async move { source }, |source| {
+                                Message::Fiat(FiatMessage::ListCurrencies(source))
+                            });
+                        }
+                    }
+                    view::FiatMessage::CurrencyEdited(currency) => {
+                        self.new_price_setting.currency = currency;
+                        return Task::perform(async move {}, |_| {
+                            Message::Fiat(FiatMessage::ValidateCurrencySetting)
+                        });
+                    }
+                }
+                Task::none()
+            }
+            _ => Task::none(),
+        }
+    }
+}

--- a/liana-gui/src/app/state/settings/mod.rs
+++ b/liana-gui/src/app/state/settings/mod.rs
@@ -1,4 +1,5 @@
 mod bitcoind;
+mod general;
 mod wallet;
 
 use std::convert::From;
@@ -64,6 +65,16 @@ impl State for SettingsState {
         message: Message,
     ) -> Task<Message> {
         match &message {
+            Message::View(view::Message::Settings(view::SettingsMessage::GeneralSection)) => {
+                // TODO: It would be nice to keep the previous state, if any, in order not to have to fetch
+                // the currencies list again.
+                self.setting = Some(general::GeneralSettingsState::new(self.wallet.clone()).into());
+                let wallet = self.wallet.clone();
+                self.setting
+                    .as_mut()
+                    .map(|s| s.reload(daemon, wallet))
+                    .unwrap_or_else(Task::none)
+            }
             Message::View(view::Message::Settings(view::SettingsMessage::EditBitcoindSettings)) => {
                 self.setting = Some(
                     BitcoindSettingsState::new(

--- a/liana-gui/src/app/view/fiat.rs
+++ b/liana-gui/src/app/view/fiat.rs
@@ -1,0 +1,52 @@
+use std::convert::TryFrom;
+
+use liana::miniscript::bitcoin::Amount;
+use liana_ui::component::amount::{format_f64_as_string, DisplayAmount};
+
+use crate::app::cache;
+use crate::services::fiat::Currency;
+
+/// A fiat amount with a specific currency.
+pub struct FiatAmount {
+    pub amount: f64,
+    pub currency: Currency,
+}
+
+impl FiatAmount {
+    pub fn new(amount: f64, currency: Currency) -> Self {
+        FiatAmount { amount, currency }
+    }
+}
+
+// Format a fiat amount as a string with two decimal places and a comma as the thousands separator.
+impl DisplayAmount for FiatAmount {
+    fn to_formatted_string(&self) -> String {
+        format_f64_as_string(self.amount, ",", 2, false)
+    }
+}
+
+/// Used to convert a bitcoin `Amount` to fiat.
+pub struct FiatAmountConverter {
+    pub price_per_btc: f64,
+    pub currency: Currency,
+}
+
+impl FiatAmountConverter {
+    pub fn convert(&self, btc_amount: Amount) -> FiatAmount {
+        let fiat_amt = btc_amount.to_btc() * self.price_per_btc;
+        FiatAmount::new(fiat_amt, self.currency)
+    }
+}
+
+impl TryFrom<cache::FiatPrice> for FiatAmountConverter {
+    type Error = String;
+
+    fn try_from(fiat_price: cache::FiatPrice) -> Result<Self, Self::Error> {
+        let cache::FiatPrice { res, currency, .. } = fiat_price;
+        res.map(|price| FiatAmountConverter {
+            price_per_btc: price.value,
+            currency,
+        })
+        .map_err(|e| e.to_string())
+    }
+}

--- a/liana-gui/src/app/view/message.rs
+++ b/liana-gui/src/app/view/message.rs
@@ -1,4 +1,9 @@
-use crate::{app::menu::Menu, export::ImportExportMessage, node::bitcoind::RpcAuthType};
+use crate::{
+    app::menu::Menu,
+    export::ImportExportMessage,
+    node::bitcoind::RpcAuthType,
+    services::fiat::{Currency, PriceSource},
+};
 use liana::miniscript::bitcoin::{bip32::Fingerprint, Address, OutPoint};
 
 pub trait Close {
@@ -102,6 +107,8 @@ pub enum SettingsMessage {
     FingerprintAliasEdited(Fingerprint, String),
     WalletAliasEdited(String),
     Save,
+    GeneralSection,
+    Fiat(FiatMessage),
 }
 
 #[derive(Debug, Clone)]
@@ -127,4 +134,11 @@ pub enum CreateRbfMessage {
     FeerateEdited(String),
     Cancel,
     Confirm,
+}
+
+#[derive(Debug, Clone)]
+pub enum FiatMessage {
+    Enable(bool),
+    SourceEdited(PriceSource),
+    CurrencyEdited(Currency),
 }

--- a/liana-gui/src/app/view/mod.rs
+++ b/liana-gui/src/app/view/mod.rs
@@ -1,3 +1,4 @@
+mod fiat;
 mod label;
 mod message;
 mod warning;

--- a/liana-gui/src/app/view/settings/general.rs
+++ b/liana-gui/src/app/view/settings/general.rs
@@ -1,0 +1,122 @@
+use iced::widget::{pick_list, Column, Row, Space, Toggler};
+use iced::{Alignment, Length};
+
+use super::header;
+
+use liana_ui::component::card;
+use liana_ui::component::text::*;
+use liana_ui::theme;
+use liana_ui::widget::*;
+
+use crate::app::cache;
+use crate::app::error::Error;
+use crate::app::menu::Menu;
+use crate::app::settings::fiat::PriceSetting;
+use crate::app::view::dashboard;
+use crate::app::view::message::*;
+use crate::app::view::settings::SettingsMessage;
+use crate::services::fiat::{Currency, ALL_PRICE_SOURCES};
+
+pub fn general_section<'a>(
+    cache: &'a cache::Cache,
+    new_price_setting: &'a PriceSetting,
+    currencies_list: &'a [Currency],
+    warning: Option<&Error>,
+) -> Element<'a, Message> {
+    let header = header("General", SettingsMessage::GeneralSection);
+
+    dashboard(
+        &Menu::Settings,
+        cache,
+        warning,
+        Column::new()
+            .spacing(20)
+            .push(header)
+            .push(fiat_price(new_price_setting, currencies_list)),
+    )
+}
+
+pub fn fiat_price<'a>(
+    new_price_setting: &'a PriceSetting,
+    currencies_list: &'a [Currency],
+) -> Element<'a, Message> {
+    card::simple(
+        Column::new()
+            .spacing(20)
+            .push(
+                Row::new()
+                    .spacing(10)
+                    .align_y(Alignment::Center)
+                    .push(text("Fiat price:").bold())
+                    .push(Space::with_width(Length::Fill))
+                    .push(
+                        Toggler::new(new_price_setting.is_enabled)
+                            .on_toggle(|new_selection| {
+                                Message::Settings(SettingsMessage::Fiat(FiatMessage::Enable(
+                                    new_selection,
+                                )))
+                            })
+                            .style(theme::toggler::primary),
+                    ),
+            )
+            .push_maybe(
+                new_price_setting.is_enabled.then_some(
+                    Row::new()
+                        .spacing(20)
+                        .align_y(Alignment::Center)
+                        .push(text("Exchange rate source:").bold())
+                        .push(Space::with_width(Length::Fill))
+                        .push(
+                            pick_list(
+                                &ALL_PRICE_SOURCES[..],
+                                Some(new_price_setting.source),
+                                |source| {
+                                    Message::Settings(SettingsMessage::Fiat(
+                                        FiatMessage::SourceEdited(source),
+                                    ))
+                                },
+                            )
+                            .style(theme::pick_list::primary)
+                            .padding(10),
+                        ),
+                ),
+            )
+            .push_maybe(
+                new_price_setting.is_enabled.then_some(
+                    Row::new()
+                        .spacing(20)
+                        .align_y(Alignment::Center)
+                        .push(text("Currency:").bold())
+                        .push(Space::with_width(Length::Fill))
+                        .push(
+                            pick_list(
+                                currencies_list,
+                                Some(new_price_setting.currency),
+                                |currency| {
+                                    Message::Settings(SettingsMessage::Fiat(
+                                        FiatMessage::CurrencyEdited(currency),
+                                    ))
+                                },
+                            )
+                            .style(theme::pick_list::primary)
+                            .padding(10),
+                        ),
+                ),
+            )
+            .push_maybe(
+                new_price_setting
+                    .source
+                    .attribution()
+                    .filter(|_| new_price_setting.is_enabled)
+                    .map(|s| {
+                        Row::new()
+                            .spacing(20)
+                            .align_y(Alignment::Center)
+                            .push(Space::with_width(Length::Fill))
+                            .push(text(s))
+                    }),
+            ),
+    )
+    .width(Length::Fill)
+    .into()
+}

--- a/liana-gui/src/app/view/settings/mod.rs
+++ b/liana-gui/src/app/view/settings/mod.rs
@@ -1,3 +1,5 @@
+pub mod general;
+
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
@@ -116,6 +118,13 @@ pub fn list(cache: &Cache, is_remote_backend: bool) -> Element<Message> {
         .style(theme::button::transparent)
         .on_press(Message::Menu(Menu::Settings));
 
+    let general = settings_section(
+        "General",
+        None,
+        icon::wrench_icon(),
+        Message::Settings(SettingsMessage::GeneralSection),
+    );
+
     let node = settings_section(
         "Node",
         None,
@@ -159,6 +168,7 @@ pub fn list(cache: &Cache, is_remote_backend: bool) -> Element<Message> {
             .spacing(20)
             .width(Length::Fill)
             .push(header)
+            .push(general)
             .push(if !is_remote_backend { node } else { backend })
             .push(wallet)
             .push(import_export)

--- a/liana-gui/src/app/view/warning.rs
+++ b/liana-gui/src/app/view/warning.rs
@@ -51,6 +51,7 @@ impl From<&Error> for WarningMessage {
             Error::Spend(e) => WarningMessage(format!("Spend creation error: '{}'.", e)),
             Error::ImportExport(e) => WarningMessage(format!("{e}")),
             Error::RestoreBackup(e) => WarningMessage(format!("Failed to restore backup: {e}")),
+            Error::FiatPrice(e) => WarningMessage(format!("Fiat price error: {}", e)),
         }
     }
 }

--- a/liana-gui/src/daemon/mod.rs
+++ b/liana-gui/src/daemon/mod.rs
@@ -86,6 +86,10 @@ impl DaemonBackend {
         )
     }
 
+    pub fn is_remote(&self) -> bool {
+        matches!(self, DaemonBackend::RemoteBackend)
+    }
+
     pub fn node_type(&self) -> Option<node::NodeType> {
         if let DaemonBackend::EmbeddedLianad(node_type) = self {
             *node_type

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -362,6 +362,7 @@ pub fn create_app_with_remote_backend(
                 // We ignore last poll fields for remote backend.
                 last_poll_timestamp: None,
             },
+            fiat_price: None,
         },
         Arc::new(
             Wallet::new(wallet.descriptor)
@@ -371,6 +372,8 @@ pub fn create_app_with_remote_backend(
                 .with_key_aliases(aliases)
                 .with_provider_keys(provider_keys)
                 .with_hardware_wallets(hws)
+                .with_fiat_price_setting(wallet_settings.fiat_price)
+                .or_default_fiat_price_setting(network, true)
                 .load_hotsigners(&liana_dir, network)
                 .expect("Datadir should be conform"),
         ),

--- a/liana-gui/src/installer/mod.rs
+++ b/liana-gui/src/installer/mod.rs
@@ -425,6 +425,7 @@ pub async fn install_local_wallet(
         hardware_wallets,
         remote_backend_auth: None,
         start_internal_bitcoind: Some(ctx.internal_bitcoind.is_some()),
+        fiat_price: None,
     };
 
     let cfg: lianad::config::Config = extract_daemon_config(&ctx, &wallet_settings)?;
@@ -644,6 +645,7 @@ pub async fn create_remote_wallet(
             remote_backend.wallet_id(),
         )),
         start_internal_bitcoind: None,
+        fiat_price: None,
     };
     update_settings_file(&network_datadir, |mut settings| {
         settings.wallets.push(wallet_settings.clone());
@@ -723,6 +725,7 @@ pub async fn import_remote_wallet(
             backend.wallet_id(),
         )),
         start_internal_bitcoind: None,
+        fiat_price: None,
     };
     update_settings_file(&network_datadir, |mut settings| {
         settings.wallets.push(wallet_settings.clone());

--- a/liana-gui/src/loader.rs
+++ b/liana-gui/src/loader.rs
@@ -431,6 +431,7 @@ pub async fn load_application(
 > {
     let wallet = Wallet::new(info.descriptors.main)
         .load_from_settings(wallet_settings)?
+        .or_default_fiat_price_setting(network, daemon.backend().is_remote())
         .load_hotsigners(&datadir_path, network)?;
 
     let coins = coins_to_cache(daemon.clone()).await.map(|res| res.coins)?;
@@ -447,6 +448,7 @@ pub async fn load_application(
             last_poll_timestamp: info.last_poll_timestamp,
             ..Default::default()
         },
+        fiat_price: None,
     };
 
     Ok((Arc::new(wallet), cache, daemon, internal_bitcoind, backup))

--- a/liana-gui/src/services/fiat/api.rs
+++ b/liana-gui/src/services/fiat/api.rs
@@ -1,0 +1,42 @@
+use super::currency::Currency;
+
+use async_trait::async_trait;
+
+use crate::services::http::NotSuccessResponseInfo;
+
+#[derive(Debug, Clone)]
+pub struct GetPriceResult {
+    pub value: f64,
+    pub updated_at: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ListCurrenciesResult {
+    pub currencies: Vec<Currency>,
+}
+
+#[derive(Debug, Clone)]
+pub enum PriceApiError {
+    RequestFailed(String),
+    NotSuccessResponse(NotSuccessResponseInfo),
+    CannotParseResponse(String),
+    CannotParseData(String),
+}
+
+impl std::fmt::Display for PriceApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RequestFailed(e) => write!(f, "Request failed: {}", e),
+            Self::NotSuccessResponse(info) => write!(f, "Not success response: {:?}", info),
+            Self::CannotParseResponse(e) => write!(f, "Cannot parse response: {}", e),
+            Self::CannotParseData(e) => write!(f, "Cannot parse data: {}", e),
+        }
+    }
+}
+
+#[async_trait]
+pub trait PriceApi {
+    async fn get_price(&self, currency: Currency) -> Result<GetPriceResult, PriceApiError>;
+
+    async fn list_currencies(&self) -> Result<ListCurrenciesResult, PriceApiError>;
+}

--- a/liana-gui/src/services/fiat/client.rs
+++ b/liana-gui/src/services/fiat/client.rs
@@ -1,0 +1,57 @@
+use super::api::{GetPriceResult, ListCurrenciesResult, PriceApi, PriceApiError};
+use super::currency::Currency;
+use super::source::PriceSource;
+
+use async_trait::async_trait;
+
+use crate::services::http::ResponseExt;
+
+pub struct PriceClient<C> {
+    inner: C,
+    pub source: PriceSource,
+}
+
+impl<C> PriceClient<C> {
+    pub fn new(inner: C, source: PriceSource) -> Self {
+        Self { inner, source }
+    }
+}
+
+impl<C: Default> PriceClient<C> {
+    pub fn default_from_source(source: PriceSource) -> Self {
+        Self::new(C::default(), source)
+    }
+}
+
+#[async_trait]
+impl PriceApi for PriceClient<reqwest::Client> {
+    async fn get_price(&self, currency: Currency) -> Result<GetPriceResult, PriceApiError> {
+        let url = self.source.get_price_url(currency);
+        let data = get_data(&self.inner, &url).await?;
+        self.source.parse_price_data(currency, &data)
+    }
+
+    async fn list_currencies(&self) -> Result<ListCurrenciesResult, PriceApiError> {
+        let url = self.source.list_currencies_url();
+        let data = get_data(&self.inner, &url).await?;
+        self.source.parse_currencies_data(&data)
+    }
+}
+
+// Sends a GET request to the specified URL and returns the parsed JSON response.
+// If the request fails or the response is not successful, it returns an error.
+async fn get_data(client: &reqwest::Client, url: &str) -> Result<serde_json::Value, PriceApiError> {
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| PriceApiError::RequestFailed(e.to_string()))?
+        .check_success()
+        .await
+        .map_err(PriceApiError::NotSuccessResponse)?;
+    let data: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| PriceApiError::CannotParseResponse(e.to_string()))?;
+    Ok(data)
+}

--- a/liana-gui/src/services/fiat/currency.rs
+++ b/liana-gui/src/services/fiat/currency.rs
@@ -1,0 +1,90 @@
+macro_rules! currency_enum {
+    ($name:ident { $($variant:ident),* $(,)? }) => {
+        #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]
+        pub enum $name {
+            #[default]
+            $($variant,)*
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    $(Self::$variant => write!(f, stringify!($variant)),)*
+                }
+            }
+        }
+
+        impl std::str::FromStr for $name {
+            type Err = String;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s.to_uppercase().as_str() {
+                    $(stringify!($variant) => Ok(Self::$variant),)*
+                    _ => Err("Invalid currency".to_string()),
+                }
+            }
+        }
+    };
+}
+
+currency_enum!(Currency {
+    USD, // macro sets first variant as the default
+    AED,
+    AMD,
+    ARS,
+    AUD,
+    BAM,
+    BDT,
+    BHD,
+    BMD,
+    BRL,
+    CAD,
+    CHF,
+    CLP,
+    CNY,
+    COP,
+    CRC,
+    CZK,
+    DKK,
+    DOP,
+    EUR,
+    GBP,
+    GEL,
+    GTQ,
+    HKD,
+    HNL,
+    HUF,
+    IDR,
+    ILS,
+    INR,
+    JPY,
+    KES,
+    KRW,
+    KWD,
+    LKR,
+    LBP,
+    MMK,
+    MXN,
+    MYR,
+    NGN,
+    NOK,
+    NZD,
+    PEN,
+    PHP,
+    PKR,
+    PLN,
+    RON,
+    RUB,
+    SAR,
+    SEK,
+    SGD,
+    SVC,
+    THB,
+    TRY,
+    TWD,
+    UAH,
+    VEF,
+    VND,
+    ZAR,
+    ZMW,
+});

--- a/liana-gui/src/services/fiat/mod.rs
+++ b/liana-gui/src/services/fiat/mod.rs
@@ -1,0 +1,8 @@
+pub mod api;
+pub mod client;
+pub mod currency;
+pub mod source;
+
+pub use client::PriceClient;
+pub use currency::Currency;
+pub use source::{PriceSource, ALL_PRICE_SOURCES};

--- a/liana-gui/src/services/fiat/source.rs
+++ b/liana-gui/src/services/fiat/source.rs
@@ -1,0 +1,119 @@
+use std::str::FromStr;
+
+use super::api::{GetPriceResult, ListCurrenciesResult, PriceApiError};
+use super::currency::Currency;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum PriceSource {
+    #[default]
+    CoinGecko,
+    MempoolSpace,
+}
+
+/// All variants of `PriceSource`.
+pub const ALL_PRICE_SOURCES: [PriceSource; 2] = [PriceSource::MempoolSpace, PriceSource::CoinGecko];
+
+impl std::fmt::Display for PriceSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CoinGecko => write!(f, "coingecko"),
+            Self::MempoolSpace => write!(f, "mempool.space"),
+        }
+    }
+}
+
+impl FromStr for PriceSource {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "coingecko" => Ok(Self::CoinGecko),
+            "mempool.space" => Ok(Self::MempoolSpace),
+            _ => Err("Invalid price source".to_string()),
+        }
+    }
+}
+
+impl PriceSource {
+    /// Required attribution for the price source, if any.
+    pub fn attribution(&self) -> Option<String> {
+        match self {
+            // See https://www.coingecko.com/en/api_terms
+            Self::CoinGecko => Some("Powered by CoinGecko"),
+            Self::MempoolSpace => None,
+        }
+        .map(|s| s.to_string())
+    }
+
+    /// Returns the URL to fetch the price for a given currency.
+    pub fn get_price_url(&self, _currency: Currency) -> String {
+        match self {
+            Self::CoinGecko => "https://api.coingecko.com/api/v3/exchange_rates".to_string(),
+            Self::MempoolSpace => "https://mempool.space/api/v1/prices".to_string(),
+        }
+    }
+
+    /// Returns the URL to fetch the list of supported currencies.
+    pub fn list_currencies_url(&self) -> String {
+        match self {
+            Self::CoinGecko => "https://api.coingecko.com/api/v3/exchange_rates".to_string(),
+            Self::MempoolSpace => "https://mempool.space/api/v1/prices".to_string(),
+        }
+    }
+
+    /// Parses the price data in the API response from the `get_price_url` endpoint.
+    pub fn parse_price_data(
+        &self,
+        currency: Currency,
+        data: &serde_json::Value,
+    ) -> Result<GetPriceResult, PriceApiError> {
+        let (value, updated_at) = match self {
+            Self::CoinGecko => {
+                let value = data
+                    .get("rates")
+                    .and_then(|rates| rates.get(currency.to_string().to_lowercase()))
+                    .and_then(|curr| curr.get("value"))
+                    .and_then(|num| num.as_f64())
+                    .ok_or(PriceApiError::CannotParseData("price".to_string()))?;
+                (value, None)
+            }
+            Self::MempoolSpace => {
+                let value = data
+                    .get(currency.to_string())
+                    .and_then(|curr| curr.as_u64())
+                    .map(|v| v as f64)
+                    .ok_or(PriceApiError::CannotParseData("price".to_string()))?;
+                let updated_at = data.get("time").and_then(|t| t.as_u64());
+                (value, updated_at)
+            }
+        };
+        Ok(GetPriceResult { value, updated_at })
+    }
+
+    /// Parses the currencies data in the API response from the `list_currencies_url` endpoint.
+    pub fn parse_currencies_data(
+        &self,
+        data: &serde_json::Value,
+    ) -> Result<ListCurrenciesResult, PriceApiError> {
+        let currencies: Vec<_> = match self {
+            Self::CoinGecko => data
+                .get("rates")
+                .and_then(|rates| rates.as_object())
+                .ok_or(PriceApiError::CannotParseData(
+                    "data is not object".to_string(),
+                ))?
+                .keys()
+                .filter_map(|v| v.parse::<Currency>().ok())
+                .collect(),
+            Self::MempoolSpace => data
+                .as_object()
+                .ok_or(PriceApiError::CannotParseData(
+                    "data is not object".to_string(),
+                ))?
+                .keys()
+                .filter_map(|s| s.parse::<Currency>().ok())
+                .collect(),
+        };
+        Ok(ListCurrenciesResult { currencies })
+    }
+}

--- a/liana-gui/src/services/mod.rs
+++ b/liana-gui/src/services/mod.rs
@@ -1,3 +1,4 @@
 pub mod connect;
+pub mod fiat;
 pub mod http;
 pub mod keys;

--- a/liana-gui/src/utils/serde.rs
+++ b/liana-gui/src/utils/serde.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
-use serde::{de, Deserialize, Deserializer};
+use serde::{de, Deserialize, Deserializer, Serializer};
 
 pub fn deser_fromstr<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
@@ -11,4 +11,24 @@ where
 {
     let string = String::deserialize(deserializer)?;
     T::from_str(&string).map_err(de::Error::custom)
+}
+
+/// Serialize a value that implements `Display` trait as a string.
+pub fn serialize_display<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: Display,
+    S: Serializer,
+{
+    serializer.collect_str(value)
+}
+
+// Taken from https://github.com/serde-rs/json/issues/447#issuecomment-389673971.
+/// Returns `None` if deserialization fails.
+pub fn ok_or_none<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    let v = serde_json::Value::deserialize(deserializer)?;
+    Ok(T::deserialize(v).ok())
 }

--- a/liana-ui/src/icon.rs
+++ b/liana-ui/src/icon.rs
@@ -131,6 +131,10 @@ pub fn restore_icon() -> Text<'static> {
     bootstrap_icon('\u{F358}')
 }
 
+pub fn wrench_icon() -> Text<'static> {
+    bootstrap_icon('\u{F621}')
+}
+
 pub fn link_icon() -> Text<'static> {
     bootstrap_icon('\u{F470}')
 }

--- a/liana-ui/src/theme/mod.rs
+++ b/liana-ui/src/theme/mod.rs
@@ -20,6 +20,7 @@ pub mod slider;
 pub mod svg;
 pub mod text;
 pub mod text_input;
+pub mod toggler;
 
 #[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub struct Theme {

--- a/liana-ui/src/theme/palette.rs
+++ b/liana-ui/src/theme/palette.rs
@@ -17,6 +17,7 @@ pub struct Palette {
     pub progress_bars: ProgressBars,
     pub rule: iced::Color,
     pub pane_grid: PaneGrid,
+    pub togglers: Togglers,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -171,6 +172,20 @@ pub struct PaneGrid {
     pub highlight_background: iced::Color,
     pub picked_split: iced::Color,
     pub hovered_split: iced::Color,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Togglers {
+    pub on: Toggler,
+    pub off: Toggler,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Toggler {
+    pub background: iced::Color,
+    pub background_border: iced::Color,
+    pub foreground: iced::Color,
+    pub foreground_border: iced::Color,
 }
 
 impl std::default::Default for Palette {
@@ -567,6 +582,20 @@ impl std::default::Default for Palette {
                 highlight_background: color::TRANSPARENT_GREEN,
                 picked_split: color::GREEN,
                 hovered_split: color::GREEN,
+            },
+            togglers: Togglers {
+                on: Toggler {
+                    background: color::GREEN,
+                    background_border: color::GREEN,
+                    foreground: color::WHITE,
+                    foreground_border: color::WHITE,
+                },
+                off: Toggler {
+                    background: color::GREY_2,
+                    background_border: color::GREY_2,
+                    foreground: color::WHITE,
+                    foreground_border: color::WHITE,
+                },
             },
         }
     }

--- a/liana-ui/src/theme/toggler.rs
+++ b/liana-ui/src/theme/toggler.rs
@@ -1,0 +1,36 @@
+use iced::widget::toggler::{Catalog, Status, Style, StyleFn};
+
+use super::Theme;
+
+impl Catalog for Theme {
+    type Class<'a> = StyleFn<'a, Self>;
+
+    fn default<'a>() -> <Self as Catalog>::Class<'a> {
+        Box::new(primary)
+    }
+
+    fn style(&self, class: &<Self as Catalog>::Class<'_>, status: Status) -> Style {
+        class(self, status)
+    }
+}
+
+pub fn primary(theme: &Theme, status: Status) -> Style {
+    match status {
+        Status::Active { is_toggled: true } | Status::Hovered { is_toggled: true } => Style {
+            background: theme.colors.togglers.on.background,
+            background_border_width: 1.0,
+            background_border_color: theme.colors.togglers.on.background_border,
+            foreground: theme.colors.togglers.on.foreground,
+            foreground_border_width: 1.0,
+            foreground_border_color: theme.colors.togglers.on.foreground_border,
+        },
+        _ => Style {
+            background: theme.colors.togglers.off.background,
+            background_border_width: 1.0,
+            background_border_color: theme.colors.togglers.off.background_border,
+            foreground: theme.colors.togglers.off.foreground,
+            foreground_border_width: 1.0,
+            foreground_border_color: theme.colors.togglers.off.foreground_border,
+        },
+    }
+}

--- a/liana-ui/src/widget/mod.rs
+++ b/liana-ui/src/widget/mod.rs
@@ -13,6 +13,7 @@ pub type Row<'a, Message> = iced::widget::Row<'a, Message, Theme, Renderer>;
 pub type Button<'a, Message> = iced::widget::Button<'a, Message, Theme, Renderer>;
 pub type CheckBox<'a, Message> = iced::widget::Checkbox<'a, Message, Theme, Renderer>;
 pub type Text<'a> = iced::widget::Text<'a, Theme, Renderer>;
+pub type Toggler<'a, Message> = iced::widget::Toggler<'a, Message, Theme, Renderer>;
 pub type TextInput<'a, Message> = text_input::TextInput<'a, Message, Theme, Renderer>;
 pub type Tooltip<'a> = iced::widget::Tooltip<'a, Theme, Renderer>;
 pub type ProgressBar<'a> = iced::widget::ProgressBar<'a, Theme>;


### PR DESCRIPTION
This PR implements #1798 and #1800.

Once wallet syncing completes, the confirmed and unconfirmed balances on the Home page will also be displayed in a user-configurable fiat currency.

The fiat currency and source can be configured in a new General section of the Settings. Possible sources are CoinGecko and mempool.space. The available currencies depend on the chosen source. For a smoother UX, there is no "Save" button on this new settings page and changes will be written to the settings file upon each change.

Liana Connect wallets on mainnet will default to the fiat price being enabled for USD from CoinGecko, and disabled for other networks.

The fiat price will be disabled by default for wallets with a local backend. In a follow-up PR to tackle #1799, mainnet wallets with a local backend will show a notification to the user that the fiat setting is available (but will remain disabled unless the user explicitly enables it).