### PR TITLE
test: fix flaky test_rpc.py/test_start_rescan

### DIFF
--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1017,7 +1017,7 @@ def test_start_rescan(lianad, bitcoind):
     # First, get some coins
     for _ in range(10):
         addr = lianad.rpc.getnewaddress()["address"]
-        amount = random.randint(500, COIN * 10) / COIN
+        amount = random.randint(1, COIN * 10) / COIN
         txid = bitcoind.rpc.sendtoaddress(addr, amount)
         bitcoind.generate_block(random.randint(1, 10), wait_for_mempool=txid)
     wait_for(lambda: len(list_coins()) == 10)
@@ -1027,9 +1027,9 @@ def test_start_rescan(lianad, bitcoind):
     # without change, single or multiple inputs, sending externally or to self).
     for _ in range(5):
         addr = lianad.rpc.getnewaddress()["address"]
-        amount = random.randint(500, COIN * 10) / COIN
+        amount = random.randint(1, COIN * 10) / COIN
         txid = bitcoind.rpc.sendtoaddress(addr, amount)
-        avail = list(unspent_coins())
+        avail = list(c for c in unspent_coins() if c["amount"] > 1_000)
         to_spend = random.sample(avail, random.randint(1, len(avail)))
         spend_coins(lianad, bitcoind, to_spend)
         bitcoind.generate_block(random.randint(1, 5), wait_for_mempool=2)


### PR DESCRIPTION
This PR fixes the flaky test in `test_rpc.py`.
Coins & transactions are created with random amount in this test and some times it ended up a single input where spend with and amount > DUST but with not enough room for fees. Coins w/ value <= 1_000 sats are now sorted out from spending in this test.

Note: this PR also revert 1a888fd3155185f399fdd050992ce52fec4a627a changes