### PR TITLE
settings: fix name of modal when exporting backup

### DIFF
--- a/liana-gui/src/app/state/export.rs
+++ b/liana-gui/src/app/state/export.rs
@@ -76,11 +76,11 @@ impl ExportModal {
             ImportExportType::ExportPsbt(_) => "Export PSBT",
             ImportExportType::ExportXpub(_) => "Export Xpub",
             ImportExportType::ImportXpub(_) => "Import Xpub",
-            ImportExportType::ExportBackup(_) => "Export Backup",
-            ImportExportType::Descriptor(_) => "Export Descriptor",
-            ImportExportType::ExportProcessBackup(..) | ImportExportType::ExportLabels => {
-                "Export Labels"
+            ImportExportType::ExportProcessBackup(..) | ImportExportType::ExportBackup(_) => {
+                "Export Backup"
             }
+            ImportExportType::Descriptor(_) => "Export Descriptor",
+            ImportExportType::ExportLabels => "Export Labels",
             ImportExportType::ImportPsbt(_) => "Import PSBT",
             ImportExportType::ImportDescriptor => "Import Descriptor",
             ImportExportType::ImportBackup { .. } => "Restore Backup",


### PR DESCRIPTION
<img width="719" height="718" alt="image" src="https://github.com/user-attachments/assets/fc7102fd-6760-4302-9c1a-a3065a1e91bd" />

fixes #1831