### PR TITLE
installer: switch order of key/devices in the key selection modal

### DIFF
--- a/liana-gui/src/installer/step/descriptor/editor/key.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/key.rs
@@ -900,8 +900,8 @@ impl SelectKeySource {
             .spacing(10)
             .push(header)
             .push_maybe(no_devices)
-            .push_maybe(keys)
             .push_maybe(devices)
+            .push_maybe(keys)
             .push(self.view_other_options())
             .align_x(Horizontal::Center)
             .width(modal::MODAL_WIDTH);


### PR DESCRIPTION
closes #1827

<img width="831" height="474" alt="image" src="https://github.com/user-attachments/assets/e2275c6b-dd48-450a-9fb5-cb34c7d92822" />
