### PR TITLE
UI fixes & improvements

### DIFF
--- a/liana-gui/src/app/state/settings/mod.rs
+++ b/liana-gui/src/app/state/settings/mod.rs
@@ -259,6 +259,19 @@ impl State for ImportExportSettingsState {
                 if self.modal.is_none() {
                     let modal = ExportModal::new(
                         Some(daemon),
+                        ImportExportType::ExportEncryptedDescriptor(Box::new(
+                            self.wallet.main_descriptor.clone(),
+                        )),
+                    );
+                    launch!(self, modal, true);
+                }
+            }
+            Message::View(view::Message::Settings(
+                view::SettingsMessage::ExportPlaintextDescriptor,
+            )) => {
+                if self.modal.is_none() {
+                    let modal = ExportModal::new(
+                        Some(daemon),
                         ImportExportType::Descriptor(self.wallet.main_descriptor.clone()),
                     );
                     launch!(self, modal, true);

--- a/liana-gui/src/app/view/message.rs
+++ b/liana-gui/src/app/view/message.rs
@@ -101,6 +101,7 @@ pub enum SettingsMessage {
     EditWalletSettings,
     ImportExportSection,
     ExportEncryptedDescriptor,
+    ExportPlaintextDescriptor,
     ExportTransactions,
     ExportLabels,
     ExportWallet,

--- a/liana-gui/src/app/view/settings/mod.rs
+++ b/liana-gui/src/app/view/settings/mod.rs
@@ -217,8 +217,8 @@ pub fn import_export<'a>(cache: &'a Cache, warning: Option<&Error>) -> Element<'
         .push(Space::with_width(Length::Fill));
 
     let export_descriptor = export_section(
-        "Descriptor only",
-        "Plain-text descriptor file only, to use with other wallets.",
+        "Descriptor only - plain-text",
+        "Plain-text (not encrypted) descriptor file only, to use with other wallets.",
         icon::backup_icon(),
         Message::Settings(SettingsMessage::ExportEncryptedDescriptor),
     );

--- a/liana-gui/src/app/view/settings/mod.rs
+++ b/liana-gui/src/app/view/settings/mod.rs
@@ -3,8 +3,8 @@ pub mod general;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
-use iced::alignment::Vertical;
-use iced::widget::{Column, Rule};
+use iced::alignment::{Horizontal, Vertical};
+use iced::widget::{container, Column, Rule};
 use iced::{
     alignment,
     widget::{radio, scrollable, tooltip as iced_tooltip, Space},
@@ -1009,6 +1009,26 @@ pub fn wallet_settings<'a>(
     updated: bool,
 ) -> Element<'a, Message> {
     let header = header("Wallet", SettingsMessage::EditWalletSettings);
+    let r = Row::new().spacing(10).align_y(Vertical::Center)
+        .push(icon::backup_icon())
+        .push(text("Back up encrypted descriptor"))
+        .push(
+
+    Container::new(
+        iced::widget::tooltip::Tooltip::new(
+            icon::tooltip_icon(),
+            "An encrypted descriptor file (.bed) you can store anywhere. To decrypt it, you need one of your signing devices or xpubs.",
+            iced::widget::tooltip::Position::Bottom,
+        )
+        .style(theme::card::simple),
+    )
+        );
+    let back_up_encrypted_descriptor =
+        Button::new(container(r).align_x(Horizontal::Center).padding(5))
+            .on_press(Message::Settings(
+                SettingsMessage::ExportEncryptedDescriptor,
+            ))
+            .style(theme::button::secondary);
 
     let descr = card::simple(
         Column::new()
@@ -1027,12 +1047,7 @@ pub fn wallet_settings<'a>(
                 Row::new()
                     .spacing(10)
                     .push(Column::new().width(Length::Fill))
-                    .push(
-                        button::secondary(Some(icon::backup_icon()), "Back up Descriptor")
-                            .on_press(Message::Settings(
-                                SettingsMessage::ExportEncryptedDescriptor,
-                            )),
-                    )
+                    .push(back_up_encrypted_descriptor)
                     .push(
                         button::secondary(Some(icon::clipboard_icon()), "Copy")
                             .on_press(Message::Clipboard(descriptor.to_string())),

--- a/liana-gui/src/app/view/settings/mod.rs
+++ b/liana-gui/src/app/view/settings/mod.rs
@@ -216,11 +216,18 @@ pub fn import_export<'a>(cache: &'a Cache, warning: Option<&Error>) -> Element<'
         ))
         .push(Space::with_width(Length::Fill));
 
+    let export_encrypted_descriptor = export_section(
+        "Encrypted descriptor",
+        ".bed file, can be decrypted with one of your signing devices or xpubs.",
+        icon::backup_icon(),
+        Message::Settings(SettingsMessage::ExportEncryptedDescriptor),
+    );
+
     let export_descriptor = export_section(
         "Descriptor only - plain-text",
         "Plain-text (not encrypted) descriptor file only, to use with other wallets.",
         icon::backup_icon(),
-        Message::Settings(SettingsMessage::ExportEncryptedDescriptor),
+        Message::Settings(SettingsMessage::ExportPlaintextDescriptor),
     );
 
     let export_transactions = export_section(
@@ -267,6 +274,7 @@ pub fn import_export<'a>(cache: &'a Cache, warning: Option<&Error>) -> Element<'
             .spacing(20)
             .push(header)
             .push(description)
+            .push(export_encrypted_descriptor)
             .push(export_wallet)
             .push(import_wallet)
             .push(separator)

--- a/liana-gui/src/app/view/settings/mod.rs
+++ b/liana-gui/src/app/view/settings/mod.rs
@@ -239,7 +239,7 @@ pub fn import_export<'a>(cache: &'a Cache, warning: Option<&Error>) -> Element<'
 
     let export_wallet = export_section(
         "Export wallet",
-        "File with wallet info useful to sync labels and data on other devices.",
+        "File (not encrypted) with wallet info useful to sync labels and data on other devices.",
         icon::backup_icon(),
         Message::Settings(SettingsMessage::ExportWallet),
     );

