### PR TITLE
liana-business: make mainnet default network, signet via ENV var

### DIFF
--- a/liana-business/business-installer/src/installer.rs
+++ b/liana-business/business-installer/src/installer.rs
@@ -26,6 +26,26 @@ pub struct BusinessInstaller {
 
 impl BusinessInstaller {
     fn new(datadir: LianaDirectory, network: bitcoin::Network) -> (Self, Task<Message>) {
+        // Log if signet mode is enabled via LIANA_BUSINESS_SIGNET env var
+        if network != bitcoin::Network::Bitcoin {
+            tracing::info!(
+                "LIANA_BUSINESS_SIGNET enabled, using network: {:?}",
+                network
+            );
+
+            // Log custom URL overrides if set
+            if let Ok(url) = std::env::var("LIANA_BUSINESS_SIGNET_API_URL") {
+                if !url.is_empty() {
+                    tracing::info!("LIANA_BUSINESS_SIGNET_API_URL: {}", url);
+                }
+            }
+            if let Ok(url) = std::env::var("LIANA_BUSINESS_SIGNET_WS_URL") {
+                if !url.is_empty() {
+                    tracing::info!("LIANA_BUSINESS_SIGNET_WS_URL: {}", url);
+                }
+            }
+        }
+
         let mut state = State::new(network, datadir.clone());
         state.backend.set_network(network, datadir.clone());
 

--- a/liana-business/src/main.rs
+++ b/liana-business/src/main.rs
@@ -32,13 +32,23 @@ pub type LianaBusiness = GUI<BusinessInstaller, BusinessSettings, Message>;
 fn main() -> Result<(), Box<dyn Error>> {
     use bitcoin::Network::{Bitcoin, Signet};
 
-    // FIXME: change before release
-    let default_network = Signet;
+    let default_network = Bitcoin;
+
+    // Check if Signet is enabled via environment variable
+    let signet_enabled = std::env::var("LIANA_BUSINESS_SIGNET")
+        .map(|v| v == "1")
+        .unwrap_or(false);
+
+    let available_networks: Vec<bitcoin::Network> = if signet_enabled {
+        vec![Bitcoin, Signet]
+    } else {
+        vec![Bitcoin]
+    };
 
     let args = parse_args(
         std::env::args().collect(),
         VERSION,
-        &[Bitcoin, Signet],
+        &available_networks,
         Some(default_network),
     )?;
 

--- a/liana-business/src/main.rs
+++ b/liana-business/src/main.rs
@@ -32,12 +32,13 @@ pub type LianaBusiness = GUI<BusinessInstaller, BusinessSettings, Message>;
 fn main() -> Result<(), Box<dyn Error>> {
     use bitcoin::Network::{Bitcoin, Signet};
 
-    let default_network = Bitcoin;
-
     // Check if Signet is enabled via environment variable
     let signet_enabled = std::env::var("LIANA_BUSINESS_SIGNET")
         .map(|v| v == "1")
         .unwrap_or(false);
+
+    // When LIANA_BUSINESS_SIGNET=1, default to Signet (no --signet flag needed)
+    let default_network = if signet_enabled { Signet } else { Bitcoin };
 
     let available_networks: Vec<bitcoin::Network> = if signet_enabled {
         vec![Bitcoin, Signet]


### PR DESCRIPTION
this PR make mainnet the default network
signet can still be used by setting env var `LIANA_BUSINESS_SIGNET` to `1`

Note: `LIANA_BUSINESS_SIGNET_API_URL` & `LIANA_BUSINESS_SIGNET_WS_URL` can be used to route to a custom backend

<img width="835" height="228" alt="image" src="https://github.com/user-attachments/assets/ed4111ec-4cdd-44b7-b9b2-3a7912e365cf" />
