### PR TITLE
store fiat prices in new global cache

### DIFF
--- a/liana-gui/src/app/message.rs
+++ b/liana-gui/src/app/message.rs
@@ -82,3 +82,9 @@ pub enum FiatMessage {
     SaveChanges,
     ValidateCurrencySetting,
 }
+
+impl From<FiatMessage> for Message {
+    fn from(value: FiatMessage) -> Self {
+        Message::Fiat(value)
+    }
+}

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -391,7 +391,7 @@ impl App {
                 );
                 tasks.push(Task::perform(
                     async move { new_request.send_default().await },
-                    |fiat_price| Message::Fiat(FiatMessage::GetPriceResult(fiat_price)),
+                    |fiat_price| FiatMessage::GetPriceResult(fiat_price).into(),
                 ));
             }
         }

--- a/liana-gui/src/app/state/mod.rs
+++ b/liana-gui/src/app/state/mod.rs
@@ -80,7 +80,7 @@ pub fn fiat_price_for_wallet(wallet: &Wallet, cache: &Cache) -> Option<FiatPrice
         .as_ref()
         .filter(|sett| sett.is_enabled)
     {
-        if let Some(price) = cache.fiat_price_cache.fiat_price.as_ref() {
+        if let Some(price) = cache.fiat_price.as_ref() {
             if price.source() == sett.source && price.currency() == sett.currency {
                 fiat_price = Some(price.clone());
             }

--- a/liana-gui/src/app/state/settings/general.rs
+++ b/liana-gui/src/app/state/settings/general.rs
@@ -105,7 +105,7 @@ impl State for GeneralSettingsState {
         if self.new_price_setting.is_enabled {
             let source = self.new_price_setting.source;
             return Task::perform(async move { source }, |source| {
-                Message::Fiat(FiatMessage::ListCurrencies(source))
+                FiatMessage::ListCurrencies(source).into()
             });
         } else if self.wallet.fiat_price_setting.is_none() {
             // If the wallet does not have a fiat price setting, save the default disabled setting
@@ -114,7 +114,7 @@ impl State for GeneralSettingsState {
                 "Fiat price setting is missing for wallet '{}'. Saving default setting.",
                 self.wallet.id()
             );
-            return Task::perform(async move {}, |_| Message::Fiat(FiatMessage::SaveChanges));
+            return Task::perform(async move {}, |_| FiatMessage::SaveChanges.into());
         }
         Task::none()
     }
@@ -178,9 +178,7 @@ impl State for GeneralSettingsState {
                             return Task::none();
                         }
                     }
-                    return Task::perform(async move {}, |_| {
-                        Message::Fiat(FiatMessage::SaveChanges)
-                    });
+                    return Task::perform(async move {}, |_| FiatMessage::SaveChanges.into());
                 }
                 Task::none()
             }
@@ -203,7 +201,7 @@ impl State for GeneralSettingsState {
                                 .insert(source, (requested_at, list.currencies));
                         }
                         return Task::perform(async move {}, |_| {
-                            Message::Fiat(FiatMessage::ValidateCurrencySetting)
+                            FiatMessage::ValidateCurrencySetting.into()
                         });
                     }
                     Err(e) => {
@@ -219,7 +217,7 @@ impl State for GeneralSettingsState {
                     match self.currencies_list.get(&source) {
                         Some((old, _)) if now.saturating_sub(*old) <= CURRENCIES_LIST_TTL_SECS => {
                             return Task::perform(async move {}, |_| {
-                                Message::Fiat(FiatMessage::ValidateCurrencySetting)
+                                FiatMessage::ValidateCurrencySetting.into()
                             });
                         }
                         _ => {
@@ -233,9 +231,7 @@ impl State for GeneralSettingsState {
                                     )
                                 },
                                 |(source, now, res)| {
-                                    Message::Fiat(FiatMessage::ListCurrenciesResult(
-                                        source, now, res,
-                                    ))
+                                    FiatMessage::ListCurrenciesResult(source, now, res).into()
                                 },
                             );
                         }
@@ -250,11 +246,11 @@ impl State for GeneralSettingsState {
                         if self.new_price_setting.is_enabled {
                             let source = self.new_price_setting.source;
                             return Task::perform(async move { source }, |source| {
-                                Message::Fiat(FiatMessage::ListCurrencies(source))
+                                FiatMessage::ListCurrencies(source).into()
                             });
                         } else {
                             return Task::perform(async move {}, |_| {
-                                Message::Fiat(FiatMessage::SaveChanges)
+                                FiatMessage::SaveChanges.into()
                             });
                         }
                     }
@@ -263,14 +259,14 @@ impl State for GeneralSettingsState {
                         if self.new_price_setting.is_enabled {
                             let source = self.new_price_setting.source;
                             return Task::perform(async move { source }, |source| {
-                                Message::Fiat(FiatMessage::ListCurrencies(source))
+                                FiatMessage::ListCurrencies(source).into()
                             });
                         }
                     }
                     view::FiatMessage::CurrencyEdited(currency) => {
                         self.new_price_setting.currency = currency;
                         return Task::perform(async move {}, |_| {
-                            Message::Fiat(FiatMessage::ValidateCurrencySetting)
+                            FiatMessage::ValidateCurrencySetting.into()
                         });
                     }
                 }