--- a/liana-gui/src/installer/decrypt.rs
+++ b/liana-gui/src/installer/decrypt.rs
@@ -680,7 +680,7 @@ pub fn decrypt_view<'a>(state: &DecryptModal) -> Container<'a, installer::Messag
         None => valid_content(state),
     };
 
-    let content = scrollable(content);
+    let content = scrollable(Container::new(content).padding(15));
 
     let content = row![Space::with_width(50), content];
 

--- a/liana-gui/src/installer/decrypt.rs
+++ b/liana-gui/src/installer/decrypt.rs
@@ -10,7 +10,7 @@ use encrypted_backup::{Decrypted, EncryptedBackup};
 use iced::{
     alignment::{self, Horizontal},
     clipboard,
-    widget::{column, row, scrollable, Column, Space},
+    widget::{column, row, scrollable, tooltip, Column, Space},
     Length, Task,
 };
 use liana::{
@@ -32,8 +32,8 @@ use liana_ui::{
         modal::{self, widget_style, BTN_W},
         text::{self, p1_regular},
     },
-    icon,
-    widget::{modal::Modal, Button, Container, Element},
+    icon, theme,
+    widget::{modal::Modal, Button, Container, Element, Row},
 };
 
 use crate::{
@@ -596,6 +596,24 @@ fn valid_content(state: &DecryptModal) -> Container<'static, installer::Message>
 }
 
 fn optional_content(state: &DecryptModal) -> Container<'static, installer::Message> {
+    let mut tt = Column::new().push(text::text("Using an air-gapped device? Export the xpub from your device, then use the upload or paste option. If you don’t know the correct derivation path, try with the following:"));
+    for d in &state.derivation_paths {
+        tt = tt.push(text::text(format!("{d}")));
+    }
+    let tt = Container::new(tt)
+        .style(theme::card::simple)
+        .padding(10)
+        .width(300);
+
+    let airgap_hint = Row::new()
+        .push(p1_regular("Provide one of the xpubs used in this wallet."))
+        .push(tooltip::Tooltip::new(
+            icon::tooltip_icon(),
+            tt,
+            tooltip::Position::Bottom,
+        ))
+        .spacing(5);
+
     let import = modal::button_entry(
         Some(icon::import_icon()),
         "Upload extended public key file",
@@ -627,6 +645,8 @@ fn optional_content(state: &DecryptModal) -> Container<'static, installer::Messa
     );
 
     let col = column![
+        airgap_hint,
+        Space::with_height(modal::V_SPACING),
         import,
         Space::with_height(modal::V_SPACING),
         xpub,

--- a/liana-gui/src/installer/decrypt.rs
+++ b/liana-gui/src/installer/decrypt.rs
@@ -600,7 +600,7 @@ fn valid_content(state: &DecryptModal) -> Container<'static, installer::Message>
         col = col.push(optional_content(state));
     }
 
