### PR TITLE
Remove label for non owned outputs

### DIFF
--- a/liana-gui/src/app/view/label.rs
+++ b/liana-gui/src/app/view/label.rs
@@ -1,6 +1,7 @@
 use iced::{advanced::text::Shaping, widget::row, Alignment};
 
 use liana_ui::{
+    color,
     component::{button, form},
     icon,
     widget::*,
@@ -64,5 +65,27 @@ pub fn label_editing(
         .align_y(Alignment::Center),
     )
     .into();
+    e.map(move |msg| view::Message::Label(labelled.clone(), msg))
+}
+
+pub fn label_non_editable(
+    labelled: Vec<String>,
+    label: Option<&String>,
+    size: u16,
+) -> Element<view::Message> {
+    let label_text = label.map(|s| s.as_str()).unwrap_or("(External Ouput)");
+
+    let e: Element<view::LabelMessage> = Container::new(
+        row![Container::new(
+            Text::new(label_text)
+                .size(size)
+                .width(iced::Length::Fill)
+                .color(color::GREY_1)
+        ),]
+        .spacing(5)
+        .align_y(Alignment::Center),
+    )
+    .into();
+
     e.map(move |msg| view::Message::Label(labelled.clone(), msg))
 }

--- a/liana-gui/src/app/view/spend/mod.rs
+++ b/liana-gui/src/app/view/spend/mod.rs
@@ -94,10 +94,11 @@ pub fn spend_view<'a>(
                     .push(psbt::outputs_view(
                         &tx.psbt.unsigned_tx,
                         network,
-                        Some(tx.change_indexes.clone()),
+                        &tx.change_indexes,
                         &tx.labels,
                         labels_editing,
                         tx.is_single_payment().is_some(),
+                        false,
                     )),
             )
             .push(if saved {

--- a/liana-gui/src/app/view/transactions.rs
+++ b/liana-gui/src/app/view/transactions.rs
@@ -437,14 +437,11 @@ pub fn tx_view<'a>(
                     .push(super::psbt::outputs_view(
                         &tx.tx,
                         cache.network,
-                        if tx.is_external() {
-                            None
-                        } else {
-                            Some(tx.change_indexes.clone())
-                        },
+                        &tx.change_indexes,
                         &tx.labels,
                         labels_editing,
                         tx.is_single_payment().is_some(),
+                        tx.is_external(),
                     )),
             )
             .spacing(20),


### PR DESCRIPTION
This is an attempt to remove the labels for non-owned outputs of the wallet.
If there's a better approach I'm happy to adjust.

Closes #961 

<img width="1557" height="674" alt="image" src="https://github.com/user-attachments/assets/9067d317-bbe4-46e5-b3e9-20895fc6968b" />
<img width="1072" height="546" alt="image" src="https://github.com/user-attachments/assets/04c6df3c-d6ac-4e29-9a66-f80739df725e" />
