### PR TITLE
business-installer: uses theme::accent for email (blue)

### DIFF
--- a/liana-business/business-installer/src/views/keys/mod.rs
+++ b/liana-business/business-installer/src/views/keys/mod.rs
@@ -76,7 +76,7 @@ fn key_card(
     // Identity (optional - display email or other identity)
     let identity_str = key.identity.to_string();
     let identity_display = (!identity_str.is_empty())
-        .then(|| text::p2_medium(identity_str).style(theme::text::primary));
+        .then(|| text::p2_medium(identity_str).style(theme::text::accent));
 
     // Key type badge
     let key_type_str = format!("{:?}", key.key_type);

--- a/liana-business/business-installer/src/views/login/code.rs
+++ b/liana-business/business-installer/src/views/login/code.rs
@@ -7,7 +7,6 @@ use iced::{
     Length,
 };
 use liana_ui::{
-    color,
     component::{button, form, text},
     icon, theme,
     widget::*,
@@ -50,7 +49,7 @@ pub fn login_code_view(state: &State) -> Element<'_, Msg> {
         .push(row![
             text::p1_medium("An authentication token has been emailed to ")
                 .style(theme::text::primary),
-            text::p1_medium(&state.views.login.email.form.value).color(color::DARK_GREEN)
+            text::p1_medium(&state.views.login.email.form.value).style(theme::text::accent)
         ])
         .push(form)
         .push(btn_row)

--- a/liana-business/business-installer/src/views/xpub/view.rs
+++ b/liana-business/business-installer/src/views/xpub/view.rs
@@ -53,7 +53,7 @@ fn xpub_key_card(
         .align_y(Alignment::Center)
         .push(icon::key_icon())
         .push(text::p1_medium(&key.alias).style(theme::text::primary))
-        .push(text::p1_medium(identity_str).style(theme::text::primary))
+        .push(text::p1_medium(identity_str).style(theme::text::accent))
         .push(Space::with_width(Length::Fill))
         .push(xpub_status_badge(key.xpub.is_some()));
 


### PR DESCRIPTION
closes #1997

<img width="1614" height="661" alt="image" src="https://github.com/user-attachments/assets/a3d8b51d-8c25-4e2f-8c23-45d1705c9cc2" />

<img width="1739" height="525" alt="image" src="https://github.com/user-attachments/assets/c73258e5-bc1b-4931-b26a-eba419fd7c68" />

<img width="1663" height="709" alt="image" src="https://github.com/user-attachments/assets/52ae1366-c4da-4a5a-a340-eb46c95f52a4" />


