### PR TITLE
show pasted value in btc amount form even if invalid

### DIFF
--- a/liana-gui/src/app/state/spend/step.rs
+++ b/liana-gui/src/app/state/spend/step.rs
@@ -969,6 +969,7 @@ impl Recipient {
                 }
             }
             view::CreateSpendMessage::RecipientFiatAmountEdited(_, fiat_amt_str, converter) => {
+                self.amount.warning = None; // Clear any warning on the BTC amount as it is no longer the last edited field.
                 self.fiat_converter = Some(converter);
                 if fiat_amt_str.is_empty() {
                     self.fiat_amount = Some(form::Value::default());
@@ -1016,7 +1017,25 @@ impl Recipient {
             view::CreateSpendMessage::RecipientEdited(_, "amount", amount) => {
                 self.fiat_amount = None; // Clear any fiat amount to indicate BTC amount is now primary.
                 self.fiat_converter = None;
-                self.amount.value = amount;
+                self.amount.warning = None;
+
+                // If a float has been passed with more than 8 decimal places, and truncating it
+                // to 8 decimal places would result in a valid BTC amount, we truncate it and show a warning.
+                // This can only happen if the user pastes an amount, as the input only allows up to 8 decimal places.
+                // Otherwise, keep the full string value.
+                self.amount.value = f64::from_str(&amount)
+                    .ok()
+                    .and_then(|_| amount.split_once('.'))
+                    .filter(|(_, fraction)| fraction.len() > 8)
+                    .map(|(integer, fraction)| format!("{}.{}", integer, &fraction[..8]))
+                    .filter(|truncated| {
+                        Amount::from_str_in(truncated, Denomination::Bitcoin).is_ok()
+                    })
+                    .inspect(|_| {
+                        self.amount.warning = Some("Amount has been truncated to 8 decimal places");
+                    })
+                    .unwrap_or(amount);
+
                 if !self.amount.value.is_empty() {
                     self.amount.valid = self.amount().is_ok();
                 } else {

--- a/liana-gui/src/app/view/spend/mod.rs
+++ b/liana-gui/src/app/view/spend/mod.rs
@@ -514,10 +514,19 @@ pub fn recipient_view<'a>(
         .push_maybe(fiat_price)
         .push_maybe(max)
         .width(Length::Fill);
-    let dust_warning_row = Row::new()
-        .push(Space::with_width(20))
-        .push_maybe(dust_warning.as_ref().map(|w| caption(w).color(color::RED)));
-    let amount_col = column![amount_row, dust_warning_row];
+    // Show dust warning, if any, or otherwise any amount warning.
+    let amount_warning_row = Row::new().push(Space::with_width(20)).push_maybe(
+        dust_warning
+            .as_ref()
+            .map(|w| caption(w).color(color::RED))
+            .or_else(|| {
+                amount
+                    .warning
+                    .as_ref()
+                    .map(|w| caption(w).color(color::ORANGE))
+            }),
+    );
+    let amount_col = column![amount_row, amount_warning_row];
 
     Container::new(
         Column::new()

--- a/liana-ui/src/component/form.rs
+++ b/liana-ui/src/component/form.rs
@@ -87,16 +87,30 @@ where
     /// - a function that produces a message when the [`Form`] changes
     pub fn new_amount_btc<F>(placeholder: &str, value: &'a Value<String>, on_change: F) -> Self
     where
-        F: 'static + Fn(String) -> Message,
+        F: 'static + Fn(String) -> Message + Clone,
     {
+        let on_change_clone = on_change.clone();
         Self {
-            input: text_input::TextInput::new(placeholder, &value.value).on_input(move |s| {
-                if bitcoin::Amount::from_str_in(&s, Denomination::Bitcoin).is_ok() || s.is_empty() {
-                    on_change(s)
-                } else {
-                    on_change(value.value.clone())
-                }
-            }),
+            input: text_input::TextInput::new(placeholder, &value.value)
+                .on_input(move |s| {
+                    if bitcoin::Amount::from_str_in(&s, Denomination::Bitcoin).is_ok()
+                        || s.is_empty()
+                        // In order to allow the user to fix an invalid pasted value, we allow deletion
+                        // even if the result is still invalid.
+                        // Note that all invalid characters must be deleted before the user can enter
+                        // new valid values.
+                        || s.chars().count() < value.value.chars().count()
+                    {
+                        on_change(s)
+                    } else {
+                        on_change(value.value.clone())
+                    }
+                })
+                .on_paste(move |pasted| {
+                    // Keep the entire pasted content and perform any required checks or modifications
+                    // in the on_change message handler.
+                    on_change_clone(pasted)
+                }),
             warning: value.warning,
             valid: value.valid,
         }


### PR DESCRIPTION
This implements #1963 for BTC input values.

The validation on BTC input values performed by https://github.com/wizardsardine/liana/issues/798 will be skipped:
- for pasted values, so the whole pasted value will be inserted
- if the current value is invalid (i.e. an invalid value has been pasted), which will then allow the user to manually edit the pasted value until it is valid

This PR doesn't change the paste behaviour for the fiat value input field.


