### PR TITLE
fix: dashboard content flickering on window resize

### DIFF
--- a/liana-gui/src/app/cache.rs
+++ b/liana-gui/src/app/cache.rs
@@ -10,6 +10,7 @@ use crate::{
         Currency, PriceSource,
     },
 };
+use crate::app::menu::MenuWidth;
 use liana::miniscript::bitcoin::Network;
 use lianad::commands::CoinStatus;
 use std::sync::Arc;
@@ -24,6 +25,7 @@ pub struct Cache {
     pub last_poll_at_startup: Option<u32>,
     pub daemon_cache: DaemonCache,
     pub fiat_price: Option<FiatPrice>,
+    pub menu_width: MenuWidth,
 }
 
 /// only used for tests.
@@ -36,6 +38,7 @@ impl std::default::Default for Cache {
             last_poll_at_startup: None,
             daemon_cache: DaemonCache::default(),
             fiat_price: None,
+            menu_width: MenuWidth::Normal,
         }
     }
 }

--- a/liana-gui/src/app/menu.rs
+++ b/liana-gui/src/app/menu.rs
@@ -5,8 +5,9 @@ use liana_ui::{
     icon,
 };
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum MenuWidth {
+    #[default]
     Normal,
     Compact,
     Small,

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -236,6 +236,10 @@ impl<S: SettingsTrait> App<S> {
         &self.cache
     }
 
+    pub fn cache_mut(&mut self) -> &mut Cache {
+        &mut self.cache
+    }
+
     pub fn wallet(&self) -> &Wallet {
         &self.wallet
     }

--- a/liana-gui/src/app/view/mod.rs
+++ b/liana-gui/src/app/view/mod.rs
@@ -20,7 +20,7 @@ pub use message::*;
 use warning::warn;
 
 use iced::{
-    widget::{column, responsive, row, scrollable, Space},
+    widget::{column, row, scrollable, Space},
     Length,
 };
 
@@ -37,8 +37,6 @@ use crate::app::{
     error::Error,
     menu::{Menu, MenuWidth},
 };
-
-use std::cell::RefCell;
 
 pub fn sidebar<'a>(
     active: &Menu,
@@ -92,48 +90,41 @@ pub fn dashboard<'a, T: Into<Element<'a, Message>>>(
     warning: Option<&'a Error>,
     content: T,
 ) -> Element<'a, Message> {
-    let content_cell = RefCell::new(Some(content.into()));
-    responsive(move |size| {
-        let sidebar_width = MenuWidth::from_pane_width(size.width);
-        let content = content_cell
-            .borrow_mut()
-            .take()
-            .unwrap_or_else(|| Space::new(Length::Fill, Length::Shrink).into());
-        Row::new()
-            .push(
-                sidebar(menu, cache, sidebar_width)
-                    .height(Length::Fill)
-                    .width(Length::Fixed(sidebar_width.into())),
-            )
-            .push(
-                Column::new()
-                    .push(warn(warning))
-                    .push(
-                        Container::new(column![
-                            Space::with_height(25),
-                            Container::new(
-                                scrollable(row!(
-                                    Space::with_width(Length::FillPortion(1)),
-                                    column!(Space::with_height(Length::Fixed(150.0)), content)
-                                        .width(Length::FillPortion(8))
-                                        .max_width(1500),
-                                    Space::with_width(Length::FillPortion(1)),
-                                ))
-                                .on_scroll(|w| Message::Scroll(w.absolute_offset().y)),
-                            )
-                            .center_x(Length::Fill)
-                            .style(theme::container::panel_background)
-                            .height(Length::Fill)
-                        ])
-                        .style(theme::container::sidebar),
-                    )
-                    .width(Length::Fill),
-            )
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .into()
-    })
-    .into()
+    let sidebar_width = cache.menu_width;
+    let content = content.into();
+    Row::new()
+        .push(
+            sidebar(menu, cache, sidebar_width)
+                .height(Length::Fill)
+                .width(Length::Fixed(sidebar_width.into())),
+        )
+        .push(
+            Column::new()
+                .push(warn(warning))
+                .push(
+                    Container::new(column![
+                        Space::with_height(25),
+                        Container::new(
+                            scrollable(row!(
+                                Space::with_width(Length::FillPortion(1)),
+                                column!(Space::with_height(Length::Fixed(150.0)), content)
+                                    .width(Length::FillPortion(8))
+                                    .max_width(1500),
+                                Space::with_width(Length::FillPortion(1)),
+                            ))
+                            .on_scroll(|w| Message::Scroll(w.absolute_offset().y)),
+                        )
+                        .center_x(Length::Fill)
+                        .style(theme::container::panel_background)
+                        .height(Length::Fill)
+                    ])
+                    .style(theme::container::sidebar),
+                )
+                .width(Length::Fill),
+        )
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into()
 }
 
 pub fn modal<'a, T: Into<Element<'a, Message>>, F: Into<Element<'a, Message>>>(

