### PR TITLE
Add bip21 receive display support

### DIFF
--- a/liana-gui/src/app/view/message.rs
+++ b/liana-gui/src/app/view/message.rs
@@ -32,7 +32,7 @@ pub enum Message {
     Previous,
     SelectHardwareWallet(usize),
     CreateRbf(CreateRbfMessage),
-    ShowQrCode(usize),
+    ShowQrCode(usize, Option<String>),
     ImportExport(ImportExportMessage),
     HideRescanWarning,
     ExportPsbt,

--- a/liana-gui/src/app/view/receive.rs
+++ b/liana-gui/src/app/view/receive.rs
@@ -37,6 +37,7 @@ use super::message::Message;
 fn address_card<'a>(
     row_index: usize,
     address: &'a bitcoin::Address,
+    maybe_bip21: Option<String>,
     labels: &'a HashMap<String, String>,
     labels_editing: &'a HashMap<String, form::Value<String>>,
 ) -> Container<'a, Message> {
@@ -83,7 +84,7 @@ fn address_card<'a>(
                     .push(Space::with_width(Length::Fill))
                     .push(
                         button::secondary(None, "Show QR Code")
-                            .on_press(Message::ShowQrCode(row_index)),
+                            .on_press(Message::ShowQrCode(row_index, maybe_bip21)),
                     ),
             )
             .spacing(10),
@@ -129,7 +130,7 @@ pub fn receive<'a>(
                     Column::new().spacing(10).width(Length::Fill),
                     |col, (i, address)| {
                         addresses_count += 1;
-                        col.push(address_card(i, address, labels, labels_editing))
+                        col.push(address_card(i, address, None, labels, labels_editing))
                     },
                 )),
         )
@@ -229,6 +230,7 @@ pub fn receive<'a>(
                         Button::new(address_card(
                             addresses_count + i,
                             address,
+                            None,
                             prev_labels,
                             labels_editing,
                         ))


### PR DESCRIPTION
This adds the scaffolding for the receiver to display bip21 QR codes when a payjoin or other bip21 receive format is required.

This is the first commit to begin support for #1806 by splitting it up into many smaller commits.  This particular commit does not require any payjoin support.