### PR TITLE
fix: map insufficient funds error to success result for Liana Connect backend

### DIFF
--- a/liana-gui/src/services/connect/client/backend/mod.rs
+++ b/liana-gui/src/services/connect/client/backend/mod.rs
@@ -797,9 +797,7 @@ impl Daemon for BackendWalletClient {
             })
             .send()
             .await?
-            .check_success()
-            .await?
-            .json()
+            .json() // no need to check success before parsing the json as it could be an error variant
             .await?;
 
         match res {
@@ -840,9 +838,7 @@ impl Daemon for BackendWalletClient {
             })
             .send()
             .await?
-            .check_success()
-            .await?
-            .json()
+            .json() // no need to check success before parsing the json as it could be an error variant
             .await?;
 
         match res {


### PR DESCRIPTION
This fixes #1871 by correctly mapping the insufficient funds error to a success result and otherwise returning details of the unsuccessful response.