### PR TITLE
[backport v13] fix: map insufficient funds error to success result

### DIFF
--- a/liana-gui/src/services/connect/client/backend/mod.rs
+++ b/liana-gui/src/services/connect/client/backend/mod.rs
@@ -797,9 +797,7 @@ impl Daemon for BackendWalletClient {
             })
             .send()
             .await?
-            .check_success()
-            .await?
-            .json()
+            .json() // no need to check success before parsing the json as it could be an error variant
             .await?;
 
         match res {
@@ -840,9 +838,7 @@ impl Daemon for BackendWalletClient {
             })
             .send()
             .await?
-            .check_success()
-            .await?
-            .json()
+            .json() // no need to check success before parsing the json as it could be an error variant
             .await?;
 
         match res {


### PR DESCRIPTION
Both success and error responses will parse to `DraftPsbtResult` and so we should not filter for success responses in order to be able to properly handle insufficient funds errors.

backport #1872
