### PR TITLE
store fiat prices in new global cache

### DIFF
--- a/liana-gui/src/app/cache.rs
+++ b/liana-gui/src/app/cache.rs
@@ -23,7 +23,7 @@ pub struct Cache {
     /// The `last_poll_timestamp` when starting the application.
     pub last_poll_at_startup: Option<u32>,
     pub daemon_cache: DaemonCache,
-    pub fiat_price_cache: FiatPriceCache,
+    pub fiat_price: Option<FiatPrice>,
 }
 
 /// only used for tests.
@@ -34,7 +34,7 @@ impl std::default::Default for Cache {
             network: Network::Bitcoin,
             last_poll_at_startup: None,
             daemon_cache: DaemonCache::default(),
-            fiat_price_cache: FiatPriceCache::default(),
+            fiat_price: None,
         }
     }
 }
@@ -92,17 +92,6 @@ pub async fn coins_to_cache(
     daemon
         .list_coins(&[CoinStatus::Unconfirmed, CoinStatus::Confirmed], &[])
         .await
-}
-
-/// The cache for fiat price data.
-#[derive(Debug, Clone, Default)]
-pub struct FiatPriceCache {
-    /// The last fetched fiat price, if any.
-    pub fiat_price: Option<FiatPrice>,
-    /// A pending request, if any.
-    ///
-    /// This is the last request that may or may not yet have been completed.
-    pub last_request: Option<FiatPriceRequest>,
 }
 
 /// Represents a fiat price fetched from the API together with the request that was used to fetch it.

--- a/liana-gui/src/app/error.rs
+++ b/liana-gui/src/app/error.rs
@@ -105,3 +105,9 @@ impl From<SpendCreationError> for Error {
         Error::Spend(error)
     }
 }
+
+impl From<PriceApiError> for Error {
+    fn from(error: PriceApiError) -> Self {
+        Error::FiatPrice(error)
+    }
+}

--- a/liana-gui/src/app/message.rs
+++ b/liana-gui/src/app/message.rs
@@ -18,7 +18,10 @@ use crate::{
     daemon::model::*,
     export::ImportExportMessage,
     hw::HardwareWalletMessage,
-    services::fiat::{api::ListCurrenciesResult, PriceSource},
+    services::fiat::{
+        api::{ListCurrenciesResult, PriceApiError},
+        Currency, PriceSource,
+    },
 };
 
 #[derive(Debug)]
