### PR TITLE
business-installer: add support for key token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3158,9 +3158,14 @@ dependencies = [
 name = "liana-connect"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "bip39",
+ "getrandom 0.3.1",
  "miniscript",
+ "reqwest",
  "serde",
  "serde_json",
+ "tracing",
  "tungstenite",
  "uuid",
 ]
@@ -3197,6 +3202,7 @@ dependencies = [
  "iced_runtime",
  "jsonrpc",
  "liana",
+ "liana-connect",
  "liana-ui",
  "lianad",
  "libc",

--- a/liana-business/business-installer/src/state/message.rs
+++ b/liana-business/business-installer/src/state/message.rs
@@ -37,6 +37,7 @@ pub enum Msg {
     KeyUpdateAlias(String),              // Update key alias field
     KeyUpdateDescr(String),              // Update key description field
     KeyUpdateEmail(String),              // Update key email field
+    KeyUpdateToken(String),              // Update key token field
     KeyUpdateType(ws_business::KeyType), // Update key type
 
     // Template management

--- a/liana-business/business-installer/src/state/update.rs
+++ b/liana-business/business-installer/src/state/update.rs
@@ -56,6 +56,7 @@ impl State {
             Msg::KeyUpdateAlias(value) => self.views.keys.on_key_update_alias(value),
             Msg::KeyUpdateDescr(value) => self.views.keys.on_key_update_descr(value),
             Msg::KeyUpdateEmail(value) => self.views.keys.on_key_update_email(value),
+            Msg::KeyUpdateToken(value) => self.views.keys.on_key_update_token(value, &self.app.keys),
             Msg::KeyUpdateType(key_type) => self.views.keys.on_key_update_type(key_type),
             Msg::KeyAdd => self.on_key_add(),
             Msg::KeyEdit(key_id) => self.on_key_edit(key_id),
@@ -385,23 +386,30 @@ impl State {
             key_id,
             alias: String::new(),
             description: String::new(),
-            email: String::new(),
             key_type: ws_business::KeyType::Internal,
             is_new: true,
+            email: String::new(),
+            token: String::new(),
+            token_warning: None,
         });
     }
 
     fn on_key_edit(&mut self, key_id: u8) {
         if let Some(key) = self.app.keys.get(&key_id) {
-            // Extract email from KeyIdentity
-            let email = key.identity.to_string();
+            let (email, token) = match &key.identity {
+                KeyIdentity::Email(e) => (e.clone(), String::new()),
+                KeyIdentity::Token(t) => (String::new(), t.clone()),
+                KeyIdentity::Other(o) => (o.clone(), String::new()),
+            };
             self.views.keys.edit_key_modal = Some(views::EditKeyModalState {
                 key_id,
                 alias: key.alias.clone(),
                 description: key.description.clone(),
-                email,
                 key_type: key.key_type,
                 is_new: false,
+                email,
+                token,
+                token_warning: None,
             });
         }
     }
@@ -434,13 +442,23 @@ impl State {
 
     fn on_key_save(&mut self) {
         if let Some(modal_state) = &self.views.keys.edit_key_modal {
+            let identity = if matches!(
+                modal_state.key_type,
+                ws_business::KeyType::Cosigner | ws_business::KeyType::SafetyNet
+            ) {
+                KeyIdentity::Token(modal_state.token.clone())
+            } else {
+                KeyIdentity::Email(modal_state.email.clone())
+            };
+
+            // Build key from modal without updating local state
+            let mut keys = self.app.keys.clone();
             if modal_state.is_new {
-                // Creating a new key
                 let key = Key {
                     id: modal_state.key_id,
                     alias: modal_state.alias.clone(),
                     description: modal_state.description.clone(),
-                    identity: KeyIdentity::Email(modal_state.email.clone()),
+                    identity,
                     key_type: modal_state.key_type,
                     xpub: None,
                     xpub_source: None,
@@ -450,26 +468,41 @@ impl State {
                     last_edited: None,
                     last_editor: None,
                 };
-                self.app.keys.insert(modal_state.key_id, key);
-                self.app.next_key_id = self.app.next_key_id.wrapping_add(1);
-            } else {
-                // Editing existing key
-                if let Some(key) = self.app.keys.get_mut(&modal_state.key_id) {
-                    key.alias = modal_state.alias.clone();
-                    key.description = modal_state.description.clone();
-                    key.identity = KeyIdentity::Email(modal_state.email.clone());
-                    key.key_type = modal_state.key_type;
-                }
+                keys.insert(modal_state.key_id, key);
+            } else if let Some(key) = keys.get_mut(&modal_state.key_id) {
+                key.alias = modal_state.alias.clone();
+                key.description = modal_state.description.clone();
+                key.identity = identity;
+                key.key_type = modal_state.key_type;
             }
+
             self.views.keys.edit_key_modal = None;
 
-            // Auto-save
+            // Send to backend; local state will be updated when the backend responds
             if matches!(
                 self.app.current_user_role,
                 Some(UserRole::WizardSardineAdmin) | Some(UserRole::WalletManager)
             ) {
-                if let Some(wallet) = self.build_wallet_from_app_state(WalletStatus::Drafted) {
-                    self.backend.edit_wallet(wallet);
+                if let Some(wallet_id) = self.app.selected_wallet {
+                    if let Some(wallet) = self.backend.get_wallet(wallet_id) {
+                        let template = PolicyTemplate {
+                            keys,
+                            primary_path: self.app.primary_path.clone(),
+                            secondary_paths: self.app.secondary_paths.clone(),
+                        };
+                        self.backend.edit_wallet(Wallet {
+                            id: wallet.id,
+                            alias: wallet.alias.clone(),
+                            org: wallet.org,
+                            owner: wallet.owner,
+                            status: WalletStatus::Drafted,
+                            template: Some(template),
+                            last_edited: None,
+                            last_editor: None,
+                            descriptor: wallet.descriptor.clone(),
+                            devices: wallet.devices.clone(),
+                        });
+                    }
                 }
             }
         }
@@ -1505,18 +1538,20 @@ impl State {
                     if let Some(wallet) = self.backend.get_wallet(wallet_id) {
                         if let Some(template) = &wallet.template {
                             if let Some(key) = template.keys.get(&key_id) {
-                                // Extract email from KeyIdentity
-                                let email = match &key.identity {
-                                    KeyIdentity::Email(e) => e.clone(),
-                                    KeyIdentity::Token(t) => t.clone(),
-                                    KeyIdentity::Other(o) => o.clone(),
+                                // Extract identity fields
+                                let (email, token) = match &key.identity {
+                                    KeyIdentity::Email(e) => (e.clone(), String::new()),
+                                    KeyIdentity::Token(t) => (String::new(), t.clone()),
+                                    KeyIdentity::Other(o) => (o.clone(), String::new()),
                                 };
                                 // Update the modal with server data
                                 if let Some(modal) = &mut self.views.keys.edit_key_modal {
                                     modal.alias = key.alias.clone();
                                     modal.description = key.description.clone();
                                     modal.email = email;
+                                    modal.token = token;
                                     modal.key_type = key.key_type;
+                                    modal.token_warning = None;
                                 }
                                 // Also update local AppState
                                 self.app.keys.insert(key_id, key.clone());

--- a/liana-business/business-installer/src/state/views/keys/mod.rs
+++ b/liana-business/business-installer/src/state/views/keys/mod.rs
@@ -24,12 +24,14 @@ impl KeysViewState {
     }
 
     pub fn on_key_update_email(&mut self, value: String) {
+        let value = value.trim().to_string();
         if let Some(modal) = &mut self.edit_key_modal {
             modal.email = value;
         }
     }
 
     pub fn on_key_update_token(&mut self, value: String, keys: &BTreeMap<u8, Key>) {
+        let value = value.trim().to_string();
         if let Some(modal) = &mut self.edit_key_modal {
             modal.token = value.clone();
 

--- a/liana-business/business-installer/src/state/views/keys/mod.rs
+++ b/liana-business/business-installer/src/state/views/keys/mod.rs
@@ -1,7 +1,8 @@
 pub mod modal;
 
-use liana_connect::ws_business;
+use liana_connect::ws_business::{self, Key, KeyIdentity};
 pub use modal::EditKeyModalState;
+use std::{collections::BTreeMap, str::FromStr};
 
 /// Keys view state
 #[derive(Debug, Clone, Default)]
@@ -28,14 +29,57 @@ impl KeysViewState {
         }
     }
 
+    pub fn on_key_update_token(&mut self, value: String, keys: &BTreeMap<u8, Key>) {
+        if let Some(modal) = &mut self.edit_key_modal {
+            modal.token = value.clone();
+
+            if value.trim().is_empty() {
+                modal.token_warning = None;
+                return;
+            }
+
+            // Local format validation
+            if liana_connect::keys::token::Token::from_str(&value).is_err() {
+                modal.token_warning = Some("Invalid token!");
+                return;
+            }
+
+            // Check for duplicate tokens in existing keys
+            let editing_key_id = modal.key_id;
+            let is_duplicate = keys.iter().any(|(&id, k)| {
+                id != editing_key_id && matches!(&k.identity, KeyIdentity::Token(t) if t == &value)
+            });
+            if is_duplicate {
+                modal.token_warning = Some("Duplicate token");
+                return;
+            }
+
+            modal.token_warning = None;
+        }
+    }
+
     pub fn on_key_update_type(&mut self, key_type: ws_business::KeyType) {
         if let Some(modal) = &mut self.edit_key_modal {
             modal.key_type = key_type;
+            modal.token_warning = None;
         }
     }
 
     pub fn on_key_cancel_modal(&mut self) {
         self.edit_key_modal = None;
+    }
+
+    /// Whether the current key type uses token identity (Cosigner/SafetyNet)
+    pub fn uses_token_identity(&self) -> bool {
+        self.edit_key_modal
+            .as_ref()
+            .map(|modal| {
+                matches!(
+                    modal.key_type,
+                    ws_business::KeyType::Cosigner | ws_business::KeyType::SafetyNet
+                )
+            })
+            .unwrap_or(false)
     }
 
     pub fn is_alias_valid(&self) -> bool {
@@ -58,8 +102,28 @@ impl KeysViewState {
         }
     }
 
-    /// Check if both alias and email are valid
+    pub fn is_token_format_valid(&self) -> bool {
+        if let Some(modal) = &self.edit_key_modal {
+            use std::str::FromStr;
+            liana_connect::keys::token::Token::from_str(&modal.token).is_ok()
+        } else {
+            false
+        }
+    }
+
+    /// Check if the key can be saved based on current key type
     pub fn can_save(&self) -> bool {
-        self.is_alias_valid() && self.is_email_valid()
+        if !self.is_alias_valid() {
+            return false;
+        }
+        if self.uses_token_identity() {
+            self.is_token_format_valid()
+                && self
+                    .edit_key_modal
+                    .as_ref()
+                    .is_some_and(|m| m.token_warning.is_none())
+        } else {
+            self.is_email_valid()
+        }
     }
 }

--- a/liana-business/business-installer/src/state/views/keys/modal.rs
+++ b/liana-business/business-installer/src/state/views/keys/modal.rs
@@ -6,7 +6,11 @@ pub struct EditKeyModalState {
     pub key_id: u8,
     pub alias: String,
     pub description: String,
-    pub email: String,
     pub key_type: ws_business::KeyType,
     pub is_new: bool,
+    // Identity fields - only one is active based on key_type
+    pub email: String,
+    pub token: String,
+    // Token validation state
+    pub token_warning: Option<&'static str>,
 }

--- a/liana-business/business-installer/src/views/keys/modal.rs
+++ b/liana-business/business-installer/src/views/keys/modal.rs
@@ -60,13 +60,12 @@ pub fn edit_key_modal_view<'a>(
         None
     };
 
-    // Alias input - validate (must not be empty)
-    // No warning if empty, but Save button will be disabled
+    // Alias input
     let alias_valid = state.views.keys.is_alias_valid();
     let alias_value = form::Value {
         value: modal_state.alias.clone(),
-        warning: None, // No warning displayed for empty field
-        valid: alias_valid || modal_state.alias.trim().is_empty(), // Don't show red border if empty
+        warning: None,
+        valid: alias_valid || modal_state.alias.trim().is_empty(),
     };
     let alias_input = Column::new()
         .spacing(5)
@@ -92,32 +91,7 @@ pub fn edit_key_modal_view<'a>(
             Message::KeyUpdateDescr,
         ));
 
-    // Email input - validate (same as login flow)
-    // No warning if empty, but Save button will be disabled
-    // Only show warning if not empty but invalid format
-    let is_empty = modal_state.email.trim().is_empty();
-    let email_valid = state.views.keys.is_email_valid();
-    let email_value = form::Value {
-        value: modal_state.email.clone(),
-        warning: if is_empty {
-            None // No warning for empty field
-        } else if !email_valid {
-            Some("Invalid email!") // Only show warning if not empty but invalid
-        } else {
-            None
-        },
-        valid: email_valid || is_empty, // Don't show red border if empty
-    };
-    let email_input = Column::new()
-        .spacing(5)
-        .push(text::p1_medium("Email Address of the Key Manager").style(theme::text::primary))
-        .push(form::Form::new(
-            "Enter email address",
-            &email_value,
-            Message::KeyUpdateEmail,
-        ));
-
-    // Key type picker
+    // Key type picker (placed before identity input)
     let key_types: &[ws_business::KeyType] = &[
         ws_business::KeyType::Internal,
         ws_business::KeyType::External,
@@ -143,8 +117,71 @@ pub fn edit_key_modal_view<'a>(
         .width(Length::Fill),
     );
 
-    // Footer - Cancel and Save buttons (aligned right)
-    // Save button is disabled if alias or email is invalid
+    // Identity input — conditional on key type
+    let uses_token = matches!(
+        modal_state.key_type,
+        ws_business::KeyType::Cosigner | ws_business::KeyType::SafetyNet
+    );
+
+    let email_input: Option<Element<'a, Message>> = if !uses_token {
+        let is_empty = modal_state.email.trim().is_empty();
+        let email_valid = state.views.keys.is_email_valid();
+        let email_value = form::Value {
+            value: modal_state.email.clone(),
+            warning: if is_empty {
+                None
+            } else if !email_valid {
+                Some("Invalid email!")
+            } else {
+                None
+            },
+            valid: email_valid || is_empty,
+        };
+        Some(
+            Column::new()
+                .spacing(5)
+                .push(
+                    text::p1_medium("Email Address of the Key Manager").style(theme::text::primary),
+                )
+                .push(form::Form::new(
+                    "Enter email address",
+                    &email_value,
+                    Message::KeyUpdateEmail,
+                ))
+                .into(),
+        )
+    } else {
+        None
+    };
+
+    let token_input: Option<Element<'a, Message>> = if uses_token {
+        let is_empty = modal_state.token.trim().is_empty();
+        let token_valid = state.views.keys.is_token_format_valid();
+        let token_value = form::Value {
+            value: modal_state.token.clone(),
+            warning: if is_empty {
+                None
+            } else {
+                modal_state.token_warning
+            },
+            valid: (token_valid && modal_state.token_warning.is_none()) || is_empty,
+        };
+        Some(
+            Column::new()
+                .spacing(5)
+                .push(text::p1_medium("Token").style(theme::text::primary))
+                .push(form::Form::new(
+                    "Enter token (e.g., 42-absent-cake-eagle)",
+                    &token_value,
+                    Message::KeyUpdateToken,
+                ))
+                .into(),
+        )
+    } else {
+        None
+    };
+
+    // Footer
     let can_save = state.views.keys.can_save();
     let save_button = if can_save {
         button::primary(None, "Save")
@@ -168,8 +205,9 @@ pub fn edit_key_modal_view<'a>(
         .push_maybe(last_edit_info)
         .push(alias_input)
         .push(description_input)
-        .push(email_input)
         .push(key_type_picker)
+        .push_maybe(email_input)
+        .push_maybe(token_input)
         .push(footer)
         .spacing(15)
         .padding(20.0)

--- a/liana-connect/Cargo.toml
+++ b/liana-connect/Cargo.toml
@@ -13,8 +13,13 @@ name = "liana_connect"
 path = "src/lib.rs"
 
 [dependencies]
+async-trait = { workspace = true }
+bip39 = { workspace = true }
+getrandom = { workspace = true }
 miniscript = { workspace = true, features = ["serde"]}
+reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 tungstenite = { workspace = true }
 uuid = { workspace = true , features = ["serde", "v4"]}

--- a/liana-connect/src/keys/api.rs
+++ b/liana-connect/src/keys/api.rs
@@ -1,6 +1,6 @@
 use serde::{de, Deserialize};
 
-use liana::miniscript::descriptor::DescriptorPublicKey;
+use miniscript::descriptor::DescriptorPublicKey;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
 pub enum KeyKind {

--- a/liana-connect/src/keys/http.rs
+++ b/liana-connect/src/keys/http.rs
@@ -1,0 +1,33 @@
+use async_trait::async_trait;
+use reqwest::Response;
+
+/// Information about an unsuccessful response.
+#[derive(Debug, Clone)]
+pub struct NotSuccessResponseInfo {
+    pub status_code: u16,
+    pub text: String,
+}
+
+#[async_trait]
+pub trait ResponseExt {
+    async fn check_success(self) -> Result<Self, NotSuccessResponseInfo>
+    where
+        Self: Sized;
+}
+
+#[async_trait]
+impl ResponseExt for Response {
+    async fn check_success(self) -> Result<Self, NotSuccessResponseInfo> {
+        let status = self.status();
+        if !status.is_success() {
+            return Err(NotSuccessResponseInfo {
+                status_code: status.as_u16(),
+                text: self
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Failed to read response text".to_string()),
+            });
+        }
+        Ok(self)
+    }
+}

--- a/liana-connect/src/keys/mod.rs
+++ b/liana-connect/src/keys/mod.rs
@@ -1,10 +1,11 @@
 pub mod api;
+mod http;
 pub mod token;
 
 use reqwest::{self, IntoUrl, Method, RequestBuilder};
 use serde_json::json;
 
-use super::http::{NotSuccessResponseInfo, ResponseExt};
+use self::http::{NotSuccessResponseInfo, ResponseExt};
 
 const KEYS_API_URL: &str = "https://keys.wizardsardine.com";
 
@@ -37,38 +38,51 @@ fn request<U: reqwest::IntoUrl>(
     http: &reqwest::Client,
     method: reqwest::Method,
     url: U,
+    user_agent: &str,
 ) -> reqwest::RequestBuilder {
     let req = http
         .request(method, url)
         .header("Content-Type", "application/json")
         .header("API-Version", "0.1")
-        .header("User-Agent", format!("liana-gui/{}", crate::VERSION));
+        .header("User-Agent", user_agent);
     tracing::debug!("Sending http request: {:?}", req);
     req
 }
 
 #[derive(Debug, Clone)]
-pub struct Client(reqwest::Client);
-
-impl Default for Client {
-    fn default() -> Self {
-        Self::new()
-    }
+pub struct Client {
+    http: reqwest::Client,
+    url: String,
+    user_agent: String,
 }
 
 impl Client {
-    pub fn new() -> Self {
-        let http = reqwest::Client::new();
-        Client(http)
+    pub fn new(user_agent: &str) -> Self {
+        Self::new_with_url(KEYS_API_URL, user_agent)
+    }
+
+    pub fn new_with_url(url: &str, user_agent: &str) -> Self {
+        Client {
+            http: reqwest::Client::new(),
+            url: url.to_string(),
+            user_agent: user_agent.to_string(),
+        }
+    }
+
+    pub fn new_with_optional_url(url: Option<&str>, user_agent: &str) -> Self {
+        match url {
+            Some(url) => Self::new_with_url(url, user_agent),
+            None => Self::new(user_agent),
+        }
     }
 
     async fn request<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
-        request(&self.0, method, url)
+        request(&self.http, method, url, &self.user_agent)
     }
 
     pub async fn get_key_by_token(&self, token: String) -> Result<api::Key, Error> {
         let response = self
-            .request(Method::GET, &format!("{}/v1/keys", KEYS_API_URL))
+            .request(Method::GET, &format!("{}/v1/keys", self.url))
             .await
             .query(&[("token", token)])
             .send()
@@ -83,7 +97,7 @@ impl Client {
         let response = self
             .request(
                 Method::POST,
-                &format!("{}/v1/keys/{}/redeem", KEYS_API_URL, uuid),
+                &format!("{}/v1/keys/{}/redeem", self.url, uuid),
             )
             .await
             .json(&json!({

--- a/liana-connect/src/keys/token.rs
+++ b/liana-connect/src/keys/token.rs
@@ -1,4 +1,3 @@
-use liana::{bip39, getrandom, miniscript};
 use miniscript::bitcoin::hashes::{sha256, Hash, HashEngine};
 use std::error::Error;
 use std::fmt::Display;
@@ -112,8 +111,6 @@ pub fn generate_random_token() -> Result<Token, Box<dyn Error>> {
 
 #[cfg(test)]
 mod tests {
-    use liana::bip39;
-
     use super::*;
     use std::str::FromStr;
 

--- a/liana-connect/src/lib.rs
+++ b/liana-connect/src/lib.rs
@@ -3,4 +3,5 @@
 //! This crate provides shared protocol types and domain models for
 //! Liana Connect client/server communication.
 
+pub mod keys;
 pub mod ws_business;

--- a/liana-gui/Cargo.toml
+++ b/liana-gui/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 async-trait = { workspace = true }
 async-hwi = { workspace = true }
 liana = { path = "../liana" }
+liana-connect = { workspace = true }
 lianad = { path = "../lianad", default-features = false, features = ["nonblocking_shutdown"] }
 liana-ui = { path = "../liana-ui" }
 backtrace = { workspace = true }

--- a/liana-gui/src/app/settings/mod.rs
+++ b/liana-gui/src/app/settings/mod.rs
@@ -28,10 +28,7 @@ use crate::{
     backup::{Key, KeyRole, KeyType},
     dir::{LianaDirectory, NetworkDirectory},
     hw::HardwareWalletConfig,
-    services::{
-        self,
-        connect::client::backend::{self, api, BackendWalletClient},
-    },
+    services::connect::client::backend::{self, api, BackendWalletClient},
     utils::serde::ok_or_none,
 };
 
@@ -448,8 +445,8 @@ impl From<backend::api::Provider> for Provider {
     }
 }
 
-impl From<services::keys::api::Provider> for Provider {
-    fn from(provider: services::keys::api::Provider) -> Self {
+impl From<liana_connect::keys::api::Provider> for Provider {
+    fn from(provider: liana_connect::keys::api::Provider) -> Self {
         Self {
             uuid: provider.uuid,
             name: provider.name,

--- a/liana-gui/src/installer/descriptor.rs
+++ b/liana-gui/src/installer/descriptor.rs
@@ -4,9 +4,8 @@ use liana::miniscript::{
     descriptor::DescriptorPublicKey,
 };
 
-use crate::{
-    app::settings::ProviderKey, hw::is_compatible_with_tapminiscript, services::keys::api::KeyKind,
-};
+use crate::{app::settings::ProviderKey, hw::is_compatible_with_tapminiscript};
+use liana_connect::keys::api::KeyKind;
 
 /// Whether to enable cosigner keys on all paths (excluding safety net paths).
 const ENABLE_COSIGNER_KEYS: bool = false;

--- a/liana-gui/src/installer/message.rs
+++ b/liana-gui/src/installer/message.rs
@@ -29,10 +29,7 @@ use crate::{
         bitcoind::{Bitcoind, ConfigField, RpcAuthType},
         electrum, NodeType,
     },
-    services::{
-        self,
-        connect::client::{auth::AuthClient, backend::api},
-    },
+    services::connect::client::{auth::AuthClient, backend::api},
 };
 
 #[derive(Debug, Clone)]
@@ -65,7 +62,7 @@ pub enum Message {
     MnemonicWord(usize, String),
     ImportMnemonic(bool),
     RedeemNextKey,
-    KeyRedeemed(ProviderKey, Result<(), services::keys::Error>),
+    KeyRedeemed(ProviderKey, Result<(), liana_connect::keys::Error>),
     AllKeysRedeemed,
     BackupDescriptor,
     ExportEncryptedDescriptor(Result<Box<LianaDescriptor>, encrypted_backup::Error>),

--- a/liana-gui/src/installer/mod.rs
+++ b/liana-gui/src/installer/mod.rs
@@ -37,17 +37,14 @@ use crate::{
     dir::LianaDirectory,
     hw::{HardwareWalletConfig, HardwareWalletMessage, HardwareWallets},
     node::bitcoind::Bitcoind,
-    services::{
-        self,
-        connect::client::{
-            auth::AuthError,
-            backend::{
-                api::payload::{Provider, ProviderKey},
-                BackendClient, BackendWalletClient,
-            },
-            cache::update_connect_cache,
-            BackendType,
+    services::connect::client::{
+        auth::AuthError,
+        backend::{
+            api::payload::{Provider, ProviderKey},
+            BackendClient, BackendWalletClient,
         },
+        cache::update_connect_cache,
+        BackendType,
     },
     signer::Signer,
 };
@@ -979,7 +976,7 @@ pub enum Error {
     // DaemonError does not implement Clone.
     // TODO: maybe Arc is overkill
     Backend(Arc<DaemonError>),
-    Services(services::keys::Error),
+    Services(liana_connect::keys::Error),
     Settings(SettingsError),
     Bitcoind(String),
     Electrum(String),

--- a/liana-gui/src/installer/step/descriptor/editor/key.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/key.rs
@@ -42,12 +42,9 @@ use crate::{
         message::{self, Message},
         Error, PathKind,
     },
-    services::{
-        self,
-        keys::{self, api::KeyKind},
-    },
     signer::Signer,
 };
+use liana_connect::keys::{self, api::KeyKind};
 
 const MAX_ALIAS_LEN: usize = 24;
 pub type FnMsg = fn() -> Message;
@@ -445,7 +442,7 @@ impl SelectKeySource {
     }
     fn fetch_provider(&mut self, token: String) -> Task<Message> {
         self.processing = true;
-        let client = services::keys::Client::new();
+        let client = keys::Client::new(&format!("liana-gui/{}", crate::VERSION));
         Task::perform(
             async move { (token.clone(), client.get_key_by_token(token).await) },
             |(token, res)| {

--- a/liana-gui/src/installer/step/descriptor/editor/key.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/key.rs
@@ -42,6 +42,7 @@ use crate::{
         message::{self, Message},
         Error, PathKind,
     },
+    services::connect::client::BackendType,
     signer::Signer,
 };
 use liana_connect::keys::{self, api::KeyKind};
@@ -442,7 +443,11 @@ impl SelectKeySource {
     }
     fn fetch_provider(&mut self, token: String) -> Task<Message> {
         self.processing = true;
-        let client = keys::Client::new(&format!("liana-gui/{}", crate::VERSION));
+        let ua = BackendType::LianaConnect.user_agent();
+        let url = (self.network != Network::Bitcoin)
+            .then(|| std::env::var("LIANA_KEYS_SIGNET_API_URL").ok())
+            .flatten();
+        let client = keys::Client::new_with_optional_url(url.as_deref(), &ua);
         Task::perform(
             async move { (token.clone(), client.get_key_by_token(token).await) },
             |(token, res)| {

--- a/liana-gui/src/installer/step/descriptor/editor/mod.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/mod.rs
@@ -31,9 +31,9 @@ use crate::{
         step::{Context, Step},
         view,
     },
-    services::keys::api::KeyKind,
     signer::Signer,
 };
+use liana_connect::keys::api::KeyKind;
 
 use key::{new_multixkey_from_xpub, EditKeyAlias, PathData, SelectKeySource};
 

--- a/liana-gui/src/installer/step/mod.rs
+++ b/liana-gui/src/installer/step/mod.rs
@@ -36,7 +36,6 @@ use crate::{
     hw::HardwareWallets,
     installer::{context::Context, message::Message, view},
     node::bitcoind::Bitcoind,
-    services,
 };
 
 pub trait Step {
@@ -72,7 +71,7 @@ pub struct Final {
     internal_bitcoind: Option<Bitcoind>,
     warning: Option<String>,
     wallet_settings: Option<WalletSettings>,
-    key_redemptions: HashMap<ProviderKey, Option<Result<(), services::keys::Error>>>,
+    key_redemptions: HashMap<ProviderKey, Option<Result<(), liana_connect::keys::Error>>>,
     backup: Option<Backup>,
 }
 
@@ -116,7 +115,8 @@ impl Step for Final {
         match message {
             Message::RedeemNextKey => {
                 if let Some((pk, _)) = self.key_redemptions.iter().find(|(_, v)| v.is_none()) {
-                    let client = services::keys::Client::new();
+                    let client =
+                        liana_connect::keys::Client::new(&format!("liana-gui/{}", crate::VERSION));
                     let pk = pk.clone();
                     return Task::perform(
                         async move { (pk.clone(), client.redeem_key(pk.uuid, pk.token).await) },

--- a/liana-gui/src/installer/step/mod.rs
+++ b/liana-gui/src/installer/step/mod.rs
@@ -27,6 +27,7 @@ pub use wallet_alias::WalletAlias;
 use std::collections::HashMap;
 
 use iced::{Subscription, Task};
+use liana::miniscript::bitcoin::Network;
 
 use liana_ui::widget::*;
 
@@ -36,6 +37,7 @@ use crate::{
     hw::HardwareWallets,
     installer::{context::Context, message::Message, view},
     node::bitcoind::Bitcoind,
+    services::connect::client::BackendType,
 };
 
 pub trait Step {
@@ -73,6 +75,7 @@ pub struct Final {
     wallet_settings: Option<WalletSettings>,
     key_redemptions: HashMap<ProviderKey, Option<Result<(), liana_connect::keys::Error>>>,
     backup: Option<Backup>,
+    network: Network,
 }
 
 impl Final {
@@ -84,6 +87,7 @@ impl Final {
             wallet_settings: None,
             key_redemptions: HashMap::new(),
             backup: None,
+            network: Network::Bitcoin,
         }
     }
 }
@@ -98,6 +102,7 @@ impl Step for Final {
     fn load_context(&mut self, ctx: &Context) {
         self.internal_bitcoind.clone_from(&ctx.internal_bitcoind);
         self.backup.clone_from(&ctx.backup);
+        self.network = ctx.bitcoin_config.network;
         self.key_redemptions = ctx
             .keys
             .values()
@@ -115,8 +120,12 @@ impl Step for Final {
         match message {
             Message::RedeemNextKey => {
                 if let Some((pk, _)) = self.key_redemptions.iter().find(|(_, v)| v.is_none()) {
+                    let ua = BackendType::LianaConnect.user_agent();
+                    let url = (self.network != Network::Bitcoin)
+                        .then(|| std::env::var("LIANA_KEYS_SIGNET_API_URL").ok())
+                        .flatten();
                     let client =
-                        liana_connect::keys::Client::new(&format!("liana-gui/{}", crate::VERSION));
+                        liana_connect::keys::Client::new_with_optional_url(url.as_deref(), &ua);
                     let pk = pk.clone();
                     return Task::perform(
                         async move { (pk.clone(), client.redeem_key(pk.uuid, pk.token).await) },

--- a/liana-gui/src/services/mod.rs
+++ b/liana-gui/src/services/mod.rs
@@ -1,4 +1,3 @@
 pub mod connect;
 pub mod fiat;
 pub mod http;
-pub mod keys;


### PR DESCRIPTION
This PR is preparatory for support key token, it does 2 things:
- move the key client from `liana-gui` to `liana-connect` crate
- modify the key modal for support token

<img width="714" height="613" alt="image" src="https://github.com/user-attachments/assets/2c38b032-20d4-4960-8198-2272207b4a94" />
