### PR TITLE
fix wording for coin expiration status

### DIFF
--- a/liana-gui/src/app/view/coins.rs
+++ b/liana-gui/src/app/view/coins.rs
@@ -156,12 +156,12 @@ fn coin_list_view<'a>(
                             if let Some(b) = coin.block_height {
                                 if blockheight > b as u32 + timelock as u32 {
                                     Some(Container::new(
-                                        p1_bold("One of the recovery path is available")
+                                        p1_bold("One or more recovery paths are available")
                                             .style(theme::text::error),
                                     ))
                                 } else {
                                     Some(Container::new(p1_bold(format!(
-                                        "One of the recovery path will be available in {} blocks",
+                                        "First recovery path will be available in {} blocks",
                                         b as u32 + timelock as u32 - blockheight
                                     ))))
                                 }


### PR DESCRIPTION
This fixes some wording on the Coins tab about whether any recovery paths are available.

The previous "One of the recovery path is ..." has been changed to:
- "One or more recovery paths are available"
- "First recovery path will be available in {} blocks"

We don't currently have information in this tab about the number of recovery paths and so I kept the wording general.

<img width="1737" height="412" alt="image" src="https://github.com/user-attachments/assets/f15d36d0-933d-45e5-a3e3-8983cc79e753" />

<img width="1737" height="412" alt="image" src="https://github.com/user-attachments/assets/e55d4fe4-9566-404b-815f-d89016deea6e" />