--- a/liana-gui/src/app/wallet.rs
+++ b/liana-gui/src/app/wallet.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use crate::app::cache::FiatPrice;
 use crate::dir::LianaDirectory;
 use crate::services::fiat::{Currency, PriceSource};
 use crate::{
@@ -231,6 +232,16 @@ impl Wallet {
         });
 
         map
+    }
+
+    /// Whether the wallet's fiat price setting is enabled and matches
+    /// the given fiat price's source and currency.
+    pub fn fiat_price_is_relevant(&self, fiat_price: &FiatPrice) -> bool {
+        self.fiat_price_setting.as_ref().is_some_and(|sett| {
+            sett.is_enabled
+                && sett.source == fiat_price.source()
+                && sett.currency == fiat_price.currency()
+        })
     }
 }
 

--- a/liana-gui/src/gui/cache.rs
+++ b/liana-gui/src/gui/cache.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::app::cache::{FiatPrice, FiatPriceRequest};
+use crate::services::fiat::{Currency, PriceSource};
+
+/// How long a cached fiat price is considered fresh.
+const FIAT_PRICE_TTL: Duration = Duration::from_secs(300);
+
+/// A global cache for the application.
+#[derive(Default)]
+pub struct GlobalCache {
+    fiat_prices: FiatPricesCache,
+}
+
+impl GlobalCache {
+    /// Get a fiat price from the cache if it exists and is not older than `FIAT_PRICE_TTL`.
+    pub fn fresh_fiat_price(&self, source: PriceSource, currency: Currency) -> Option<&FiatPrice> {
+        self.fiat_prices.fresh_price(source, currency)
+    }
+
+    /// Get a pending fiat price request if it exists.
+    pub fn pending_fiat_price_request(
+        &self,
+        source: PriceSource,
+        currency: Currency,
+    ) -> Option<&FiatPriceRequest> {
+        self.fiat_prices.pending_request(source, currency)
+    }
+
+    /// Insert a fiat price into the cache.
+    pub fn insert_fiat_price(&mut self, fiat_price: FiatPrice) {
+        self.fiat_prices.insert_price(fiat_price);
+    }
+
+    /// Insert a pending fiat price request into the cache.
+    pub fn insert_fiat_price_request(&mut self, request: FiatPriceRequest) {
+        self.fiat_prices.insert_price_request(request);
+    }
+
+    /// Remove a pending fiat price request from the cache.
+    pub fn remove_fiat_price_request(&mut self, source: PriceSource, currency: Currency) {
+        self.fiat_prices.remove_price_request(source, currency);
+    }
+}
+
+#[derive(Default)]
+struct FiatPricesCache {
+    /// Fiat price for a given source and currency.
+    prices: HashMap<(PriceSource, Currency), FiatPrice>,
+    /// Any pending requests that have not yet completed.
+    pending_requests: HashMap<(PriceSource, Currency), FiatPriceRequest>,
+}
+
+impl FiatPricesCache {
+    fn price(&self, source: PriceSource, currency: Currency) -> Option<&FiatPrice> {
+        self.prices.get(&(source, currency))
+    }
+
+    fn fresh_price(&self, source: PriceSource, currency: Currency) -> Option<&FiatPrice> {
+        self.price(source, currency)
+            .filter(|price| price.requested_at().elapsed() <= FIAT_PRICE_TTL)
+    }
+
+    fn pending_request(
+        &self,
+        source: PriceSource,
+        currency: Currency,
+    ) -> Option<&FiatPriceRequest> {
+        self.pending_requests.get(&(source, currency))
+    }
+
+    fn insert_price(&mut self, fiat_price: FiatPrice) {
+        self.prices
+            .insert((fiat_price.source(), fiat_price.currency()), fiat_price);
+    }
+
+    fn insert_price_request(&mut self, request: FiatPriceRequest) {
+        self.pending_requests
+            .insert((request.source, request.currency), request);
+    }
+
+    fn remove_price_request(&mut self, source: PriceSource, currency: Currency) {
+        self.pending_requests.remove(&(source, currency));
+    }
+}

