### PR TITLE
installer: do not allow duplicate key aliases

### DIFF
--- a/liana-gui/src/installer/step/descriptor/editor/mod.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/mod.rs
@@ -383,8 +383,13 @@ impl Step for DefineDescriptor {
                                     if let Some(Some(key)) = path.keys.get(j) {
                                         let fg = key.fingerprint;
                                         let alias = key.name.clone();
-                                        let modal =
-                                            EditKeyAlias::new(fg, alias, path_kind, coordinates);
+                                        let modal = EditKeyAlias::new(
+                                            self.keys(),
+                                            fg,
+                                            alias,
+                                            path_kind,
+                                            coordinates,
+                                        );
                                         self.modal = Some(Box::new(modal));
                                         return Task::none();
                                     }


### PR DESCRIPTION
This PR add a check to detect if an alias is already in use for another key in both:
 - `SelectKeySource`:  
 
<img width="745" height="410" alt="image" src="https://github.com/user-attachments/assets/1bf1a46c-d23f-43e0-917c-fc0908e50c20" />

 - `EditKeyAlias`:
 
<img width="1218" height="632" alt="image" src="https://github.com/user-attachments/assets/bbce6763-17eb-4c3e-b18a-5830b2997819" />

 
closes #1850 