--- a/liana-gui/src/gui/mod.rs
+++ b/liana-gui/src/gui/mod.rs
@@ -22,6 +22,7 @@ pub mod tab;
 use crate::{
     app::{
         cache::{FiatPrice, FiatPriceRequest},
+        menu::MenuWidth,
         message::{FiatMessage as AppFiatMessage, Message as AppMessage},
         settings::{
             global::{GlobalSettings, WindowConfig},
@@ -192,6 +193,11 @@ where
                 }
             }
             Message::WindowSize(monitor_size) => {
+                let menu_width =
+                    MenuWidth::from_pane_width(monitor_size.width);
+                for (_, pane) in self.panes.iter_mut() {
+                    pane.set_menu_width(menu_width);
+                }
                 let cloned_cfg = self.window_config.clone();
                 match (cloned_cfg, &self.window_init, &self.window_id) {
                     // no previous screen size recorded && window maximized

--- a/liana-gui/src/gui/pane.rs
+++ b/liana-gui/src/gui/pane.rs
@@ -173,6 +173,10 @@ where
         self.tabs.iter_mut().for_each(|t| t.stop());
     }
 
+    pub fn set_menu_width(&mut self, menu_width: app::menu::MenuWidth) {
+        self.tabs.iter_mut().for_each(|t| t.set_menu_width(menu_width));
+    }
+
     pub fn tabs_menu_view(&self) -> Element<Message<M>> {
         let mut menu = Row::new().spacing(3);
         let tabs_len = self.tabs.len();

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -13,6 +13,7 @@ use crate::{
     app::{
         self,
         cache::{Cache, DaemonCache},
+        menu::MenuWidth,
         settings::{
             self, update_settings_file, LianaSettings, LianaWalletSettings, SettingsError,
             SettingsTrait,
@@ -142,6 +143,12 @@ where
             Some(app.cache())
         } else {
             None
+        }
+    }
+
+    pub fn set_menu_width(&mut self, menu_width: MenuWidth) {
+        if let State::App(ref mut app) = self.state {
+            app.cache_mut().menu_width = menu_width;
         }
     }
 
@@ -651,6 +658,7 @@ pub fn create_app_with_remote_backend(
                 last_tick: Instant::now(),
             },
             fiat_price: None,
+            menu_width: Default::default(),
         },
         Arc::new(
             Wallet::new(wallet.descriptor)

--- a/liana-gui/src/loader.rs
+++ b/liana-gui/src/loader.rs
@@ -451,6 +451,7 @@ pub async fn load_application(
             ..Default::default()
         },
         fiat_price: None,
+        menu_width: Default::default(),
     };
 
     Ok((Arc::new(wallet), cache, daemon, internal_bitcoind, backup))


### PR DESCRIPTION
The dashboard used iced's `responsive` widget to adapt the sidebar width. Because `responsive` takes an `Fn` closure but `Element` isn't `Clone`, the content was consumed via `RefCell::take()` on the first call, falling back to an empty `Space` on subsequent calls. During resize, `responsive` can re-invoke the closure on the stale widget tree before `view()` rebuilds a fresh one — `.take()` returns `None`, the `Space` fallback is briefly rendered, and the content flickers.

Remove `responsive` from `dashboard()` and store `MenuWidth` in `Cache`, updated synchronously on every `WindowSize` event via `Pane` → `Tab` → `App` cache. `dashboard()` reads `cache.menu_width` directly to size the sidebar — no closure, no `RefCell`, no fallback, no flicker. The function signature is unchanged so callers are not modified.