### PR TITLE
fix UX: force user to save psbt before exporting it

### DIFF
--- a/liana-gui/src/app/view/psbt.rs
+++ b/liana-gui/src/app/view/psbt.rs
@@ -78,6 +78,7 @@ pub fn psbt_view<'a>(
                 desc_info,
                 key_aliases,
                 currently_signing,
+                saved,
             ))
             .push(
                 Column::new()
@@ -337,7 +338,15 @@ pub fn spend_overview_view<'a>(
     desc_info: &'a LianaPolicy,
     key_aliases: &'a HashMap<Fingerprint, String>,
     currently_signing: bool,
+    saved: bool,
 ) -> Element<'a, Message> {
+    let export_button = button::secondary(Some(icon::backup_icon()), "Export").on_press_maybe(
+        if currently_signing || !saved {
+            None
+        } else {
+            Some(Message::ExportPsbt)
+        },
+    );
     Column::new()
         .spacing(20)
         .push(
@@ -354,23 +363,22 @@ pub fn spend_overview_view<'a>(
                                     .push(
                                         Row::new()
                                             .spacing(5)
-                                            .push(
-                                                button::secondary(
-                                                    Some(icon::backup_icon()),
-                                                    "Export",
-                                                )
-                                                .on_press_maybe(if currently_signing {
-                                                    None
-                                                } else {
-                                                    Some(Message::ExportPsbt)
-                                                }),
-                                            )
+                                            .push(if saved {
+                                                Container::new(export_button)
+                                            } else {
+                                                Container::new(tooltip::Tooltip::new(
+                                                    export_button,
+                                                    Container::new(p1_regular("Sign or save the transaction first to enable export"))
+                                                        .style(theme::card::simple).padding(10),
+                                                    tooltip::Position::Top,
+                                                ))
+                                            })
                                             .push(
                                                 button::secondary(
                                                     Some(icon::restore_icon()),
                                                     "Import",
                                                 )
-                                                .on_press_maybe(if currently_signing {
+                                                .on_press_maybe(if currently_signing || !saved {
                                                     None
                                                 } else {
                                                     Some(Message::ImportPsbt)

--- a/liana-gui/src/app/view/spend/mod.rs
+++ b/liana-gui/src/app/view/spend/mod.rs
@@ -63,7 +63,8 @@ pub fn spend_view<'a>(
         },
     ));
 
-    let spend_overview = psbt::spend_overview_view(tx, desc_info, key_aliases, currently_signing);
+    let spend_overview =
+        psbt::spend_overview_view(tx, desc_info, key_aliases, currently_signing, saved);
 
     let inputs_outputs = Column::new()
         .spacing(20)
@@ -84,23 +85,27 @@ pub fn spend_view<'a>(
         ));
 
     let bottom_row = if saved {
-        Row::new()
-            .push(button::secondary(None, "Delete").width(200).on_press_maybe(
-                (!currently_signing).then_some(Message::Spend(SpendTxMessage::Delete)),
-            ))
-            .width(Length::Fill)
+        Column::new().push(
+            Row::new()
+                .push(button::secondary(None, "Delete").width(200).on_press_maybe(
+                    (!currently_signing).then_some(Message::Spend(SpendTxMessage::Delete)),
+                ))
+                .width(Length::Fill),
+        )
     } else {
-        Row::new()
-            .push(
-                button::secondary(None, "< Previous")
-                    .width(150)
-                    .on_press_maybe((!currently_signing).then_some(Message::Previous)),
-            )
-            .push(Space::with_width(Length::Fill))
-            .push(button::secondary(None, "Save").width(150).on_press_maybe(
-                (!currently_signing).then_some(Message::Spend(SpendTxMessage::Save)),
-            ))
-            .width(Length::Fill)
+        Column::new().spacing(20).push(
+            Row::new()
+                .push(
+                    button::secondary(None, "< Previous")
+                        .width(150)
+                        .on_press_maybe((!currently_signing).then_some(Message::Previous)),
+                )
+                .push(Space::with_width(Length::Fill))
+                .push(button::secondary(None, "Save").width(150).on_press_maybe(
+                    (!currently_signing).then_some(Message::Spend(SpendTxMessage::Save)),
+                ))
+                .width(Length::Fill),
+        )
     };
 
     let content = Column::new()


### PR DESCRIPTION
To be sure that the user does not export the psbt without saving it which may be the cause of change address reuse. As the derivation index is not incremented in database unless the psbt is saved, it is better to make the user commit to the tx if he is satisfied.