### PR TITLE
Add global tick subscription

### DIFF
--- a/liana-gui/src/app/cache.rs
+++ b/liana-gui/src/app/cache.rs
@@ -13,6 +13,7 @@ use crate::{
 use liana::miniscript::bitcoin::Network;
 use lianad::commands::CoinStatus;
 use std::sync::Arc;
+use std::time::Instant;
 
 pub const FIAT_PRICE_UPDATE_INTERVAL_SECS: u64 = 300;
 
@@ -70,6 +71,7 @@ pub struct DaemonCache {
     pub sync_progress: f64,
     /// The most recent `last_poll_timestamp`.
     pub last_poll_timestamp: Option<u32>,
+    pub last_tick: std::time::Instant,
 }
 
 /// only used for tests.
@@ -81,6 +83,7 @@ impl std::default::Default for DaemonCache {
             rescan_progress: None,
             sync_progress: 1.0,
             last_poll_timestamp: None,
+            last_tick: Instant::now(),
         }
     }
 }

--- a/liana-gui/src/app/message.rs
+++ b/liana-gui/src/app/message.rs
@@ -23,7 +23,6 @@ use crate::{
 
 #[derive(Debug)]
 pub enum Message {
-    Tick,
     UpdateDaemonCache(Result<DaemonCache, Error>),
     CacheUpdated,
     Fiat(FiatMessage),

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -14,7 +14,7 @@ use std::io::Write;
 use std::sync::Arc;
 use std::time::Duration;
 
-use iced::{clipboard, time, Subscription, Task};
+use iced::{clipboard, Subscription, Task};
 use tokio::runtime::Handle;
 use tracing::{error, info, warn};
 
@@ -290,38 +290,7 @@ impl App {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        let mut subs = vec![
-            time::every(Duration::from_secs(
-                match sync_status(
-                    self.daemon.backend(),
-                    self.cache.blockheight(),
-                    self.cache.sync_progress(),
-                    self.cache.last_poll_timestamp(),
-                    self.cache.last_poll_at_startup,
-                ) {
-                    SyncStatus::BlockchainSync(_) => 5, // Only applies to local backends
-                    SyncStatus::WalletFullScan
-                        if self.daemon.backend() == DaemonBackend::RemoteBackend =>
-                    {
-                        10
-                    } // If remote backend, don't ping too often
-                    SyncStatus::WalletFullScan | SyncStatus::LatestWalletSync => 3,
-                    SyncStatus::Synced => {
-                        if self.daemon.backend() == DaemonBackend::RemoteBackend {
-                            // Remote backend has no rescan feature. For a synced wallet,
-                            // cache refresh is only used to warn user about recovery availability.
-                            120
-                        } else {
-                            // For the rescan feature, we refresh more often in order
-                            // to give user an up-to-date view of the rescan progress.
-                            10
-                        }
-                    }
-                },
-            ))
-            .map(|_| Message::Tick),
-            self.panels.current().subscription(),
-        ];
+        let mut subs = vec![self.panels.current().subscription()];
         // Add fiat price subscription if enabled.
         if let Some(sett) = self
             .wallet
@@ -341,7 +310,7 @@ impl App {
                 })
             {
                 subs.push(
-                    time::every(Duration::from_secs(FIAT_PRICE_UPDATE_INTERVAL_SECS))
+                    iced::time::every(Duration::from_secs(FIAT_PRICE_UPDATE_INTERVAL_SECS))
                         .map(|_| Message::Fiat(FiatMessage::GetPrice)),
                 )
             }
@@ -363,31 +332,71 @@ impl App {
         }
     }
 
+    pub fn on_tick(&mut self, tick: std::time::Instant) -> Task<Message> {
+        let duration = Duration::from_secs(
+            match sync_status(
+                self.daemon.backend(),
+                self.cache.blockheight(),
+                self.cache.sync_progress(),
+                self.cache.last_poll_timestamp(),
+                self.cache.last_poll_at_startup,
+            ) {
+                SyncStatus::BlockchainSync(_) => 5, // Only applies to local backends
+                SyncStatus::WalletFullScan
+                    if self.daemon.backend() == DaemonBackend::RemoteBackend =>
+                {
+                    10
+                } // If remote backend, don't ping too often
+                SyncStatus::WalletFullScan | SyncStatus::LatestWalletSync => 3,
+                SyncStatus::Synced => {
+                    if self.daemon.backend() == DaemonBackend::RemoteBackend {
+                        // Remote backend has no rescan feature. For a synced wallet,
+                        // cache refresh is only used to warn user about recovery availability.
+                        120
+                    } else {
+                        // For the rescan feature, we refresh more often in order
+                        // to give user an up-to-date view of the rescan progress.
+                        10
+                    }
+                }
+            },
+        );
+
+        if self.cache.daemon_cache.last_tick + duration > tick {
+            return Task::none();
+        }
+        tracing::debug!("Updating daemon cache");
+
+        // We have to update here the last_tick to prevent that during a burst of events
+        // there is a race condition with the Task and too much tasks are triggered.
+        self.cache.daemon_cache.last_tick = tick;
+
+        let daemon = self.daemon.clone();
+        let datadir_path = self.cache.datadir_path.clone();
+        let network = self.cache.network;
+        Task::perform(
+            async move {
+                // we check every 10 second if the daemon poller is alive
+                // or if the access token is not expired.
+                daemon.is_alive(&datadir_path, network).await?;
+
+                let info = daemon.get_info().await?;
+                let coins = cache::coins_to_cache(daemon).await?;
+                Ok(DaemonCache {
+                    blockheight: info.block_height,
+                    coins: coins.coins,
+                    rescan_progress: info.rescan_progress,
+                    sync_progress: info.sync,
+                    last_poll_timestamp: info.last_poll_timestamp,
+                    last_tick: tick,
+                })
+            },
+            Message::UpdateDaemonCache,
+        )
+    }
+
     pub fn update(&mut self, message: Message) -> Task<Message> {
         match message {
-            Message::Tick => {
-                let daemon = self.daemon.clone();
-                let datadir_path = self.cache.datadir_path.clone();
-                let network = self.cache.network;
-                Task::perform(
-                    async move {
-                        // we check every 10 second if the daemon poller is alive
-                        // or if the access token is not expired.
-                        daemon.is_alive(&datadir_path, network).await?;
-
-                        let info = daemon.get_info().await?;
-                        let coins = cache::coins_to_cache(daemon).await?;
-                        Ok(DaemonCache {
-                            blockheight: info.block_height,
-                            coins: coins.coins,
-                            rescan_progress: info.rescan_progress,
-                            sync_progress: info.sync,
-                            last_poll_timestamp: info.last_poll_timestamp,
-                        })
-                    },
-                    Message::UpdateDaemonCache,
-                )
-            }
             Message::Fiat(FiatMessage::GetPrice) => {
                 if let Some(price_setting) = self
                     .wallet

--- a/liana-gui/src/gui/pane.rs
+++ b/liana-gui/src/gui/pane.rs
@@ -1,6 +1,7 @@
 use iced::{Length, Subscription, Task};
 use iced_aw::ContextMenu;
 use liana_ui::{component::text::*, icon::plus_icon, theme, widget::*};
+use std::time::Instant;
 
 use crate::gui::Config;
 
@@ -88,6 +89,13 @@ impl Pane {
         if self.focused_tab + focused_tab + 1 < self.tabs.len() {
             self.focused_tab += focused_tab + 1;
         }
+    }
+
+    pub fn on_tick(&mut self, i: Instant) -> Task<Message> {
+        Task::batch(self.tabs.iter_mut().map(|t| {
+            let id = t.id;
+            t.on_tick(i).map(move |msg| Message::Tab(id, msg))
+        }))
     }
 
     pub fn update(&mut self, message: Message, cfg: &Config) -> Task<Message> {

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use iced::{Subscription, Task};
 use tracing::{error, info};
@@ -76,6 +76,15 @@ impl Tab {
             State::Launcher(_) => "Launcher",
             State::Login(_) => "Login",
             State::App(a) => a.title(),
+        }
+    }
+
+    pub fn on_tick(&mut self, i: std::time::Instant) -> Task<Message> {
+        // currently the Tick is only used by the app
+        if let State::App(app) = &mut self.state {
+            app.on_tick(i).map(|msg| Message::Run(Box::new(msg)))
+        } else {
+            Task::none()
         }
     }
 
@@ -361,6 +370,7 @@ pub fn create_app_with_remote_backend(
                 blockheight: wallet.tip_height.unwrap_or(0),
                 // We ignore last poll fields for remote backend.
                 last_poll_timestamp: None,
+                last_tick: Instant::now(),
             },
             fiat_price_cache: FiatPriceCache::default(),
         },


### PR DESCRIPTION
In order to reduce back pressure with multiple pane open, only one subscription is providing a tick every 1 second. It is up to each state of each panel to handle this tick.

For example the app state will compare the tick instant to the last time it had updated the daemon cache to know if it has to update it again.