-    Container::new(col)
+    Container::new(col).width(BTN_W)
 }
 
 fn optional_content(state: &DecryptModal) -> Container<'static, installer::Message> {
@@ -744,9 +744,11 @@ pub fn decrypt_view<'a>(state: &DecryptModal) -> Container<'a, installer::Messag
         None => valid_content(state),
     };
 
-    let content = scrollable(Container::new(content).padding(15));
-
-    let content = row![Space::with_width(50), content];
+    let content = scrollable(
+        Container::new(content)
+            .padding(15)
+            .align_x(Horizontal::Center),
+    );
 
     let column = Column::new()
         .push(header)

--- a/liana-gui/src/installer/decrypt.rs
+++ b/liana-gui/src/installer/decrypt.rs
@@ -8,7 +8,7 @@ use std::{
 use async_hwi::{bitbox::api::btc::Fingerprint, DeviceKind, Version, HWI};
 use encrypted_backup::{Decrypted, EncryptedBackup};
 use iced::{
-    alignment::{self, Horizontal},
+    alignment::{self, Horizontal, Vertical},
     clipboard,
     widget::{column, row, scrollable, tooltip, Column, Space},
     Length, Task,
@@ -26,14 +26,15 @@ use liana::{
     },
 };
 use liana_ui::{
+    color,
     component::{
         card,
-        form::Value,
-        modal::{self, widget_style, BTN_W},
+        form::{self, Value},
+        modal::{self, widget_style, BTN_H, BTN_W, V_SPACING},
         text::{self, p1_regular},
     },
     icon, theme,
-    widget::{modal::Modal, Button, Container, Element, Row},
+    widget::{modal::Modal, Button, CheckBox, Container, Element, Row},
 };
 
 use crate::{
@@ -82,6 +83,7 @@ pub struct DecryptModal {
     xpub: Value<String>,
     xpub_busy: bool,
     mnemonic: Value<String>,
+    mnemonic_ack: bool,
     mnemonic_busy: bool,
     focus: Focus,
     pub modal: Option<ExportModal>,
@@ -110,6 +112,7 @@ pub enum Decrypt {
     PasteMnemonic,
     SelectMnemonic,
     MnemonicStatus(Option<&'static str> /* error */, Option<Fingerprint>),
+    MnemonicAck(bool),
     SelectImportXpub,
     UnexpectedPayload(Decrypted),
     InvalidDescriptor,
@@ -201,6 +204,7 @@ impl DecryptModal {
             xpub_busy: false,
             mnemonic: Value::default(),
             mnemonic_busy: false,
+            mnemonic_ack: false,
             focus: Focus::None,
             modal: None,
         }
@@ -285,6 +289,10 @@ impl DecryptModal {
             }
             Decrypt::CloseModal => {
                 self.modal = None;
+                Task::none()
+            }
+            Decrypt::MnemonicAck(ack) => {
+                self.mnemonic_ack = ack;
                 Task::none()
             }
             Decrypt::None
@@ -633,15 +641,10 @@ fn optional_content(state: &DecryptModal) -> Container<'static, installer::Messa
         || Decrypt::SelectXpub.into(),
     );
 
-    let mnemonic = modal::collapsible_input_button(
+    let mnemonic = mnemonic_input_button(
         state.focus == Focus::Mnemonic,
-        Some(icon::pencil_icon()),
-        "Enter mnemonic of one of the keys".to_string(),
-        "code code code code code code code code code code code brave".to_string(),
+        state.mnemonic_ack,
         &state.mnemonic,
-        Some(|s| Decrypt::Mnemonic(s).into()),
-        Some(|| Decrypt::PasteMnemonic.into()),
-        || Decrypt::SelectMnemonic.into(),
     );
 
     let col = column![
@@ -651,10 +654,71 @@ fn optional_content(state: &DecryptModal) -> Container<'static, installer::Messa
         Space::with_height(modal::V_SPACING),
         xpub,
         Space::with_height(modal::V_SPACING),
-        mnemonic
+        mnemonic,
+        Space::with_height(modal::V_SPACING),
     ];
 
     Container::new(col)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn mnemonic_input_button<'a>(
+    collapsed: bool,
+    ack: bool,
+    input_value: &Value<String>,
+) -> Element<'a, installer::Message> {
+    let icon = icon::pencil_icon().color(color::WHITE);
+    let label = "UNSAFE: Enter mnemonic of one of the keys";
+    let input_placeholder = "code code code code code code code code code code code brave";
+    let disclaimer = " This option is not secure. I understand that entering a mnemonic on a computer may result in theft of my funds.";
+    let paste_message = Decrypt::PasteMnemonic.into();
+    let collapse_message = Decrypt::SelectMnemonic.into();
+
+    let form = if ack {
+        form::Form::new(input_placeholder, input_value, |s| {
+            Decrypt::Mnemonic(s).into()
+        })
+    } else {
+        form::Form::new_disabled(input_placeholder, input_value)
+    }
+    .padding(10);
+    let paste = Button::new(icon::paste_icon().color(color::BLACK)).on_press(paste_message);
+
+    if collapsed {
+        let line = Row::new().push(form).push(paste).spacing(V_SPACING);
+        let check_box =
+            CheckBox::new(disclaimer, ack).on_toggle(|ack| Decrypt::MnemonicAck(ack).into());
+        let col = Column::new()
+            .push(row![
+                text::p1_regular(label).color(color::WHITE),
+                Space::with_width(Length::Fill)
+            ])
+            .push(line);
+        let content = if ack {
+            Container::new(col)
+        } else {
+            Container::new(check_box)
+        };
+        let row = Row::new()
+            .push(icon)
+            .push(content)
+            .align_y(Vertical::Center)
+            .spacing(V_SPACING);
+
+        Button::new(row).style(widget_style)
+    } else {
+        let row = Row::new()
+            .push(icon)
+            .push(text::p1_regular(label))
+            .height(BTN_H)
+            .spacing(V_SPACING)
+            .align_y(Vertical::Center);
+        Button::new(row)
+            .on_press(collapse_message)
+            .style(widget_style)
+    }
+    .width(BTN_W)
+    .into()
 }
 
 /// Return the modal view for an export task

--- a/liana-gui/src/installer/step/backend.rs
+++ b/liana-gui/src/installer/step/backend.rs
@@ -570,6 +570,11 @@ impl Step for ImportRemoteWallet {
                     self.error = Some("Backup imported but descriptor missing!".into());
                 }
             }
+            Message::Decrypt(m) => {
+                if let ImportDescriptorModal::Decrypt(modal) = &mut self.modal {
+                    return modal.update(m);
+                }
+            }
             Message::ImportRemoteWallet(message::ImportRemoteWallet::ImportDescriptor(desc)) => {
                 self.imported_descriptor.value = desc;
                 if !self.imported_descriptor.value.is_empty() {

--- a/liana-gui/src/installer/step/descriptor/editor/key.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/key.rs
@@ -1393,7 +1393,7 @@ where
             Space::with_width(Length::Fill)
         ])
         .push(row![
-            p1_regular("Give this key a friendly name. it helps you identify it later:"),
+            p1_regular("Give this key a friendly name. It helps you identify it later:"),
             Space::with_width(Length::Fill)
         ])
         .push(

--- a/liana-gui/src/installer/step/descriptor/editor/key.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/key.rs
@@ -1393,7 +1393,7 @@ where
             Space::with_width(Length::Fill)
         ])
         .push(row![
-            p1_regular("Give this key a friendly name. It helps you identify it later:"),
+            p1_regular("Give this key a friendly name. It will help you identify it later:"),
             Space::with_width(Length::Fill)
         ])
         .push(

--- a/liana-gui/src/installer/step/import_descriptor.rs
+++ b/liana-gui/src/installer/step/import_descriptor.rs
@@ -93,6 +93,7 @@ impl ImportDescriptorModal {
                         | Decrypt::SelectImportXpub
                         | Decrypt::None
                         | Decrypt::CloseModal
+                        | Decrypt::MnemonicAck(_)
                         | Decrypt::ShowOptions(_) => return modal.update(msg),
                         Decrypt::Backup(_) | Decrypt::Close => {}
                     }


### PR DESCRIPTION
This PR:
 - Add a tooltip that displays derivation paths (useful for airgap devices users)
 - Fix scrollbar overlaping buttons in `DecryptModal`
 - Hint the user it's unsafe to enter a mnemonic in `DecryptModal`
 - Change somes wording in `Settings` > `Wallet` & `Settings` > `Import/Export`
 - Add option for export encrypted descriptor in `Settings` > `Import/Export`
 - Fix wording in key editing modal
 - Fix alignment in `DecryptModal`
 - closes #1868 
 - closes #1866