### PR TITLE
business-installer: fix paste xpub

### DIFF
--- a/liana-business/business-installer/src/state/message.rs
+++ b/liana-business/business-installer/src/state/message.rs
@@ -87,6 +87,7 @@ pub enum Msg {
     XpubRetry,                                                  // Retry fetch after error
     XpubLoadFromFile,                                           // Trigger file picker
     XpubFileLoaded(Result<(String, String), String>),           // (content, filename) or error
+    XpubSelectEnterXpub,                                        // Expand paste xpub card
     XpubPaste,                                                  // Trigger paste from clipboard
     XpubPasted(String),                                         // Xpub pasted from clipboard
     XpubUpdateAccount(miniscript::bitcoin::bip32::ChildNumber), // Change account (triggers re-fetch)

--- a/liana-business/business-installer/src/state/update.rs
+++ b/liana-business/business-installer/src/state/update.rs
@@ -104,6 +104,7 @@ impl State {
             Msg::XpubRetry => return self.on_xpub_retry(),
             Msg::XpubLoadFromFile => return self.on_xpub_load_from_file(),
             Msg::XpubFileLoaded(result) => self.on_xpub_file_loaded(result),
+            Msg::XpubSelectEnterXpub => self.on_xpub_select_enter_xpub(),
             Msg::XpubPaste => return self.on_xpub_paste(),
             Msg::XpubPasted(xpub) => self.on_xpub_pasted(xpub),
             Msg::XpubUpdateAccount(account) => return self.on_xpub_update_account(account),
@@ -1623,7 +1624,10 @@ impl State {
     /// Update xpub input text
     fn on_xpub_update_input(&mut self, input: String) {
         if let Some(modal) = self.views.xpub.modal_mut() {
+            modal.form_xpub.value = input.clone();
             modal.update_input(input);
+            modal.form_xpub.valid = modal.validate().is_ok();
+            modal.input_source = Some(views::XpubInputSource::Pasted);
         }
     }
 
@@ -1809,6 +1813,13 @@ impl State {
         }
     }
 
+    /// Expand the paste xpub card
+    fn on_xpub_select_enter_xpub(&mut self) {
+        if let Some(modal) = self.views.xpub.modal_mut() {
+            modal.paste_expanded = true;
+        }
+    }
+
     /// Handle paste xpub from clipboard
     fn on_xpub_paste(&mut self) -> Task<Msg> {
         use iced::clipboard;
@@ -1833,6 +1844,8 @@ impl State {
     fn on_xpub_pasted(&mut self, xpub: String) {
         debug!(source = "pasted", "Xpub pasted from clipboard");
         if let Some(modal) = self.views.xpub.modal_mut() {
+            modal.form_xpub.value = xpub.clone();
+            modal.form_xpub.valid = modal.validate().is_ok();
             modal.update_input(xpub);
             modal.input_source = Some(views::XpubInputSource::Pasted);
         }

--- a/liana-business/business-installer/src/state/views/xpub/mod.rs
+++ b/liana-business/business-installer/src/state/views/xpub/mod.rs
@@ -60,6 +60,11 @@ pub struct XpubEntryModalState {
 
     /// Actual source of the current xpub input (for audit)
     pub input_source: Option<XpubInputSource>,
+
+    /// Whether the paste xpub card is expanded (showing input + paste button)
+    pub paste_expanded: bool,
+    /// Form value for the paste xpub input field (with validation state)
+    pub form_xpub: liana_ui::component::form::Value<String>,
 }
 
 impl XpubEntryModalState {
@@ -90,6 +95,8 @@ impl XpubEntryModalState {
             fetch_error: None,
             network,
             input_source: None,
+            paste_expanded: false,
+            form_xpub: liana_ui::component::form::Value::default(),
         }
     }
 


### PR DESCRIPTION
This PR do 2 things:
- restrict paste xpub to WalletManager only
- add an input field so the user can see what is pasted

<img width="779" height="740" alt="image" src="https://github.com/user-attachments/assets/c11ef302-c187-4971-9fec-a736344972ce" />

closes #2018 