### PR TITLE
lianad: fix help text for config option

### DIFF
--- a/lianad/src/bin/daemon.rs
+++ b/lianad/src/bin/daemon.rs
@@ -9,7 +9,7 @@ use lianad::{config::Config, setup_panic_hook, DaemonHandle, VERSION};
 
 fn print_help_exit(code: i32) {
     eprintln!("lianad version {}", VERSION);
-    eprintln!("A TOML configuration file is required to run lianad. By default lianad looks for a 'config.toml' file in its data directory. A different one may be provided like so: '--conf <config file path>'.");
+    eprintln!("A TOML configuration file is required to run lianad. By default lianad looks for a 'config.toml' file in its data directory. A different one may be provided like so: '--config <config file path>'.");
     eprintln!("A documented sample is available at 'contrib/lianad_config_example.toml' in the source tree (https://github.com/wizardsardine/liana/blob/v1.0/contrib/lianad_config_example.toml).");
     eprintln!("The default data directory path is a 'liana/' folder in the XDG standard configuration directory for all OSes but Linux ones, where it's '~/.liana/'.");
     process::exit(code);


### PR DESCRIPTION
Corrects the exit help text to accurately list custom config file path option as `--config` rather than current `--conf`