### PR TITLE
Remove parenthesis and move right the fiat price

### DIFF
--- a/liana-gui/src/app/view/home.rs
+++ b/liana-gui/src/app/view/home.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Local, Utc};
 use std::{collections::HashMap, convert::TryInto, time::Duration, vec};
 
 use iced::{
-    alignment,
+    alignment::{self, Vertical},
     widget::{Container, Row, Space},
     Alignment::{self, Center},
     Length,
@@ -83,20 +83,25 @@ pub fn home_view<'a>(
             Column::new()
                 .push(if sync_status.is_synced() {
                     Row::new()
-                        .push(amount_with_size(balance, H1_SIZE))
+                        .align_y(Vertical::Center)
+                        .push(
+                            Container::new(amount_with_size(balance, H1_SIZE))
+                                .width(Length::FillPortion(3)),
+                        )
                         .push_maybe(fiat_balance.map(|fiat| {
-                            Row::new()
-                                .align_y(Alignment::Center)
-                                .push(Space::with_width(10))
-                                .push(
+                            Container::new(
+                                Row::new().align_y(Alignment::Center).push(
                                     text(format!(
-                                        "({} {})",
+                                        "{} {}",
                                         fiat.to_formatted_string(),
                                         fiat.currency
                                     ))
-                                    .size(H1_SIZE)
+                                    .size(H2_SIZE)
                                     .color(color::GREY_2),
-                                )
+                                ),
+                            )
+                            .width(Length::FillPortion(2))
+                            .align_x(Alignment::End)
                         }))
                 } else {
                     Row::new().push(spinner::Carousel::new(

--- a/liana-ui/src/component/amount.rs
+++ b/liana-ui/src/component/amount.rs
@@ -14,12 +14,12 @@ impl DisplayAmount for Amount {
 }
 
 /// Amount with default size and colors.
-pub fn amount<'a, T: 'a>(a: &Amount) -> Row<'a, T> {
+pub fn amount<'a, T: 'a>(a: &Amount) -> Element<'a, T> {
     amount_with_size(a, P1_SIZE)
 }
 
 /// Amount with default colors.
-pub fn amount_with_size<'a, T: 'a>(a: &Amount, size: u16) -> Row<'a, T> {
+pub fn amount_with_size<'a, T: 'a>(a: &Amount, size: u16) -> Element<'a, T> {
     amount_with_size_and_colors(a, size, color::GREY_3, None)
 }
 
@@ -36,7 +36,7 @@ pub fn amount_with_size_and_colors<'a, T: 'a>(
     size: u16,
     color_before: Color,
     color_after: Option<Color>,
-) -> Row<'a, T> {
+) -> Element<'a, T> {
     render_amount(a.to_formatted_string(), size, color_before, color_after)
 }
 
@@ -119,7 +119,7 @@ fn render_amount<'a, T: 'a>(
     size: u16,
     color_before: Color,
     color_after: Option<Color>,
-) -> Row<'a, T> {
+) -> Element<'a, T> {
     let spacing = if size > P1_SIZE { 10 } else { 5 };
 
     let (before, after) = match split_at_first_non_zero(amount) {
@@ -141,6 +141,8 @@ fn render_amount<'a, T: 'a>(
     ])
     .spacing(spacing)
     .align_y(iced::Alignment::Center)
+    .wrap()
+    .into()
 }
 
 // Build the rendering elements for displaying a Bitcoin amount.


### PR DESCRIPTION
Mostly a subjective change for my personal taste and to keep the code somewhere.
Usage of wrap is to allow a better layout when the window size is small.
<img width="983" height="700" alt="20250905_11h14m37s_grim" src="https://github.com/user-attachments/assets/2d810d4d-d2bd-495a-b530-865074f9f7ea" />
