### PR TITLE
liana-gui: make installer generic

### DIFF
--- a/liana-gui/src/gui/pane.rs
+++ b/liana-gui/src/gui/pane.rs
@@ -1,14 +1,22 @@
 use iced::{Length, Subscription, Task};
 use iced_aw::ContextMenu;
 use liana_ui::{component::text::*, icon::plus_icon, theme, widget::*};
+use std::marker::PhantomData;
 
-use crate::{app, gui::Config};
+use crate::{
+    app,
+    gui::Config,
+    installer::{self},
+};
 
 use super::tab;
 
 #[derive(Debug)]
-pub enum Message {
-    Tab(usize, tab::Message),
+pub enum Message<M>
+where
+    M: Clone + Send + 'static,
+{
+    Tab(usize, tab::Message<M>),
     View(ViewMessage),
 }
 
@@ -20,39 +28,50 @@ pub enum ViewMessage {
     AddTab,
 }
 
-pub struct Pane {
-    pub tabs: Vec<tab::Tab>,
+pub struct Pane<I, M>
+where
+    I: for<'a> installer::Installer<'a, M>,
+    M: Clone + Send + 'static,
+{
+    pub tabs: Vec<tab::Tab<I, M>>,
 
     // this is an index in the tabs array
     pub focused_tab: usize,
 
     // used to generate tabs ids.
     tabs_created: usize,
+    _phantom: PhantomData<M>,
 }
 
-impl Pane {
-    pub fn new(cfg: &Config) -> (Self, Task<Message>) {
-        let (state, task) = tab::State::new(cfg.liana_directory.clone(), cfg.network);
+impl<I, M> Pane<I, M>
+where
+    M: Clone + Send + 'static,
+    I: for<'a> installer::Installer<'a, M>,
+{
+    pub fn new(cfg: &Config) -> (Self, Task<Message<M>>) {
+        let (state, task) = tab::State::<I, M>::new(cfg.liana_directory.clone(), cfg.network);
         (
             Self {
                 tabs: vec![tab::Tab::new(1, state)],
                 focused_tab: 0,
                 tabs_created: 1,
+                _phantom: PhantomData,
             },
             task.map(|msg| Message::Tab(1, msg)),
         )
     }
 
-    pub fn new_with_tab(s: tab::State) -> Self {
+    pub fn new_with_tab(s: tab::State<I, M>) -> Self {
         Self {
             tabs: vec![tab::Tab::new(1, s)],
             focused_tab: 0,
             tabs_created: 1,
+            _phantom: PhantomData,
         }
     }
 
-    fn add_tab(&mut self, cfg: &Config) -> Task<Message> {
-        let (state, task) = tab::State::new(cfg.liana_directory.clone(), cfg.network);
+    fn add_tab(&mut self, cfg: &Config) -> Task<Message<M>> {
+        let (state, task) = tab::State::<I, M>::new(cfg.liana_directory.clone(), cfg.network);
         self.tabs_created += 1;
         let id = self.tabs_created;
         self.tabs.push(tab::Tab::new(id, state));
@@ -66,7 +85,7 @@ impl Pane {
         }
     }
 
-    pub fn remove_tab(&mut self, i: usize) -> Option<tab::Tab> {
+    pub fn remove_tab(&mut self, i: usize) -> Option<tab::Tab<I, M>> {
         if i >= self.tabs.len() {
             return None;
         }
@@ -79,18 +98,19 @@ impl Pane {
         Some(tab)
     }
 
-    pub fn add_tabs(&mut self, tabs: Vec<tab::Tab>, focused_tab: usize) {
-        for tab in tabs {
+    pub fn add_tabs(&mut self, tabs: Vec<tab::Tab<I, M>>, focused_tab: usize) {
+        for mut tab in tabs {
             self.tabs_created += 1;
             let id = self.tabs_created;
-            self.tabs.push(tab::Tab::new(id, tab.state));
+            tab.id = id;
+            self.tabs.push(tab);
         }
         if self.focused_tab + focused_tab + 1 < self.tabs.len() {
             self.focused_tab += focused_tab + 1;
         }
     }
 
-    pub fn on_tick(&mut self) -> Task<Message> {
+    pub fn on_tick(&mut self) -> Task<Message<M>> {
         Task::batch(self.tabs.iter_mut().map(|t| {
             let id = t.id;
             t.on_tick().map(move |msg| Message::Tab(id, msg))
@@ -103,14 +123,14 @@ impl Pane {
         tab_id: usize,
         app_msg: impl Into<app::Message>,
         cfg: &Config,
-    ) -> Task<Message> {
+    ) -> Task<Message<M>> {
         self.update(
             Message::Tab(tab_id, tab::Message::Run(Box::new(app_msg.into()))),
             cfg,
         )
     }
 
-    pub fn update(&mut self, message: Message, cfg: &Config) -> Task<Message> {
+    pub fn update(&mut self, message: Message<M>, cfg: &Config) -> Task<Message<M>> {
         match message {
             Message::Tab(id, msg) => self
                 .tabs
@@ -134,8 +154,8 @@ impl Pane {
         }
     }
 
-    pub fn subscription(&self) -> Subscription<Message> {
-        let subs: Vec<Subscription<Message>> = self
+    pub fn subscription(&self) -> Subscription<Message<M>> {
+        let subs: Vec<Subscription<Message<M>>> = self
             .tabs
             .iter()
             .map(|t| {
@@ -151,7 +171,7 @@ impl Pane {
         self.tabs.iter_mut().for_each(|t| t.stop());
     }
 
-    pub fn tabs_menu_view(&self) -> Element<Message> {
+    pub fn tabs_menu_view(&self) -> Element<Message<M>> {
         let mut menu = Row::new().spacing(3);
         let tabs_len = self.tabs.len();
         for (i, tab) in self.tabs.iter().enumerate() {
@@ -204,7 +224,7 @@ impl Pane {
         Into::<Element<ViewMessage>>::into(menu.wrap()).map(Message::View)
     }
 
-    pub fn view(&self) -> Element<Message> {
+    pub fn view(&self) -> Element<Message<M>> {
         Container::new(if let Some(t) = self.tabs.get(self.focused_tab) {
             let id = t.id;
             t.view().map(move |msg| Message::Tab(id, msg))

--- a/liana-gui/src/installer/step/mod.rs
+++ b/liana-gui/src/installer/step/mod.rs
@@ -32,6 +32,7 @@ use liana_ui::widget::*;
 
 use crate::{
     app::settings::{ProviderKey, WalletSettings},
+    backup::Backup,
     hw::HardwareWallets,
     installer::{context::Context, message::Message, view},
     node::bitcoind::Bitcoind,
@@ -72,6 +73,7 @@ pub struct Final {
     warning: Option<String>,
     wallet_settings: Option<WalletSettings>,
     key_redemptions: HashMap<ProviderKey, Option<Result<(), services::keys::Error>>>,
+    backup: Option<Backup>,
 }
 
 impl Final {
@@ -82,6 +84,7 @@ impl Final {
             warning: None,
             wallet_settings: None,
             key_redemptions: HashMap::new(),
+            backup: None,
         }
     }
 }
@@ -95,6 +98,7 @@ impl Default for Final {
 impl Step for Final {
     fn load_context(&mut self, ctx: &Context) {
         self.internal_bitcoind.clone_from(&ctx.internal_bitcoind);
+        self.backup.clone_from(&ctx.backup);
         self.key_redemptions = ctx
             .keys
             .values()

--- a/liana-gui/src/loader.rs
+++ b/liana-gui/src/loader.rs
@@ -55,6 +55,7 @@ type StartedResult = Result<
     Error,
 >;
 
+#[derive(Debug)]
 pub struct Loader {
     pub datadir_path: LianaDirectory,
     pub network: bitcoin::Network,
@@ -67,6 +68,7 @@ pub struct Loader {
     step: Step,
 }
 
+#[derive(Debug)]
 pub enum Step {
     Connecting,
     StartingDaemon,

--- a/liana-gui/src/main.rs
+++ b/liana-gui/src/main.rs
@@ -16,7 +16,7 @@ use liana_ui::{component::text, font, image, theme};
 use liana_gui::{
     app::settings::global::{GlobalSettings, WindowConfig},
     dir::LianaDirectory,
-    gui::{Config, GUI},
+    gui::{Config, LianaGUI},
     node::bitcoind::delete_all_bitcoind_locks_for_process,
     VERSION,
 };
@@ -137,13 +137,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         };
     }
 
-    if let Err(e) = iced::application(GUI::title, GUI::update, GUI::view)
+    if let Err(e) = iced::application(LianaGUI::title, LianaGUI::update, LianaGUI::view)
         .theme(|_| theme::Theme::default())
-        .scale_factor(GUI::scale_factor)
-        .subscription(GUI::subscription)
+        .scale_factor(LianaGUI::scale_factor)
+        .subscription(LianaGUI::subscription)
         .settings(settings)
         .window(window_settings)
-        .run_with(move || GUI::new((config, log_level)))
+        .run_with(move || LianaGUI::new((config, log_level)))
     {
         log::error!("{}", e);
         Err(format!("Failed to launch UI: {}", e).into())

--- a/liana-gui/src/services/connect/login.rs
+++ b/liana-gui/src/services/connect/login.rs
@@ -109,6 +109,7 @@ pub enum BackendState {
     WalletExists(BackendWalletClient, api::Wallet, ListCoinsResult),
 }
 
+#[derive(Debug, Clone)]
 pub struct LianaLiteLogin {
     pub datadir: LianaDirectory,
     pub network: Network,
@@ -126,6 +127,7 @@ pub struct LianaLiteLogin {
     auth_error: Option<&'static str>,
 }
 
+#[derive(Debug, Clone)]
 pub enum ConnectionStep {
     CheckingAuthFile,
     CheckEmail,

--- a/liana-ui/src/component/collapse.rs
+++ b/liana-ui/src/component/collapse.rs
@@ -20,7 +20,7 @@ where
     Renderer: advanced::Renderer,
     Theme: iced::widget::button::Catalog,
     Message: 'a,
-    T: Into<Message> + Clone + 'a,
+    T: Into<Message> + Clone + 'a + From<Message>,
     H: Fn() -> Button<'a, Event<T>, Theme, Renderer> + 'a,
     F: Fn() -> Button<'a, Event<T>, Theme, Renderer> + 'a,
     C: Fn() -> Element<'a, T, Theme, Renderer> + 'a,
@@ -50,7 +50,7 @@ pub enum Event<T> {
 impl<'a, Message, T, H, F, C, Theme, Renderer> Component<Message, Theme, Renderer>
     for Collapse<'a, Message, H, F, C>
 where
-    T: Into<Message> + Clone + 'a,
+    T: Into<Message> + Clone + 'a + From<Message>,
     H: Fn() -> Button<'a, Event<T>, Theme, Renderer>,
     F: Fn() -> Button<'a, Event<T>, Theme, Renderer>,
     C: Fn() -> Element<'a, T, Theme, Renderer>,
@@ -99,7 +99,7 @@ where
     Message: 'a,
     Renderer: 'a + advanced::Renderer,
     Theme: 'a + iced::widget::button::Catalog,
-    T: Into<Message> + Clone + 'a,
+    T: Into<Message> + Clone + 'a + From<Message>,
     H: Fn() -> Button<'a, Event<T>, Theme, Renderer>,
     F: Fn() -> Button<'a, Event<T>, Theme, Renderer>,
     C: Fn() -> Element<'a, T, Theme, Renderer>,


### PR DESCRIPTION
This PR add an `Installer` trait and move the actual liana install behind it, in order to easily add installer variants in the future.