### PR TITLE
business-installer: add a wallet loading view

### DIFF
--- a/liana-business/business-installer/src/state/mod.rs
+++ b/liana-business/business-installer/src/state/mod.rs
@@ -3,8 +3,8 @@ use crate::{
     client::Client,
     state::app::AppState,
     views::{
-        keys_view, login_view, modals, org_select_view, registration_view, template_builder_view,
-        wallet_select_view, xpub_view,
+        keys_view, loading_view, login_view, modals, org_select_view, registration_view,
+        template_builder_view, wallet_select_view, xpub_view,
     },
 };
 use async_hwi::{bitbox::NoiseConfig, service::HwiService};
@@ -38,6 +38,7 @@ pub enum View {
     Xpub,
     Keys,
     Registration,
+    Loading,
 }
 
 /// Main application state
@@ -160,6 +161,7 @@ impl State {
             View::Xpub => xpub_view(self),
             View::Keys => keys_view(self),
             View::Registration => registration_view(self),
+            View::Loading => loading_view(),
         };
 
         // Overlay modals if any are open

--- a/liana-business/business-installer/src/state/update.rs
+++ b/liana-business/business-installer/src/state/update.rs
@@ -356,7 +356,8 @@ impl State {
             }
             Some(WalletStatus::Finalized) => {
                 // Final -> Signal exit to Wallet GUI
-                // Return Task::done to generate a follow-up message that triggers exit_maybe
+                // Show loading view before exiting
+                self.current_view = View::Loading;
                 self.app.exit = true;
                 return Task::done(Msg::Update);
             }
@@ -865,6 +866,10 @@ impl State {
                 self.current_view = View::WalletSelect;
                 Task::none()
             }
+            View::Loading => {
+                // Cannot navigate back from loading state
+                Task::none()
+            }
         }
     }
 }
@@ -1187,7 +1192,8 @@ impl State {
                 self.stop_hw();
 
                 // Signal exit to open the main wallet application
-                // Return Task::done to generate a follow-up message that triggers exit_maybe
+                // Show loading view before exiting
+                self.current_view = View::Loading;
                 self.app.exit = true;
                 return Task::done(Msg::Update);
             } else {
@@ -1239,7 +1245,8 @@ impl State {
                     }
 
                     // Signal exit to open the main wallet application
-                    // Return Task::done to generate a follow-up message that triggers exit_maybe
+                    // Show loading view before exiting
+                    self.current_view = View::Loading;
                     self.app.exit = true;
                     return Task::done(Msg::Update);
                 }

--- a/liana-business/business-installer/src/views/loading.rs
+++ b/liana-business/business-installer/src/views/loading.rs
@@ -1,0 +1,25 @@
+use crate::state::message::Msg;
+use iced::{Alignment, Length};
+use liana_ui::{component::text, theme, widget::*};
+
+use super::layout;
+
+/// Loading view shown during wallet opening transition
+pub fn loading_view() -> Element<'static, Msg> {
+    layout(
+        (0, 0),
+        None,
+        None,
+        &[],
+        Container::new(
+            Column::new()
+                .spacing(30)
+                .align_x(Alignment::Center)
+                .width(Length::Fill)
+                .push(text::h2("Liana Business"))
+                .push(text::p1_medium("Loading wallet...").style(theme::text::secondary)),
+        ),
+        true,
+        None,
+    )
+}

--- a/liana-business/business-installer/src/views/mod.rs
+++ b/liana-business/business-installer/src/views/mod.rs
@@ -1,4 +1,5 @@
 pub mod keys;
+pub mod loading;
 pub mod login;
 pub mod modals;
 pub mod org_select;
@@ -9,6 +10,7 @@ pub mod wallet_select;
 pub mod xpub;
 
 pub use keys::keys_view;
+pub use loading::loading_view;
 pub use login::login_view;
 pub use org_select::org_select_view;
 pub use registration::registration_view;


### PR DESCRIPTION
This PR add a "Loading wallet.." view when a wallet is loading

<img width="1874" height="1051" alt="image" src="https://github.com/user-attachments/assets/130764a2-714e-48f2-8bb4-28b4e3203421" />