@@ -73,14 +76,21 @@ impl From<ImportExportMessage> for Message {
 
 #[derive(Debug)]
 pub enum FiatMessage {
-    GetPrice,
+    GetPriceTick,
+    GetPrice(PriceSource, Currency),
     GetPriceResult(FiatPrice),
     ListCurrencies(PriceSource),
     ListCurrenciesResult(
         PriceSource,
         /* timestamp */ u64,
-        Result<ListCurrenciesResult, Error>,
+        Result<ListCurrenciesResult, PriceApiError>,
     ),
     SaveChanges,
     ValidateCurrencySetting,
+}
+
+impl From<FiatMessage> for Message {
+    fn from(value: FiatMessage) -> Self {
+        Message::Fiat(value)
+    }
 }

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -45,7 +45,6 @@ use crate::{
     daemon::{embedded::EmbeddedDaemon, Daemon, DaemonBackend},
     dir::LianaDirectory,
     node::{bitcoind::Bitcoind, NodeType},
-    utils::now,
 };
 
 use self::state::SettingsState;
@@ -180,14 +179,17 @@ impl App {
         let mut cmds = vec![];
         cmds.push(panels.home.reload(daemon.clone(), wallet.clone()));
         // If the fiat price setting is enabled, fetch the fiat price when app starts.
-        if wallet
+        if let Some(sett) = wallet
             .fiat_price_setting
             .as_ref()
-            .is_some_and(|sett| sett.is_enabled)
+            .filter(|sett| sett.is_enabled)
         {
-            cmds.push(Task::perform(async move {}, |_| {
-                Message::Fiat(FiatMessage::GetPrice)
-            }));
+            let source = sett.source;
+            let currency = sett.currency;
+            cmds.push(Task::perform(
+                async move { (source, currency) },
+                |(source, currency)| Message::Fiat(FiatMessage::GetPrice(source, currency)),
+            ));
         }
         (
             Self {
@@ -212,6 +214,14 @@ impl App {
             }
         }
         "Liana wallet"
+    }
+
+    pub fn cache(&self) -> &Cache {
+        &self.cache
+    }
+
+    pub fn wallet(&self) -> &Wallet {
+        &self.wallet
     }
 
     fn set_current_panel(&mut self, menu: Menu) -> Task<Message> {
@@ -322,29 +332,19 @@ impl App {
             .map(|_| Message::Tick),
             self.panels.current().subscription(),
         ];
-        // Add fiat price subscription if enabled.
-        if let Some(sett) = self
-            .wallet
-            .fiat_price_setting
+        // Add fiat price subscription if the setting is enabled and matches what is already in the cache.
+        // This forces a new subscription to be created if the source or currency setting changes so that the first
+        // tick will occur `FIAT_PRICE_UPDATE_INTERVAL_SECS` seconds after the initial cache entry for this pair.
+        if self
+            .cache
+            .fiat_price
             .as_ref()
-            .filter(|sett| sett.is_enabled)
+            .is_some_and(|price| self.wallet.fiat_price_is_relevant(price))
         {
-            // Force a new subscription to be created if the source or currency changes. This way, the first tick
-            // will occur `FIAT_PRICE_UPDATE_INTERVAL_SECS` seconds after the initial cache entry for this pair.
-            if self
-                .cache
-                .fiat_price_cache
-                .fiat_price
-                .as_ref()
-                .is_some_and(|price| {
-                    price.source() == sett.source && price.currency() == sett.currency
-                })
-            {
-                subs.push(
-                    time::every(Duration::from_secs(FIAT_PRICE_UPDATE_INTERVAL_SECS))
-                        .map(|_| Message::Fiat(FiatMessage::GetPrice)),
-                )
-            }
+            subs.push(
+                time::every(Duration::from_secs(FIAT_PRICE_UPDATE_INTERVAL_SECS))
+                    .map(|_| Message::Fiat(FiatMessage::GetPriceTick)),
+            )
         }
         Subscription::batch(subs)
     }
@@ -388,77 +388,29 @@ impl App {
                     Message::UpdateDaemonCache,
                 )
             }
-            Message::Fiat(FiatMessage::GetPrice) => {
-                if let Some(price_setting) = self
+            Message::Fiat(FiatMessage::GetPriceTick) => {
+                if let Some(sett) = self
                     .wallet
                     .fiat_price_setting
                     .as_ref()
                     .filter(|sett| sett.is_enabled)
                 {
-                    let now = now().as_secs();
-                    // Do nothing if the last request was recent and was for the same source & currency, where
-                    // "recent" means within half the update interval.
-                    // Using half the update interval is sufficient as we are mostly concerned with preventing
-                    // multiple requests being sent within seconds of each other (e.g. after the GUI window is
-                    // inactive for an extended period). Using the full update interval could lead to a kind
-                    // of race condition and cause a regular subscription message to be missed.
-                    if let Some(recent_request) = self
-                        .cache
-                        .fiat_price_cache
-                        .last_request
-                        .as_ref()
-                        .filter(|req| {
-                            req.source == price_setting.source
-                                && req.currency == price_setting.currency
-                                && req.timestamp + FIAT_PRICE_UPDATE_INTERVAL_SECS / 2 > now
-                        })
-                    {
-                        // Cached request is still valid, no need to fetch a new one.
-                        tracing::debug!(
-                            "Using cached fiat price request for {} from {}",
-                            recent_request.currency,
-                            recent_request.source,
-                        );
-                        return Task::none();
-                    }
-                    let new_request = cache::FiatPriceRequest {
-                        source: price_setting.source,
-                        currency: price_setting.currency,
-                        timestamp: now,
-                    };
-                    self.cache.fiat_price_cache.last_request = Some(new_request.clone());
-                    tracing::debug!(
-                        "Getting fiat price in {} from {}",
-                        price_setting.currency,
-                        price_setting.source,
-                    );
-                    return Task::perform(
-                        async move { new_request.send_default().await },
-                        |fiat_price| Message::Fiat(FiatMessage::GetPriceResult(fiat_price)),
-                    );
+                    let source = sett.source;
+                    let currency = sett.currency;
+                    Task::perform(async move { (source, currency) }, |(source, currency)| {
+                        Message::Fiat(FiatMessage::GetPrice(source, currency))
+                    })
+                } else {
+                    Task::none()
                 }
-                Task::none()
             }
             Message::Fiat(FiatMessage::GetPriceResult(fiat_price)) => {
-                if Some(&fiat_price.request) != self.cache.fiat_price_cache.last_request.as_ref() {
-                    tracing::debug!(
-                        "Ignoring fiat price result for {} from {} as it is not the last request",
-                        fiat_price.currency(),
-                        fiat_price.source(),
-                    );
-                    return Task::none();
+                if self.wallet.fiat_price_is_relevant(&fiat_price) {
+                    self.cache.fiat_price = Some(fiat_price);
+                    Task::perform(async {}, |_| Message::CacheUpdated)
+                } else {
+                    Task::none()
                 }
-                if let Err(e) = fiat_price.res.as_ref() {
-                    tracing::error!(
-                        "Failed to get fiat price in {} from {}: {}",
-                        fiat_price.currency(),
-                        fiat_price.source(),
-                        e
-                    );
-                }
-                // Update the cache with the result even if there was an error.
-                self.cache.fiat_price_cache.fiat_price = Some(fiat_price);
-                Task::perform(async {}, |_| Message::CacheUpdated)
             }
             Message::UpdateDaemonCache(res) => {
                 match res {

--- a/liana-gui/src/app/state/mod.rs
+++ b/liana-gui/src/app/state/mod.rs
@@ -80,7 +80,7 @@ pub fn fiat_price_for_wallet(wallet: &Wallet, cache: &Cache) -> Option<FiatPrice
         .as_ref()
         .filter(|sett| sett.is_enabled)
     {
-        if let Some(price) = cache.fiat_price_cache.fiat_price.as_ref() {
+        if let Some(price) = cache.fiat_price.as_ref() {
             if price.source() == sett.source && price.currency() == sett.currency {
                 fiat_price = Some(price.clone());
             }

--- a/liana-gui/src/app/state/settings/general.rs
+++ b/liana-gui/src/app/state/settings/general.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use iced::Task;
@@ -15,14 +14,7 @@ use crate::app::view;
 use crate::app::wallet::Wallet;
 use crate::daemon::Daemon;
 use crate::dir::LianaDirectory;
-use crate::services::fiat::api::PriceApi;
-use crate::services::fiat::client::PriceClient;
 use crate::services::fiat::currency::Currency;
-use crate::services::fiat::source::PriceSource;
-use crate::utils::now;
-
-/// Time to live of the list of available currencies for a given `PriceSource`.
-const CURRENCIES_LIST_TTL_SECS: u64 = 3_600; // 1 hour
 
 async fn update_price_setting(
     data_dir: LianaDirectory,
@@ -61,7 +53,7 @@ fn wallet_price_setting_or_default(wallet: &Wallet) -> PriceSetting {
 pub struct GeneralSettingsState {
     wallet: Arc<Wallet>,
     new_price_setting: PriceSetting,
-    currencies_list: HashMap<PriceSource, (/* timestamp */ u64, Vec<Currency>)>,
+    currencies: Vec<Currency>,
     error: Option<Error>,
 }
 
@@ -77,7 +69,7 @@ impl GeneralSettingsState {
         Self {
             wallet,
             new_price_setting,
-            currencies_list: HashMap::new(),
+            currencies: Vec::new(),
             error: None,
         }
     }
@@ -88,10 +80,7 @@ impl State for GeneralSettingsState {
         view::settings::general::general_section(
             cache,
             &self.new_price_setting,
-            self.currencies_list
-                .get(&self.new_price_setting.source)
-                .map(|(_, list)| &list[..])
-                .unwrap_or(&[]),
+            &self.currencies,
             self.error.as_ref(),
         )
     }
@@ -138,9 +127,14 @@ impl State for GeneralSettingsState {
                         self.new_price_setting = wallet_price_setting_or_default(&wallet); // no change expected since wallet was updated with new price setting
                         self.wallet = wallet;
                         if get_price {
-                            return Task::perform(async move {}, |_| {
-                                Message::Fiat(FiatMessage::GetPrice)
-                            });
+                            let source = self.new_price_setting.source;
+                            let currency = self.new_price_setting.currency;
+                            return Task::perform(
+                                async move { (source, currency) },
+                                |(source, currency)| {
+                                    Message::Fiat(FiatMessage::GetPrice(source, currency))
+                                },
+                            );
                         }
                     }
                     Err(e) => {
@@ -172,83 +166,38 @@ impl State for GeneralSettingsState {
                 Task::none()
             }
             Message::Fiat(FiatMessage::ValidateCurrencySetting) => {
-                if let Some((_, list)) = self.currencies_list.get(&self.new_price_setting.source) {
-                    self.error = None;
-                    // If the currently selected currency is not in the list of available currencies,
-                    // set it to the default currency if eligible or otherwise the first available currency.
-                    if !list.contains(&self.new_price_setting.currency) {
-                        if list.contains(&Currency::default()) {
-                            self.new_price_setting.currency = Currency::default();
-                        } else if let Some(curr) = list.first() {
-                            self.new_price_setting.currency = *curr;
-                        } else {
-                            self.error = Some(Error::Unexpected(
-                                "No available currencies in the list.".to_string(),
-                            ));
-                            return Task::none();
-                        }
+                self.error = None;
+                // If the currently selected currency is not in the list of available currencies,
+                // set it to the default currency if eligible or otherwise the first available currency.
+                if !self.currencies.contains(&self.new_price_setting.currency) {
+                    if self.currencies.contains(&Currency::default()) {
+                        self.new_price_setting.currency = Currency::default();
+                    } else if let Some(curr) = self.currencies.first() {
+                        self.new_price_setting.currency = *curr;
+                    } else {
+                        self.error = Some(Error::Unexpected(
+                            "No available currencies in the list.".to_string(),
+                        ));
+                        return Task::none();
                     }
-                    return Task::perform(async move {}, |_| {
-                        Message::Fiat(FiatMessage::SaveChanges)
-                    });
                 }
-                Task::none()
+                Task::perform(async move {}, |_| Message::Fiat(FiatMessage::SaveChanges))
             }
-            Message::Fiat(FiatMessage::ListCurrenciesResult(source, requested_at, res)) => {
+            Message::Fiat(FiatMessage::ListCurrenciesResult(source, _, res)) => {
+                if self.new_price_setting.source != source {
+                    // Ignore results for a source that is no longer selected.
+                    return Task::none();
+                }
                 match res {
                     Ok(list) => {
                         self.error = None;
-                        // Update the currencies list only if the requested_at is newer than the existing one.
-                        if !self
-                            .currencies_list
-                            .get(&source)
-                            .is_some_and(|(old, _)| *old > requested_at)
-                        {
-                            tracing::debug!(
-                                "Updating currencies list for source '{}' as requested at {}.",
-                                source,
-                                requested_at,
-                            );
-                            self.currencies_list
-                                .insert(source, (requested_at, list.currencies));
-                        }
+                        self.currencies = list.currencies;
                         return Task::perform(async move {}, |_| {
                             Message::Fiat(FiatMessage::ValidateCurrencySetting)
                         });
                     }
                     Err(e) => {
-                        self.error = Some(e);
-                    }
-                }
-                Task::none()
-            }
-            Message::Fiat(FiatMessage::ListCurrencies(source)) => {
-                if self.new_price_setting.is_enabled {
-                    // Update the currencies list if the cached list is stale.
-                    let now = now().as_secs();
-                    match self.currencies_list.get(&source) {
-                        Some((old, _)) if now.saturating_sub(*old) <= CURRENCIES_LIST_TTL_SECS => {
-                            return Task::perform(async move {}, |_| {
-                                Message::Fiat(FiatMessage::ValidateCurrencySetting)
-                            });
-                        }
-                        _ => {
-                            return Task::perform(
-                                async move {
-                                    let client = PriceClient::default_from_source(source);
-                                    (
-                                        source,
-                                        now,
-                                        client.list_currencies().await.map_err(Error::FiatPrice),
-                                    )
-                                },
-                                |(source, now, res)| {
-                                    Message::Fiat(FiatMessage::ListCurrenciesResult(
-                                        source, now, res,
-                                    ))
-                                },
-                            );
-                        }
+                        self.error = Some(e.into());
                     }
                 }
                 Task::none()

--- a/liana-gui/src/app/state/settings/mod.rs
+++ b/liana-gui/src/app/state/settings/mod.rs
@@ -66,8 +66,6 @@ impl State for SettingsState {
     ) -> Task<Message> {
         match &message {
             Message::View(view::Message::Settings(view::SettingsMessage::GeneralSection)) => {
-                // TODO: It would be nice to keep the previous state, if any, in order not to have to fetch
-                // the currencies list again.
                 self.setting = Some(general::GeneralSettingsState::new(self.wallet.clone()).into());
                 let wallet = self.wallet.clone();
                 self.setting

--- a/liana-gui/src/app/wallet.rs
+++ b/liana-gui/src/app/wallet.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use crate::app::cache::FiatPrice;
 use crate::dir::LianaDirectory;
 use crate::services::fiat::{Currency, PriceSource};
 use crate::{
@@ -231,6 +232,16 @@ impl Wallet {
         });
 
         map
+    }
+
+    /// Whether the wallet's fiat price setting is enabled and matches
+    /// the given fiat price's source and currency.
+    pub fn fiat_price_is_relevant(&self, fiat_price: &FiatPrice) -> bool {
+        self.fiat_price_setting.as_ref().is_some_and(|sett| {
+            sett.is_enabled
+                && sett.source == fiat_price.source()
+                && sett.currency == fiat_price.currency()
+        })
     }
 }
 

--- a/liana-gui/src/gui/cache.rs
+++ b/liana-gui/src/gui/cache.rs
@@ -1,0 +1,127 @@
+use std::collections::HashMap;
+
+use crate::app::cache::{FiatPrice, FiatPriceRequest, FIAT_PRICE_UPDATE_INTERVAL_SECS};
+use crate::app::message::FiatMessage;
+use crate::services::fiat::{Currency, PriceSource};
+use crate::utils::now;
+
+/// Time to live of the list of available currencies for a given `PriceSource`.
+const CURRENCIES_LIST_TTL_SECS: u64 = 3_600; // 1 hour
+
+#[derive(Default)]
+pub struct FiatPricesCache {
+    /// Fiat price for a given source and currency.
+    prices: HashMap<(PriceSource, Currency), FiatPrice>,
+    /// Last request for a given source and currency, if any,
+    /// which may not have completed yet.
+    last_requests: HashMap<(PriceSource, Currency), FiatPriceRequest>,
+    /// Available currencies for each source, along with the timestamp of when they were fetched.
+    currencies: HashMap<PriceSource, (u64, Vec<Currency>)>,
+}
+
+/// A global cache for the application.
+#[derive(Default)]
+pub struct GlobalCache {
+    fiat_prices: FiatPricesCache,
+}
+
+impl GlobalCache {
+    /// Get a fiat price from the cache if it exists.
+    pub fn fiat_price(&self, source: PriceSource, currency: Currency) -> Option<&FiatPrice> {
+        self.fiat_prices.prices.get(&(source, currency))
+    }
+
+    /// Insert a fiat price into the cache.
+    pub fn insert_fiat_price(&mut self, fiat_price: FiatPrice) {
+        self.fiat_prices.prices.insert(
+            (fiat_price.source(), fiat_price.currency()),
+            fiat_price.clone(),
+        );
+    }
+
+    /// Get the last fiat price request from the cache if it exists.
+    pub fn last_fiat_price_request(
+        &self,
+        source: PriceSource,
+        currency: Currency,
+    ) -> Option<&FiatPriceRequest> {
+        self.fiat_prices.last_requests.get(&(source, currency))
+    }
+
+    /// Insert a fiat price request into the cache.
+    pub fn insert_fiat_price_request(&mut self, request: FiatPriceRequest) {
+        self.fiat_prices
+            .last_requests
+            .insert((request.source, request.currency), request);
+    }
+
+    /// Insert a list of available currencies for a given source into the cache.
+    pub fn insert_currencies(
+        &mut self,
+        source: PriceSource,
+        timestamp: u64,
+        currencies: Vec<Currency>,
+    ) {
+        self.fiat_prices
+            .currencies
+            .insert(source, (timestamp, currencies));
+    }
+
+    /// Process a fiat message and determine what action should be taken.
+    pub fn fiat_message_action(&self, fiat_msg: &FiatMessage) -> FiatMessageAction {
+        match fiat_msg {
+            FiatMessage::GetPrice(source, currency) => {
+                self.process_price_request(*source, *currency)
+            }
+            FiatMessage::ListCurrencies(source) => self.process_currencies_request(*source),
+            _ => FiatMessageAction::None,
+        }
+    }
+
+    /// Process a price request and determine if we can use cached data or need to fetch.
+    fn process_price_request(&self, source: PriceSource, currency: Currency) -> FiatMessageAction {
+        // Check if we have a valid cached price.
+        // We add a small buffer of 5 seconds to ensure we don't accidentally skip a regular update.
+        let now = now().as_secs();
+        if let Some(cached_price) = self
+            .fiat_price(source, currency)
+            .filter(|p| p.requested_at() + FIAT_PRICE_UPDATE_INTERVAL_SECS > now + 5)
+        {
+            return FiatMessageAction::UseCachedPrice(cached_price.clone());
+        }
+        FiatMessageAction::RequestPrice(source, currency)
+    }
+
+    /// Process a currencies list request and determine if we can use cached data or need to fetch.
+    fn process_currencies_request(&self, source: PriceSource) -> FiatMessageAction {
+        let now = now().as_secs();
+
+        // Check if we have valid cached currencies
+        if let Some((timestamp, currencies)) = self.fiat_prices.currencies.get(&source) {
+            if now.saturating_sub(*timestamp) <= CURRENCIES_LIST_TTL_SECS {
+                return FiatMessageAction::UseCachedCurrencies(
+                    source,
+                    *timestamp,
+                    currencies.clone(),
+                );
+            }
+        }
+        // Need to request currencies
+        FiatMessageAction::RequestCurrencies(source)
+    }
+}
+
+/// Represents a required action as determined by the cache.
+#[derive(Debug, Clone)]
+pub enum FiatMessageAction {
+    /// Fetch the price using the contained request.
+    RequestPrice(PriceSource, Currency),
+    /// Use the cached fiat price.
+    UseCachedPrice(FiatPrice),
+    /// Send a new request for currencies for the contained source.
+    RequestCurrencies(PriceSource),
+    /// Use the cached currencies list.
+    UseCachedCurrencies(PriceSource, u64, Vec<Currency>),
+    /// No specific action needed.
+    None,
+}

--- a/liana-gui/src/gui/pane.rs
+++ b/liana-gui/src/gui/pane.rs
@@ -2,7 +2,7 @@ use iced::{Length, Subscription, Task};
 use iced_aw::ContextMenu;
 use liana_ui::{component::text::*, icon::plus_icon, theme, widget::*};
 
-use crate::gui::Config;
+use crate::{app, gui::Config};
 
 use super::tab;
 
@@ -88,6 +88,19 @@ impl Pane {
         if self.focused_tab + focused_tab + 1 < self.tabs.len() {
             self.focused_tab += focused_tab + 1;
         }
+    }
+
+    /// Helper to update a tab with an app message.
+    pub fn update_tab_with_app_msg(
+        &mut self,
+        tab_id: usize,
+        app_msg: impl Into<app::Message>,
+        cfg: &Config,
+    ) -> Task<Message> {
+        self.update(
+            Message::Tab(tab_id, tab::Message::Run(Box::new(app_msg.into()))),
+            cfg,
+        )
     }
 
     pub fn update(&mut self, message: Message, cfg: &Config) -> Task<Message> {

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -12,7 +12,7 @@ use lianad::commands::ListCoinsResult;
 use crate::{
     app::{
         self,
-        cache::{Cache, DaemonCache, FiatPriceCache},
+        cache::{Cache, DaemonCache},
         settings::{update_settings_file, WalletSettings},
         wallet::Wallet,
         App,
@@ -67,6 +67,22 @@ pub struct Tab {
 impl Tab {
     pub fn new(id: usize, state: State) -> Self {
         Tab { id, state }
+    }
+
+    pub fn cache(&self) -> Option<&Cache> {
+        if let State::App(ref app) = self.state {
+            Some(app.cache())
+        } else {
+            None
+        }
+    }
+
+    pub fn wallet(&self) -> Option<&Wallet> {
+        if let State::App(ref app) = self.state {
+            Some(app.wallet())
+        } else {
+            None
+        }
     }
 
     pub fn title(&self) -> &str {
@@ -362,7 +378,7 @@ pub fn create_app_with_remote_backend(
                 // We ignore last poll fields for remote backend.
                 last_poll_timestamp: None,
             },
-            fiat_price_cache: FiatPriceCache::default(),
+            fiat_price: None,
         },
         Arc::new(
             Wallet::new(wallet.descriptor)

--- a/liana-gui/src/loader.rs
+++ b/liana-gui/src/loader.rs
@@ -23,7 +23,7 @@ use lianad::{
 };
 
 use crate::app;
-use crate::app::cache::{DaemonCache, FiatPriceCache};
+use crate::app::cache::DaemonCache;
 use crate::app::settings::WalletSettings;
 use crate::backup::Backup;
 use crate::dir::LianaDirectory;
@@ -448,7 +448,7 @@ pub async fn load_application(
             last_poll_timestamp: info.last_poll_timestamp,
             ..Default::default()
         },
-        fiat_price_cache: FiatPriceCache::default(),
+        fiat_price: None,
     };
 
     Ok((Arc::new(wallet), cache, daemon, internal_bitcoind, backup))


### PR DESCRIPTION
This PR addresses #1819 by adding a new global cache to store fiat prices.

This global cache will be used to avoid making multiple API requests for the same currency in case several tabs are open. It will also store the list of available currencies for a given price source to avoid multiple requests when accessing the settings page.

The fiat price settings and iced subscriptions are still handled by each individual wallet.

When a new price is fetched, it will be sent to all tabs that require it.