--- a/liana-gui/src/gui/pane.rs
+++ b/liana-gui/src/gui/pane.rs
@@ -2,7 +2,7 @@ use iced::{Length, Subscription, Task};
 use iced_aw::ContextMenu;
 use liana_ui::{component::text::*, icon::plus_icon, theme, widget::*};
 
-use crate::gui::Config;
+use crate::{app, gui::Config};
 
 use super::tab;
 
@@ -95,6 +95,19 @@ impl Pane {
             let id = t.id;
             t.on_tick().map(move |msg| Message::Tab(id, msg))
         }))
+    }
+
+    /// Helper to update a tab with an app message.
+    pub fn update_tab_with_app_msg(
+        &mut self,
+        tab_id: usize,
+        app_msg: impl Into<app::Message>,
+        cfg: &Config,
+    ) -> Task<Message> {
+        self.update(
+            Message::Tab(tab_id, tab::Message::Run(Box::new(app_msg.into()))),
+            cfg,
+        )
     }
 
     pub fn update(&mut self, message: Message, cfg: &Config) -> Task<Message> {

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -12,7 +12,7 @@ use lianad::commands::ListCoinsResult;
 use crate::{
     app::{
         self,
-        cache::{Cache, DaemonCache, FiatPriceCache},
+        cache::{Cache, DaemonCache},
         settings::{update_settings_file, WalletSettings},
         wallet::Wallet,
         App,
@@ -67,6 +67,22 @@ pub struct Tab {
 impl Tab {
     pub fn new(id: usize, state: State) -> Self {
         Tab { id, state }
+    }
+
+    pub fn cache(&self) -> Option<&Cache> {
+        if let State::App(ref app) = self.state {
+            Some(app.cache())
+        } else {
+            None
+        }
+    }
+
+    pub fn wallet(&self) -> Option<&Wallet> {
+        if let State::App(ref app) = self.state {
+            Some(app.wallet())
+        } else {
+            None
+        }
     }
 
     pub fn title(&self) -> &str {
@@ -372,7 +388,7 @@ pub fn create_app_with_remote_backend(
                 last_poll_timestamp: None,
                 last_tick: Instant::now(),
             },
-            fiat_price_cache: FiatPriceCache::default(),
+            fiat_price: None,
         },
         Arc::new(
             Wallet::new(wallet.descriptor)

--- a/liana-gui/src/loader.rs
+++ b/liana-gui/src/loader.rs
@@ -23,7 +23,7 @@ use lianad::{
 };
 
 use crate::app;
-use crate::app::cache::{DaemonCache, FiatPriceCache};
+use crate::app::cache::DaemonCache;
 use crate::app::settings::WalletSettings;
 use crate::backup::Backup;
 use crate::dir::LianaDirectory;
@@ -448,7 +448,7 @@ pub async fn load_application(
             last_poll_timestamp: info.last_poll_timestamp,
             ..Default::default()
         },
-        fiat_price_cache: FiatPriceCache::default(),
+        fiat_price: None,
     };
 
     Ok((Arc::new(wallet), cache, daemon, internal_bitcoind, backup))


### PR DESCRIPTION
This PR addresses https://github.com/wizardsardine/liana/issues/1819 by adding a new global cache to store fiat prices.

The `GUI` rather than individual tabs will now take care of triggering new price requests and processing results .