### PR TITLE
backport: fix bitcoind start: retry on error 401

### DIFF
--- a/lianad/src/bitcoin/d/mod.rs
+++ b/lianad/src/bitcoin/d/mod.rs
@@ -110,7 +110,7 @@ impl BitcoindError {
             if let Some(minreq_http::Error::Http(minreq_http::HttpError { status_code, .. })) =
                 e.downcast_ref::<minreq_http::Error>()
             {
-                return status_code == &402;
+                return status_code == &401;
             }
         }
         false


### PR DESCRIPTION
backport of #1889 

Sometimes liana-gui reads the previous bitcoin .cookie state before the new cookie is generated, it provokes an unauthorized error that is solved by waiting bitcoind startup before reading new cookie credentials.

close #1888