### PR TITLE
Automatic and user triggered refresh of home information

### DIFF
--- a/liana-gui/src/app/message.rs
+++ b/liana-gui/src/app/message.rs
@@ -26,6 +26,7 @@ use crate::{
 
 #[derive(Debug)]
 pub enum Message {
+    Tick,
     UpdateDaemonCache(Result<DaemonCache, Error>),
     CacheUpdated,
     Fiat(FiatMessage),

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -305,7 +305,12 @@ impl App {
 
     pub fn on_tick(&mut self) -> Task<Message> {
         let tick = std::time::Instant::now();
-        let mut tasks = vec![];
+        let mut tasks =
+            vec![self
+                .panels
+                .current_mut()
+                .update(self.daemon.clone(), &self.cache, Message::Tick)];
+
         // Check if we need to update the daemon cache.
         let duration = Duration::from_secs(
             match sync_status(

--- a/liana-gui/src/app/view/message.rs
+++ b/liana-gui/src/app/view/message.rs
@@ -12,6 +12,7 @@ pub trait Close {
 
 #[derive(Debug, Clone)]
 pub enum Message {
+    Scroll(f32),
     Reload,
     Clipboard(String),
     Menu(Menu),

--- a/liana-gui/src/app/view/mod.rs
+++ b/liana-gui/src/app/view/mod.rs
@@ -354,13 +354,16 @@ pub fn dashboard<'a, T: Into<Element<'a, Message>>>(
             Column::new()
                 .push(warn(warning))
                 .push(
-                    Container::new(scrollable(row!(
-                        Space::with_width(Length::FillPortion(1)),
-                        column!(Space::with_height(Length::Fixed(150.0)), content.into())
-                            .width(Length::FillPortion(8))
-                            .max_width(1500),
-                        Space::with_width(Length::FillPortion(1)),
-                    )))
+                    Container::new(
+                        scrollable(row!(
+                            Space::with_width(Length::FillPortion(1)),
+                            column!(Space::with_height(Length::Fixed(150.0)), content.into())
+                                .width(Length::FillPortion(8))
+                                .max_width(1500),
+                            Space::with_width(Length::FillPortion(1)),
+                        ))
+                        .on_scroll(|w| Message::Scroll(w.absolute_offset().y)),
+                    )
                     .center_x(Length::Fill)
                     .style(theme::container::background)
                     .height(Length::Fill),


### PR DESCRIPTION
- An automatic refresh of the home balance is done every 10s unless the user is currently exploring the history by loading more pages. 
- When the user scroll to the very top, the refresh is automatically triggered
if the information was not loaded in the last 3s.

This PR is a less invasive change, the refresh occurs only when it matters for the user: when he is looking at the balance and the last payments.