### PR TITLE
configure number of decimals per fiat currency

### DIFF
--- a/liana-gui/src/app/state/spend/step.rs
+++ b/liana-gui/src/app/state/spend/step.rs
@@ -920,10 +920,13 @@ impl Recipient {
                     self.amount = form::Value::default(); // reset the BTC amount to be consistent
                     return;
                 }
-                // Don't allow more than 2 decimal places for fiat amounts.
+                // Don't allow more than currency's decimal places for fiat amounts.
                 if fiat_amt_str
                     .split_once(".")
-                    .filter(|(_, decimals)| decimals.len() > 2)
+                    .filter(|(_, decimals)| {
+                        converter.currency().decimals() == 0
+                            || decimals.len() > converter.currency().decimals()
+                    })
                     .is_some()
                 {
                     return;

--- a/liana-gui/src/app/view/fiat.rs
+++ b/liana-gui/src/app/view/fiat.rs
@@ -59,9 +59,9 @@ impl FiatAmount {
         self.currency
     }
 
-    /// Format a fiat amount as a string with two decimal places and no thousands separator.
+    /// Format a fiat amount as a string with required decimal places for currency and no thousands separator.
     pub fn to_rounded_string(&self) -> String {
-        format_f64_as_string(self.amount, "", 2, false)
+        format_f64_as_string(self.amount, "", self.currency().decimals(), false)
     }
 
     /// Format a fiat amount as a `Text` widget with a tilde (~) prefix to indicate approximation.
@@ -74,10 +74,10 @@ impl FiatAmount {
     }
 }
 
-// Format a fiat amount as a string with two decimal places and a comma as the thousands separator.
+// Format a fiat amount as a string with required decimal places for currency and a comma as the thousands separator.
 impl DisplayAmount for FiatAmount {
     fn to_formatted_string(&self) -> String {
-        format_f64_as_string(self.amount, ",", 2, false)
+        format_f64_as_string(self.amount, ",", self.currency().decimals(), false)
     }
 }
 

--- a/liana-gui/src/app/view/spend/mod.rs
+++ b/liana-gui/src/app/view/spend/mod.rs
@@ -501,7 +501,7 @@ pub fn recipient_view<'a>(
                                         } else if let Some(btc_amt) = btc_amt {
                                             let fa = conv.convert(btc_amt);
                                             &form::Value {
-                                                value: fa.to_rounded_string(), // 2 decimal places
+                                                value: fa.to_rounded_string(), // required decimal places for currency
                                                 warning: None,
                                                 valid: true,
                                             }

--- a/liana-gui/src/services/fiat/currency.rs
+++ b/liana-gui/src/services/fiat/currency.rs
@@ -88,3 +88,14 @@ currency_enum!(Currency {
     ZAR,
     ZMW,
 });
+
+impl Currency {
+    /// Returns the number of decimals required for the minor unit.
+    pub fn decimals(&self) -> usize {
+        match self {
+            Currency::CLP | Currency::JPY | Currency::KRW | Currency::VND => 0,
+            Currency::BHD | Currency::KWD => 3,
+            _ => 2,
+        }
+    }
+}


### PR DESCRIPTION
This allows to configure the number of decimals displayed per fiat currency.