### PR TITLE
fix: use Instant::now() in on_tick method

### DIFF
--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -332,7 +332,8 @@ impl App {
         }
     }
 
-    pub fn on_tick(&mut self, tick: std::time::Instant) -> Task<Message> {
+    pub fn on_tick(&mut self) -> Task<Message> {
+        let tick = std::time::Instant::now();
         let duration = Duration::from_secs(
             match sync_status(
                 self.daemon.backend(),

--- a/liana-gui/src/gui/mod.rs
+++ b/liana-gui/src/gui/mod.rs
@@ -5,7 +5,7 @@ use iced::{
     Length, Size, Subscription, Task,
 };
 use iced_runtime::window;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tracing::{error, info};
 use tracing_subscriber::filter::LevelFilter;
 extern crate serde;
@@ -44,7 +44,7 @@ pub enum Key {
 #[derive(Debug)]
 pub enum Message {
     CtrlC,
-    Tick(Instant),
+    Tick,
     FontLoaded(Result<(), iced::font::Error>),
     Pane(pane_grid::Pane, pane::Message),
     KeyPressed(Key),
@@ -328,10 +328,10 @@ impl GUI {
                 }
                 Task::none()
             }
-            Message::Tick(i) => Task::batch(
+            Message::Tick => Task::batch(
                 self.panes
                     .iter_mut()
-                    .map(|(&id, p)| p.on_tick(i).map(move |msg| Message::Pane(id, msg))),
+                    .map(|(&id, p)| p.on_tick().map(move |msg| Message::Pane(id, msg))),
             ),
             _ => Task::none(),
         }
@@ -339,7 +339,7 @@ impl GUI {
 
     pub fn subscription(&self) -> Subscription<Message> {
         let mut vec = vec![
-            iced::time::every(Duration::from_secs(1)).map(Message::Tick),
+            iced::time::every(Duration::from_secs(1)).map(|_| Message::Tick),
             iced::event::listen_with(|event, status, _| match (&event, status) {
                 (
                     Event::Keyboard(keyboard::Event::KeyPressed {

--- a/liana-gui/src/gui/pane.rs
+++ b/liana-gui/src/gui/pane.rs
@@ -1,7 +1,6 @@
 use iced::{Length, Subscription, Task};
 use iced_aw::ContextMenu;
 use liana_ui::{component::text::*, icon::plus_icon, theme, widget::*};
-use std::time::Instant;
 
 use crate::gui::Config;
 
@@ -91,10 +90,10 @@ impl Pane {
         }
     }
 
-    pub fn on_tick(&mut self, i: Instant) -> Task<Message> {
+    pub fn on_tick(&mut self) -> Task<Message> {
         Task::batch(self.tabs.iter_mut().map(|t| {
             let id = t.id;
-            t.on_tick(i).map(move |msg| Message::Tab(id, msg))
+            t.on_tick().map(move |msg| Message::Tab(id, msg))
         }))
     }
 

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -79,10 +79,10 @@ impl Tab {
         }
     }
 
-    pub fn on_tick(&mut self, i: std::time::Instant) -> Task<Message> {
+    pub fn on_tick(&mut self) -> Task<Message> {
         // currently the Tick is only used by the app
         if let State::App(app) = &mut self.state {
-            app.on_tick(i).map(|msg| Message::Run(Box::new(msg)))
+            app.on_tick().map(|msg| Message::Run(Box::new(msg)))
         } else {
             Task::none()
         }


### PR DESCRIPTION
This is a follow-up to #1834.

The tick parameter could be for an `Instant` in the past, e.g. if the GUI window is inactive for a while.

In the case of `DaemonCache`, storing `last_tick` would therefore not prevent multiple updates from a burst of tick messages.

The `on_tick()` methods should rather use `Instant::now()` for performing their logic.