### PR TITLE
dep: bump bitcoin-encrypted-backup 0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-encrypted-backup"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b89ad3b53c1425530260f9080fe1a968816d762f9467c82d8e57a5d638b90aa"
+checksum = "f4e7cfd72b4e1eac651e2908660e90e65b729052bfd5d4004395a402c3e655cc"
 dependencies = [
  "aes-gcm",
  "miniscript",
@@ -1242,7 +1242,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 

--- a/liana-gui/Cargo.toml
+++ b/liana-gui/Cargo.toml
@@ -62,7 +62,7 @@ fs2 = "0.4.3"
 # Used for opening URLs in browser
 open = "5.3"
 
-encrypted_backup = { version = "0.0.1", default-features=false, features = ["miniscript_12_0"], package = "bitcoin-encrypted-backup" }
+encrypted_backup = { version = "=0.0.2", default-features=false, features = ["miniscript_12_0", "rand"], package = "bitcoin-encrypted-backup" }
 
 [target.'cfg(windows)'.dependencies]
 zip = { version = "0.6", default-features=false, features = ["bzip2", "deflate"] }


### PR DESCRIPTION
in `v0.0.2` 2 * oob read are fixed, they could have made Liana panic on malformed encrypted backup