### PR TITLE
gui: fix badge's tooltip display

### DIFF
--- a/liana-ui/src/component/badge.rs
+++ b/liana-ui/src/component/badge.rs
@@ -78,7 +78,9 @@ pub fn badge_pill<'a, T: 'a>(label: &'a str, tooltip: &'a str) -> Container<'a, 
                 .padding(10)
                 .center_x(Length::Shrink)
                 .style(theme::pill::simple),
-            tooltip,
+            Container::new(text::p1_regular(tooltip))
+                .padding(10)
+                .style(theme::card::simple),
             tooltip::Position::Top,
         )
     })


### PR DESCRIPTION
Sometimes visibility of tooltip could be improved, what do you think?

<img width="1093" height="324" alt="Capture d’écran du 2025-09-05 10-12-23" src="https://github.com/user-attachments/assets/8f661fc7-7403-4581-80a4-d381fbe20940" />


With borders and background :

<img width="1093" height="324" alt="Capture d’écran du 2025-09-05 10-02-55" src="https://github.com/user-attachments/assets/8e3a0408-c2e4-4ea0-a2a9-110d30beddad" />
