### PR TITLE
business-installer: use new key cards for select key source

### DIFF
--- a/liana-business/business-installer/src/state/message.rs
+++ b/liana-business/business-installer/src/state/message.rs
@@ -87,6 +87,7 @@ pub enum Msg {
     XpubRetry,                                                  // Retry fetch after error
     XpubLoadFromFile,                                           // Trigger file picker
     XpubFileLoaded(Result<(String, String), String>),           // (content, filename) or error
+    XpubSelectPaste,                                            // Toggle paste input expanded
     XpubPaste,                                                  // Trigger paste from clipboard
     XpubPasted(String),                                         // Xpub pasted from clipboard
     XpubUpdateAccount(miniscript::bitcoin::bip32::ChildNumber), // Change account (triggers re-fetch)

--- a/liana-business/business-installer/src/state/update.rs
+++ b/liana-business/business-installer/src/state/update.rs
@@ -104,6 +104,7 @@ impl State {
             Msg::XpubRetry => return self.on_xpub_retry(),
             Msg::XpubLoadFromFile => return self.on_xpub_load_from_file(),
             Msg::XpubFileLoaded(result) => self.on_xpub_file_loaded(result),
+            Msg::XpubSelectPaste => self.on_xpub_select_paste(),
             Msg::XpubPaste => return self.on_xpub_paste(),
             Msg::XpubPasted(xpub) => self.on_xpub_pasted(xpub),
             Msg::XpubUpdateAccount(account) => return self.on_xpub_update_account(account),
@@ -1956,6 +1957,16 @@ impl State {
     fn on_xpub_toggle_options(&mut self) {
         if let Some(modal) = self.views.xpub.modal_mut() {
             modal.options_collapsed = !modal.options_collapsed;
+        }
+    }
+
+    fn on_xpub_select_paste(&mut self) {
+        if let Some(modal) = self.views.xpub.modal_mut() {
+            modal.paste_expanded = !modal.paste_expanded;
+            if modal.paste_expanded {
+                modal.xpub_input.clear();
+                modal.input_source = None;
+            }
         }
     }
 

--- a/liana-business/business-installer/src/state/views/xpub/mod.rs
+++ b/liana-business/business-installer/src/state/views/xpub/mod.rs
@@ -49,6 +49,8 @@ pub struct XpubEntryModalState {
 
     /// Whether the "Other options" section is collapsed
     pub options_collapsed: bool,
+    /// Whether the "Paste extended public key" input is expanded
+    pub paste_expanded: bool,
 
     /// Current modal step (Select device or Details)
     pub step: ModalStep,
@@ -86,6 +88,7 @@ impl XpubEntryModalState {
             selected_account: ChildNumber::from_hardened_idx(0)
                 .expect("hardcoded valid account index"),
             options_collapsed: true, // Start with options collapsed
+            paste_expanded: false,
             step: ModalStep::default(),
             fetch_error: None,
             network,

--- a/liana-business/business-installer/src/views/xpub/modal.rs
+++ b/liana-business/business-installer/src/views/xpub/modal.rs
@@ -11,7 +11,7 @@ use iced::{
 use liana_gui::hw::{is_compatible_with_tapminiscript, min_taproot_version, UnsupportedReason};
 use liana_ui::{
     component::{
-        button, card, hw,
+        button, card, form, modal,
         text::{self, p1_bold},
         tooltip,
     },
@@ -19,6 +19,17 @@ use liana_ui::{
     widget::*,
 };
 use miniscript::bitcoin::bip32::ChildNumber;
+
+type FnMsg = fn() -> Msg;
+
+/// Capitalize the first letter of a string
+fn capitalize_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+    }
+}
 
 /// Render the xpub entry modal if it's open
 pub fn xpub_modal_view(state: &State) -> Option<Element<'_, Msg>> {
@@ -31,19 +42,11 @@ pub fn xpub_modal_view(state: &State) -> Option<Element<'_, Msg>> {
 
 /// Render the Select view - shows device list and other options
 fn select_view<'a>(state: &'a State, modal_state: &'a XpubEntryModalState) -> Element<'a, Msg> {
-    // Header with title and close button
-    let header = Row::new()
-        .spacing(10)
-        .align_y(Alignment::Center)
-        .push(text::h3(format!(
-            "Select key source - {}",
-            modal_state.key_alias
-        )))
-        .push(Space::with_width(Length::Fill))
-        .push(
-            button::transparent(Some(icon::cross_icon().size(32)), "")
-                .on_press(Msg::XpubCancelModal),
-        );
+    let header = modal::header(
+        Some(format!("Select key source - {}", modal_state.key_alias)),
+        None::<FnMsg>,
+        Some(|| Msg::XpubCancelModal),
+    );
 
     // Show current xpub status if one exists
     let xpub_status = modal_state.current_xpub.is_some().then_some(
@@ -104,25 +107,19 @@ fn select_view<'a>(state: &'a State, modal_state: &'a XpubEntryModalState) -> El
         .push_maybe(validation_error)
         .push(footer_buttons(modal_state))
         .spacing(15)
-        .padding(20.0)
-        .width(Length::Fixed(600.0));
+        .align_x(Alignment::Center)
+        .width(modal::MODAL_WIDTH);
 
     card::modal(content).into()
 }
 
 /// Render the Details view - shows account picker and fetch status
 fn details_view(modal_state: &XpubEntryModalState) -> Element<'_, Msg> {
-    // Header with back button and close button
-    let header = Row::new()
-        .spacing(10)
-        .align_y(Alignment::Center)
-        .push(button::transparent(Some(icon::previous_icon()), "").on_press(Msg::XpubDeviceBack))
-        .push(text::h3(&modal_state.key_alias))
-        .push(Space::with_width(Length::Fill))
-        .push(
-            button::transparent(Some(icon::cross_icon().size(32)), "")
-                .on_press(Msg::XpubCancelModal),
-        );
+    let header = modal::header(
+        Some(modal_state.key_alias.clone()),
+        Some(|| Msg::XpubDeviceBack),
+        Some(|| Msg::XpubCancelModal),
+    );
 
     // Account selection picker
     let accounts: Vec<_> = (0..10)
@@ -280,6 +277,7 @@ fn hw_section(state: &State) -> Element<'_, Msg> {
 /// Extracted device data for rendering (avoids lifetime issues with local BTreeMap)
 struct DeviceRenderData {
     kind: async_hwi::DeviceKind,
+    version: Option<async_hwi::Version>,
     fingerprint: Option<miniscript::bitcoin::bip32::Fingerprint>,
     state: DeviceState,
 }
@@ -290,7 +288,6 @@ enum DeviceState {
         pairing_code: Option<String>,
     },
     Unsupported {
-        version: Option<async_hwi::Version>,
         reason: UnsupportedReason,
     },
 }
@@ -298,54 +295,66 @@ enum DeviceState {
 /// Render a device card based on its state (Supported, Locked, or Unsupported)
 /// Clicking a supported device opens the Details step
 fn device_card(data: DeviceRenderData) -> Element<'static, Msg> {
-    let kind = data.kind;
+    let kind_name = capitalize_first(&data.kind.to_string());
+    let name = match &data.version {
+        Some(v) => format!("{kind_name} {v}"),
+        None => kind_name,
+    };
 
     match data.state {
         DeviceState::Supported => {
             let fp = data.fingerprint.expect("supported device has fingerprint");
-
-            // Build the device card content using liana-ui hw component
-            let card_content = hw::supported_hardware_wallet(kind, None::<&str>, fp, None::<&str>);
-
-            // Wrap in a button - clicking opens Details step
-            Button::new(card_content)
-                .style(theme::button::secondary)
-                .width(Length::Fill)
-                .on_press(Msg::XpubSelectDevice(fp))
-                .into()
+            modal::key_entry(
+                Some(icon::usb_drive_icon()),
+                name,
+                Some(format!("#{fp}")),
+                None,
+                None,
+                None,
+                Some(move || Msg::XpubSelectDevice(fp)),
+            )
         }
         DeviceState::Locked { pairing_code } => {
-            // Locked device - show as locked, not clickable
-            let card_content = hw::locked_hardware_wallet(kind, pairing_code);
-
-            Button::new(card_content)
-                .style(theme::button::secondary)
-                .width(Length::Fill)
-                .into()
+            let message = match pairing_code {
+                Some(code) => format!("Locked, check code: {code}"),
+                None => "Please unlock the device".to_string(),
+            };
+            modal::key_entry(
+                Some(icon::usb_drive_icon()),
+                name,
+                None,
+                None,
+                None,
+                Some(message),
+                None::<fn() -> Msg>,
+            )
         }
-        DeviceState::Unsupported { version, reason } => {
-            // Unsupported device - show appropriate message based on reason
-            let card_content: Container<'_, Msg> = match &reason {
+        DeviceState::Unsupported { reason } => {
+            let message = match &reason {
                 UnsupportedReason::NotPartOfWallet(fg) => {
-                    hw::unrelated_hardware_wallet(kind, version.as_ref(), fg)
+                    format!("Not part of this wallet (#{fg})")
                 }
                 UnsupportedReason::WrongNetwork => {
-                    hw::wrong_network_hardware_wallet(kind, version.as_ref())
+                    "Wrong network in device settings".to_string()
                 }
                 UnsupportedReason::Version {
                     minimal_supported_version,
-                } => hw::unsupported_version_hardware_wallet(
-                    kind,
-                    version.as_ref(),
-                    minimal_supported_version,
-                ),
-                _ => hw::unsupported_hardware_wallet(kind, version.as_ref()),
+                } => {
+                    format!("Unsupported firmware, upgrade to > {minimal_supported_version}")
+                }
+                UnsupportedReason::Method(m) => format!("Unsupported method: {m}"),
+                UnsupportedReason::AppIsNotOpen => "Please open the app on device".to_string(),
             };
-
-            Button::new(card_content)
-                .style(theme::button::secondary)
-                .width(Length::Fill)
-                .into()
+            let fp_str = data.fingerprint.map(|fp| format!("#{fp}"));
+            modal::key_entry(
+                Some(icon::usb_drive_icon()),
+                name,
+                fp_str,
+                None,
+                None,
+                Some(message),
+                None::<fn() -> Msg>,
+            )
         }
     }
 }
@@ -371,35 +380,44 @@ fn extract_device_data(device: &SigningDevice<Msg>) -> DeviceRenderData {
         }
     }
 
-    let state = match device {
+    let (version, state) = match device {
         SigningDevice::Supported(hw) => {
+            let version = hw.version().cloned();
             if is_compatible_with_tapminiscript(hw.kind(), hw.version()) {
-                DeviceState::Supported
+                (version, DeviceState::Supported)
             } else {
                 let minimal_supported_version = min_taproot_version(hw.kind())
                     .map(|v| v.to_string())
                     .unwrap_or_default();
-                DeviceState::Unsupported {
-                    version: hw.version().cloned(),
-                    reason: UnsupportedReason::Version {
-                        minimal_supported_version,
+                (
+                    version,
+                    DeviceState::Unsupported {
+                        reason: UnsupportedReason::Version {
+                            minimal_supported_version,
+                        },
                     },
-                }
+                )
             }
         }
-        SigningDevice::Locked { pairing_code, .. } => DeviceState::Locked {
-            pairing_code: pairing_code.clone(),
-        },
+        SigningDevice::Locked { pairing_code, .. } => (
+            None,
+            DeviceState::Locked {
+                pairing_code: pairing_code.clone(),
+            },
+        ),
         SigningDevice::Unsupported {
             version, reason, ..
-        } => DeviceState::Unsupported {
-            version: version.clone(),
-            reason: translate_reason(reason),
-        },
+        } => (
+            version.clone(),
+            DeviceState::Unsupported {
+                reason: translate_reason(reason),
+            },
+        ),
     };
 
     DeviceRenderData {
         kind: *kind,
+        version,
         fingerprint,
         state,
     }
@@ -407,35 +425,51 @@ fn extract_device_data(device: &SigningDevice<Msg>) -> DeviceRenderData {
 
 /// Render the "Other options" collapsible section
 fn other_options(modal_state: &XpubEntryModalState) -> Element<'_, Msg> {
-    // Collapsible header button
-    let header_text = if modal_state.options_collapsed {
-        "Other options ▼"
-    } else {
-        "Other options ▲"
-    };
-    let header_btn = button::transparent(None, header_text).on_press(Msg::XpubToggleOptions);
+    let collapsed = modal_state.options_collapsed;
 
-    let expanded_content = (!modal_state.options_collapsed).then(|| {
-        let file_button =
-            button::secondary(Some(icon::import_icon()), "Import extended public key file")
-                .on_press(Msg::XpubLoadFromFile)
-                .width(Length::Fill);
+    let section_header = modal::optional_section(
+        collapsed,
+        "Other options".to_string(),
+        || Msg::XpubToggleOptions,
+        || Msg::XpubToggleOptions,
+    );
 
-        let paste_button =
-            button::secondary(Some(icon::clipboard_icon()), "Paste extended public key")
-                .on_press(Msg::XpubPaste)
-                .width(Length::Fill);
+    let expanded_content = (!collapsed).then(|| {
+        let file_button: Element<'_, Msg> = modal::button_entry(
+            Some(icon::import_icon()),
+            "Import extended public key file",
+            None,
+            None,
+            Some(|| Msg::XpubLoadFromFile),
+        );
+
+        let form_xpub = form::Value {
+            value: modal_state.xpub_input.clone(),
+            warning: None,
+            valid: true,
+        };
+        let paste_input: Element<'_, Msg> = modal::collapsible_input_button(
+            modal_state.paste_expanded,
+            Some(icon::paste_icon()),
+            "Paste an extended public key".to_string(),
+            "xpub...".to_string(),
+            &form_xpub,
+            Some(Msg::XpubUpdateInput),
+            Some(|| Msg::XpubPaste),
+            || Msg::XpubSelectPaste,
+        );
 
         Column::new()
-            .spacing(10)
+            .spacing(modal::V_SPACING)
             .push(file_button)
-            .push(paste_button)
+            .push(paste_input)
     });
 
     Column::new()
-        .spacing(10)
-        .push(header_btn)
+        .spacing(modal::V_SPACING)
+        .push(section_header)
         .push_maybe(expanded_content)
+        .width(modal::BTN_W)
         .into()
 }
 

--- a/liana-ui/src/component/modal.rs
+++ b/liana-ui/src/component/modal.rs
@@ -108,8 +108,7 @@ where
         form::Form::new_disabled(&input_placeholder, input_value)
     }
     .padding(10);
-    let paste =
-        paste_message.map(|m| Button::new(icon::paste_icon()).on_press(m()));
+    let paste = paste_message.map(|m| Button::new(icon::paste_icon()).on_press(m()));
 
     if collapsed {
         let icon = icon.map(|i| i.style(theme::text::primary));

--- a/liana-ui/src/component/modal.rs
+++ b/liana-ui/src/component/modal.rs
@@ -109,15 +109,14 @@ where
     }
     .padding(10);
     let paste =
-        paste_message.map(|m| Button::new(icon::paste_icon().color(color::BLACK)).on_press(m()));
-
-    let icon = icon.map(|i| i.color(color::WHITE));
+        paste_message.map(|m| Button::new(icon::paste_icon()).on_press(m()));
 
     if collapsed {
+        let icon = icon.map(|i| i.style(theme::text::primary));
         let line = Row::new().push(form).push_maybe(paste).spacing(V_SPACING);
         let col = Column::new()
             .push(row![
-                text::p1_regular(label).color(color::WHITE),
+                text::p1_regular(label).style(theme::text::primary),
                 Space::with_width(Length::Fill)
             ])
             .push(line);


### PR DESCRIPTION
this PR do 2 things:
- uses same key card than liana-gui installer rather than legacy ones
- restrict paste xpub to WalletManager roles

<img width="773" height="658" alt="image" src="https://github.com/user-attachments/assets/f3136fee-dcd4-44ce-bbfc-c312a3a8e7e0" />

closes #1979
closes #2018