### PR TITLE
last fixes before release

### DIFF
--- a/liana-business/business-installer/src/client.rs
+++ b/liana-business/business-installer/src/client.rs
@@ -924,7 +924,7 @@ fn wss_thread(
     tracing::debug!("wss_thread: waiting for Connected response");
     if let Ok(msg) = ws_stream.read() {
         match Response::from_ws_message(msg) {
-            Ok((Response::Connected { user, .. }, _)) => {
+            Ok((Some(Response::Connected { user, .. }), _)) => {
                 tracing::info!("wss_thread: connected successfully, user_id={}", user);
                 // Store the authenticated user's ID
                 if let Ok(mut id) = user_id.lock() {
@@ -935,12 +935,21 @@ fn wss_thread(
                 // Fetch current user's info
                 let _ = request_sender.send(Request::FetchUser { id: user });
             }
-            Ok((response, _)) => {
+            Ok((Some(response), _)) => {
                 // NOTE: Handshake fails if we receive anything other than Response::Connected
                 tracing::error!(
                     "wss_thread: handshake failed, expected Connected, got {:?}",
                     response
                 );
+                Client::send_notif(
+                    &notif_sender,
+                    &notif_waker,
+                    Notification::Error(Error::WsConnection).into(),
+                );
+                return;
+            }
+            Ok((None, _)) => {
+                tracing::error!("wss_thread: handshake failed, unknown message from server");
                 Client::send_notif(
                     &notif_sender,
                     &notif_waker,
@@ -1114,6 +1123,15 @@ fn handle_wss_message(
     let (response, request_id) = Response::from_ws_message(msg)
         .map_err(|e| format!("Failed to convert WSS message: {}", e))?;
     let request_id = request_id.and_then(|s| Uuid::try_parse(&s).ok());
+
+    // Unknown or unparseable message — already logged in protocol layer.
+    let Some(response) = response else {
+        // Clean up sent_requests if there's a request_id so it doesn't hang.
+        if let Some(req_id) = &request_id {
+            sent_requests.lock().expect("poisoned").remove(req_id);
+        }
+        return Ok(());
+    };
 
     tracing::debug!(
         "handle_wss_message: received response={:?} request_id={:?}",
@@ -2055,7 +2073,7 @@ mod tests {
             let (response, request_id) = Response::from_ws_message(msg).unwrap();
 
             match response {
-                Response::Connected { version, .. } => assert_eq!(version, 1),
+                Some(Response::Connected { version, .. }) => assert_eq!(version, 1),
                 _ => panic!("Expected Connected response"),
             }
             assert_eq!(
@@ -2074,7 +2092,7 @@ mod tests {
             let (response, request_id) = Response::from_ws_message(msg).unwrap();
 
             match response {
-                Response::Connected { version, .. } => assert_eq!(version, 2),
+                Some(Response::Connected { version, .. }) => assert_eq!(version, 2),
                 _ => panic!("Expected Connected response"),
             }
             assert_eq!(request_id, None);
@@ -2090,7 +2108,7 @@ mod tests {
             let (response, request_id) = Response::from_ws_message(msg).unwrap();
 
             match response {
-                Response::Pong => {}
+                Some(Response::Pong) => {}
                 _ => panic!("Expected Pong response"),
             }
             assert_eq!(
@@ -2108,7 +2126,7 @@ mod tests {
             let (response, request_id) = Response::from_ws_message(msg).unwrap();
 
             match response {
-                Response::Pong => {}
+                Some(Response::Pong) => {}
                 _ => panic!("Expected Pong response"),
             }
             assert_eq!(request_id, None);
@@ -2139,7 +2157,7 @@ mod tests {
             let (response, request_id) = Response::from_ws_message(msg).unwrap();
 
             match response {
-                Response::Org { org } => {
+                Some(Response::Org { org }) => {
                     assert_eq!(org.name, "Acme Corp");
                     assert_eq!(org.id.to_string(), "550e8400-e29b-41d4-a716-446655440010");
                     assert_eq!(org.wallets.len(), 2);
@@ -2170,7 +2188,7 @@ mod tests {
             let (response, _) = Response::from_ws_message(msg).unwrap();
 
             match response {
-                Response::Org { org } => {
+                Some(Response::Org { org }) => {
                     assert_eq!(org.name, "Empty Org");
                     assert!(org.wallets.is_empty());
                     assert!(org.users.is_empty());
@@ -2232,7 +2250,7 @@ mod tests {
             let (response, request_id) = Response::from_ws_message(msg).unwrap();
 
             match response {
-                Response::Wallet { wallet } => {
+                Some(Response::Wallet { wallet }) => {
                     assert_eq!(
                         wallet.id.to_string(),
                         "550e8400-e29b-41d4-a716-446655440020"
@@ -2269,7 +2287,7 @@ mod tests {
             let (response, _) = Response::from_ws_message(msg).unwrap();
 
             match response {
-                Response::Wallet { wallet } => {
+                Some(Response::Wallet { wallet }) => {
                     assert_eq!(wallet.alias, "Simple Wallet");
                     assert_eq!(wallet.status, WalletStatus::Drafted);
                     assert!(wallet.template.is_none());
@@ -2294,7 +2312,7 @@ mod tests {
             let (response, request_id) = Response::from_ws_message(msg).unwrap();
 
             match response {
-                Response::User { user } => {
+                Some(Response::User { user }) => {
                     assert_eq!(user.name, "John Doe");
                     assert_eq!(
                         user.uuid.to_string(),
@@ -2326,7 +2344,7 @@ mod tests {
             let (response, request_id) = Response::from_ws_message(msg).unwrap();
 
             match response {
-                Response::Error { error } => {
+                Some(Response::Error { error }) => {
                     assert_eq!(error.code, "INVALID_REQUEST");
                     assert_eq!(error.message, "Invalid request format");
                     assert_eq!(
@@ -2358,7 +2376,7 @@ mod tests {
             let (response, request_id) = Response::from_ws_message(msg).unwrap();
 
             match response {
-                Response::Error { error } => {
+                Some(Response::Error { error }) => {
                     assert_eq!(error.code, "SERVER_ERROR");
                     assert_eq!(error.message, "Internal server error");
                     // request_id may not be in error object, but should be at protocol level
@@ -2418,10 +2436,8 @@ mod tests {
             let msg = WsMessage::Text(json.to_string());
             let result = Response::from_ws_message(msg);
 
-            assert!(matches!(
-                result,
-                Err(WssConversionError::DeserializationFailed(_))
-            ));
+            // Unknown types are silently ignored (future-proof behavior)
+            assert!(matches!(result, Ok((None, _))));
         }
 
         #[test]
@@ -2446,10 +2462,8 @@ mod tests {
             let msg = WsMessage::Text(json.to_string());
             let result = Response::from_ws_message(msg);
 
-            assert!(matches!(
-                result,
-                Err(WssConversionError::DeserializationFailed(_))
-            ));
+            // Non-critical types with unparseable payloads return None
+            assert!(matches!(result, Ok((None, _))));
         }
 
         #[test]
@@ -2465,9 +2479,9 @@ mod tests {
                 }
             }"#;
             let msg = WsMessage::Text(json.to_string());
-            // With direct deserialization to Org, invalid UUID should fail parsing
+            // Non-critical types with unparseable payloads return None
             let result = Response::from_ws_message(msg);
-            assert!(result.is_err(), "Invalid UUID should fail to parse");
+            assert!(matches!(result, Ok((None, _))));
         }
 
         #[test]
@@ -2484,9 +2498,9 @@ mod tests {
                 }
             }"#;
             let msg = WsMessage::Text(json.to_string());
-            // Parsing now fails for invalid enum variants
+            // Non-critical types with unparseable payloads return None
             let result = Response::from_ws_message(msg);
-            assert!(result.is_err(), "Parsing should fail for invalid status");
+            assert!(matches!(result, Ok((None, _))));
         }
 
         #[test]
@@ -2501,9 +2515,9 @@ mod tests {
                 }
             }"#;
             let msg = WsMessage::Text(json.to_string());
-            // Parsing now fails for invalid enum variants
+            // Non-critical types with unparseable payloads return None
             let result = Response::from_ws_message(msg);
-            assert!(result.is_err(), "Parsing should fail for invalid role");
+            assert!(matches!(result, Ok((None, _))));
         }
 
         #[test]
@@ -2537,9 +2551,9 @@ mod tests {
                 }
             }"#;
             let msg = WsMessage::Text(json.to_string());
-            // Parsing now fails for invalid enum variants
+            // Non-critical types with unparseable payloads return None
             let result = Response::from_ws_message(msg);
-            assert!(result.is_err(), "Parsing should fail for invalid key_type");
+            assert!(matches!(result, Ok((None, _))));
         }
     }
 

--- a/liana-business/business-installer/src/state/update.rs
+++ b/liana-business/business-installer/src/state/update.rs
@@ -398,7 +398,8 @@ impl State {
         if let Some(key) = self.app.keys.get(&key_id) {
             let (email, token) = match &key.identity {
                 KeyIdentity::Email(e) => (e.clone(), String::new()),
-                KeyIdentity::Token { token: t, .. } => (String::new(), t.clone()),
+                KeyIdentity::TokenWithProvider { token: t, .. } => (String::new(), t.clone()),
+                KeyIdentity::Token(t) => (String::new(), t.clone()),
                 KeyIdentity::Other(o) => (o.clone(), String::new()),
             };
             self.views.keys.edit_key_modal = Some(views::EditKeyModalState {
@@ -446,7 +447,7 @@ impl State {
                 modal_state.key_type,
                 ws_business::KeyType::Cosigner | ws_business::KeyType::SafetyNet
             ) {
-                KeyIdentity::Token {
+                KeyIdentity::TokenWithProvider {
                     token: modal_state.token.clone(),
                     provider: None,
                 }
@@ -1544,9 +1545,10 @@ impl State {
                                 // Extract identity fields
                                 let (email, token) = match &key.identity {
                                     KeyIdentity::Email(e) => (e.clone(), String::new()),
-                                    KeyIdentity::Token { token: t, .. } => {
+                                    KeyIdentity::TokenWithProvider { token: t, .. } => {
                                         (String::new(), t.clone())
                                     }
+                                    KeyIdentity::Token(t) => (String::new(), t.clone()),
                                     KeyIdentity::Other(o) => (o.clone(), String::new()),
                                 };
                                 // Update the modal with server data

--- a/liana-business/business-installer/src/state/views/keys/mod.rs
+++ b/liana-business/business-installer/src/state/views/keys/mod.rs
@@ -50,7 +50,7 @@ impl KeysViewState {
             let editing_key_id = modal.key_id;
             let is_duplicate = keys.iter().any(|(&id, k)| {
                 id != editing_key_id
-                    && matches!(&k.identity, KeyIdentity::Token{ token: t, .. } if t == &value)
+                    && matches!(&k.identity, KeyIdentity::TokenWithProvider{ token: t, .. } if t == &value)
             });
             if is_duplicate {
                 modal.token_warning = Some("Duplicate token");

--- a/liana-business/business-installer/src/views/keys/mod.rs
+++ b/liana-business/business-installer/src/views/keys/mod.rs
@@ -30,12 +30,20 @@ fn key_card(
     let identity_display = (!identity_str.is_empty())
         .then(|| text::p2_medium(identity_str).style(theme::text::accent));
 
+    let style = match key.key_type {
+        ws_business::KeyType::Internal => liana_ui::theme::pill::internal,
+        ws_business::KeyType::External => liana_ui::theme::pill::external,
+        ws_business::KeyType::Cosigner | ws_business::KeyType::SafetyNet => {
+            liana_ui::theme::pill::safety_net
+        }
+    };
+
     // Key type badge
     let key_type_str = format!("{:?}", key.key_type);
     let badge = Container::new(
         Container::new(text::caption(key_type_str))
             .padding([4, 12])
-            .style(liana_ui::theme::pill::simple)
+            .style(style)
             .width(Length::Fill)
             .center_x(Length::Fill),
     )

--- a/liana-business/business-installer/src/views/keys/modal.rs
+++ b/liana-business/business-installer/src/views/keys/modal.rs
@@ -69,21 +69,6 @@ pub fn edit_key_modal_view<'a>(
             Message::KeyUpdateAlias,
         ));
 
-    // Description input
-    let desc_value = form::Value {
-        value: modal_state.description.clone(),
-        warning: None,
-        valid: true,
-    };
-    let description_input = Column::new()
-        .spacing(5)
-        .push(text::p1_medium("Key Description").style(theme::text::primary))
-        .push(form::Form::new(
-            "Enter description",
-            &desc_value,
-            Message::KeyUpdateDescr,
-        ));
-
     // Key type picker (placed before identity input)
     let key_types: &[ws_business::KeyType] = &[
         ws_business::KeyType::Internal,
@@ -186,7 +171,6 @@ pub fn edit_key_modal_view<'a>(
     let body = Column::new()
         .push_maybe(last_edit_info)
         .push(alias_input)
-        .push(description_input)
         .push(key_type_picker)
         .push_maybe(email_input)
         .push_maybe(token_input)

--- a/liana-business/business-settings/src/views/mod.rs
+++ b/liana-business/business-settings/src/views/mod.rs
@@ -193,7 +193,7 @@ fn section_header(title: &'static str) -> Element<'static, Msg> {
         .align_y(Alignment::Center)
         .push(
             iced::widget::Button::new(panel_title("Settings"))
-                .style(theme::button::transparent)
+                .style(theme::button::transparent_primary_text)
                 .on_press(Msg::Home),
         )
         .push(icon::chevron_right().size(30))

--- a/liana-connect/src/ws_business/models.rs
+++ b/liana-connect/src/ws_business/models.rs
@@ -211,7 +211,9 @@ pub enum KeyIdentity {
 impl Display for KeyIdentity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let str = match self {
-            KeyIdentity::TokenWithProvider { token, .. } => token,
+            KeyIdentity::TokenWithProvider { token, provider } => provider
+                .as_ref()
+                .map_or(token.as_str(), |p| p.name.as_str()),
             KeyIdentity::Token(s) | KeyIdentity::Email(s) | KeyIdentity::Other(s) => s,
         };
         write!(f, "{str}")

--- a/liana-connect/src/ws_business/models.rs
+++ b/liana-connect/src/ws_business/models.rs
@@ -199,7 +199,8 @@ pub enum KeyIdentity {
     // The key is related to an user account in WS account system
     Email(String),
     // The key is related to a provider in WS keys system
-    Token {
+    Token(String),
+    TokenWithProvider {
         token: String,
         provider: Option<Provider>,
     },
@@ -210,8 +211,8 @@ pub enum KeyIdentity {
 impl Display for KeyIdentity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let str = match self {
-            KeyIdentity::Token { token, .. } => token,
-            KeyIdentity::Email(s) | KeyIdentity::Other(s) => s,
+            KeyIdentity::TokenWithProvider { token, .. } => token,
+            KeyIdentity::Token(s) | KeyIdentity::Email(s) | KeyIdentity::Other(s) => s,
         };
         write!(f, "{str}")
     }
@@ -1187,12 +1188,12 @@ mod wire_format_tests {
 
     #[test]
     fn test_key_with_token_identity_wire_format() {
-        // Documentation: Key with Token identity (flattened as "token" field)
+        // Documentation: Key with TokenWithProvider identity (flattened as "token_with_provider" field)
         let json = r#"{
             "id": 1,
             "alias": "Provider Key",
             "description": "Cosigner service key",
-            "token": { "token" : "provider-token-123", "provider": null},
+            "token_with_provider": { "token": "provider-token-123", "provider": null },
             "key_type": "Cosigner"
         }"#;
 
@@ -1200,7 +1201,7 @@ mod wire_format_tests {
             id: 1,
             alias: "Provider Key".to_string(),
             description: "Cosigner service key".to_string(),
-            identity: KeyIdentity::Token {
+            identity: KeyIdentity::TokenWithProvider {
                 token: "provider-token-123".to_string(),
                 provider: None,
             },

--- a/liana-connect/src/ws_business/protocol.rs
+++ b/liana-connect/src/ws_business/protocol.rs
@@ -475,30 +475,87 @@ impl Response {
         WsMessage::Text(json)
     }
 
-    /// Convert WebSocket message to application-level response, extracting protocol details
+    /// Convert WebSocket message to application-level response, extracting protocol details.
+    ///
+    /// Returns `Ok((None, _))` for unknown message types or known types whose payload
+    /// cannot be parsed (e.g. new enum variants added server-side). This allows older
+    /// clients to operate in degraded mode, silently ignoring messages they don't understand.
+    ///
+    /// Critical message types (`connected`, `pong`, `error`) still return hard errors
+    /// on parse failure since they are required for handshake and keepalive.
     pub fn from_ws_message(
         msg: WsMessage,
-    ) -> Result<(Self, Option<String> /* request_id */), WssConversionError> {
+    ) -> Result<(Option<Self>, Option<String> /* request_id */), WssConversionError> {
         let protocol_response = parse_ws_response(msg)?;
         let request_id = protocol_response.request_id;
 
         // Handle error responses
         if let Some(error) = protocol_response.error {
-            return Ok((Response::Error { error }, request_id));
+            return Ok((Some(Response::Error { error }), request_id));
         }
 
         let response = match protocol_response.msg_type.as_str() {
-            Self::METHOD_CONNECTED => parse_connected(protocol_response.payload)?,
-            Self::METHOD_PONG => Response::Pong,
-            Self::METHOD_ORG => parse_org(protocol_response.payload)?,
-            Self::METHOD_WALLET => parse_wallet(protocol_response.payload)?,
-            Self::METHOD_USER => parse_user(protocol_response.payload)?,
-            Self::METHOD_DELETE_USER_ORG => parse_delete_user_org(protocol_response.payload)?,
+            // Critical types: parse failure is a hard error
+            Self::METHOD_CONNECTED => Some(parse_connected(protocol_response.payload)?),
+            Self::METHOD_PONG => Some(Response::Pong),
+            // Non-critical types: parse failure is silently ignored
+            Self::METHOD_ORG => match parse_org(protocol_response.payload.clone()) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to parse '{}' payload: {}. Payload: {:?}",
+                        protocol_response.msg_type,
+                        e,
+                        protocol_response.payload
+                    );
+                    None
+                }
+            },
+            Self::METHOD_WALLET => match parse_wallet(protocol_response.payload.clone()) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to parse '{}' payload: {}. Payload: {:?}",
+                        protocol_response.msg_type,
+                        e,
+                        protocol_response.payload
+                    );
+                    None
+                }
+            },
+            Self::METHOD_USER => match parse_user(protocol_response.payload.clone()) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to parse '{}' payload: {}. Payload: {:?}",
+                        protocol_response.msg_type,
+                        e,
+                        protocol_response.payload
+                    );
+                    None
+                }
+            },
+            Self::METHOD_DELETE_USER_ORG => {
+                match parse_delete_user_org(protocol_response.payload.clone()) {
+                    Ok(r) => Some(r),
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to parse '{}' payload: {}. Payload: {:?}",
+                            protocol_response.msg_type,
+                            e,
+                            protocol_response.payload
+                        );
+                        None
+                    }
+                }
+            }
             _ => {
-                return Err(WssConversionError::DeserializationFailed(format!(
-                    "Unknown message type: {}",
-                    protocol_response.msg_type
-                )))
+                tracing::debug!(
+                    "Ignoring unknown message type '{}'. Payload: {:?}",
+                    protocol_response.msg_type,
+                    protocol_response.payload
+                );
+                None
             }
         };
 
@@ -1265,7 +1322,7 @@ mod protocol_tests {
         // Verify roundtrip
         assert!(matches!(
             parsed,
-            Response::Connected { version: 1, user } if user == test_uuid(1)
+            Some(Response::Connected { version: 1, user }) if user == test_uuid(1)
         ));
         assert_eq!(request_id, Some("req-001".to_string()));
 
@@ -1289,7 +1346,7 @@ mod protocol_tests {
         let (parsed, request_id) = Response::from_ws_message(ws_msg).unwrap();
 
         // Verify roundtrip
-        assert!(matches!(parsed, Response::Pong));
+        assert!(matches!(parsed, Some(Response::Pong)));
         assert_eq!(request_id, Some("req-002".to_string()));
 
         // Verify wire format against hardcoded JSON
@@ -1333,7 +1390,7 @@ mod protocol_tests {
 
         // Verify roundtrip
         match parsed {
-            Response::Org { org: parsed_org } => assert_eq!(parsed_org, org),
+            Some(Response::Org { org: parsed_org }) => assert_eq!(parsed_org, org),
             _ => panic!("Expected Org response"),
         }
         assert_eq!(request_id, Some("req-004".to_string()));
@@ -1375,7 +1432,7 @@ mod protocol_tests {
 
         // Verify roundtrip
         match parsed {
-            Response::Org { org: parsed_org } => assert_eq!(parsed_org, org),
+            Some(Response::Org { org: parsed_org }) => assert_eq!(parsed_org, org),
             _ => panic!("Expected Org response"),
         }
         assert_eq!(request_id, Some("req-004".to_string()));
@@ -1422,9 +1479,9 @@ mod protocol_tests {
 
         // Verify roundtrip
         match parsed {
-            Response::Wallet {
+            Some(Response::Wallet {
                 wallet: parsed_wallet,
-            } => assert_eq!(parsed_wallet, wallet),
+            }) => assert_eq!(parsed_wallet, wallet),
             _ => panic!("Expected Wallet response"),
         }
         assert_eq!(request_id, Some("req-005".to_string()));
@@ -1510,9 +1567,9 @@ mod protocol_tests {
 
         // Verify roundtrip
         match parsed {
-            Response::Wallet {
+            Some(Response::Wallet {
                 wallet: parsed_wallet,
-            } => assert_eq!(parsed_wallet, wallet),
+            }) => assert_eq!(parsed_wallet, wallet),
             _ => panic!("Expected Wallet response"),
         }
         assert_eq!(request_id, Some("req-005".to_string()));
@@ -1552,7 +1609,7 @@ mod protocol_tests {
 
         // Verify roundtrip
         match parsed {
-            Response::User { user: parsed_user } => assert_eq!(parsed_user, user),
+            Some(Response::User { user: parsed_user }) => assert_eq!(parsed_user, user),
             _ => panic!("Expected User response"),
         }
         assert_eq!(request_id, Some("req-006".to_string()));
@@ -1585,7 +1642,7 @@ mod protocol_tests {
 
         // Verify roundtrip
         match parsed {
-            Response::DeleteUserOrg { user, org } => {
+            Some(Response::DeleteUserOrg { user, org }) => {
                 assert_eq!(user, test_uuid(1));
                 assert_eq!(org, test_uuid(2));
             }
@@ -1625,9 +1682,9 @@ mod protocol_tests {
 
         // Verify roundtrip
         match parsed {
-            Response::Error {
+            Some(Response::Error {
                 error: parsed_error,
-            } => assert_eq!(parsed_error, error),
+            }) => assert_eq!(parsed_error, error),
             _ => panic!("Expected Error response"),
         }
         assert_eq!(request_id, Some("req-007".to_string()));
@@ -1797,17 +1854,17 @@ mod protocol_tests {
     }
 
     #[test]
-    fn test_error_unknown_message_type() {
-        // Unknown message type should fail
+    fn test_unknown_message_type_returns_none() {
+        // Unknown message type should be silently ignored (returns None)
         let json = r#"{"type": "unknown_type", "request_id": "req-001"}"#;
         let ws_msg = WsMessage::Text(json.to_string());
         let result = Response::from_ws_message(ws_msg);
 
         match result {
-            Err(WssConversionError::DeserializationFailed(msg)) => {
-                assert!(msg.contains("Unknown message type"));
+            Ok((None, Some(req_id))) => {
+                assert_eq!(req_id, "req-001");
             }
-            _ => panic!("Expected DeserializationFailed with unknown message type"),
+            _ => panic!("Expected Ok((None, Some(request_id)))"),
         }
     }
 
@@ -1842,87 +1899,57 @@ mod protocol_tests {
     }
 
     #[test]
-    fn test_error_org_missing_payload() {
-        // "org" response without payload should fail
+    fn test_org_missing_payload_returns_none() {
+        // "org" response without payload should be silently ignored
         let json = r#"{"type": "org", "request_id": "req-001"}"#;
         let ws_msg = WsMessage::Text(json.to_string());
-        let result = Response::from_ws_message(ws_msg);
-
-        match result {
-            Err(WssConversionError::DeserializationFailed(msg)) => {
-                assert!(msg.contains("Missing payload"));
-            }
-            _ => panic!("Expected DeserializationFailed with missing payload"),
-        }
+        let (parsed, _) = Response::from_ws_message(ws_msg).unwrap();
+        assert!(parsed.is_none());
     }
 
     #[test]
-    fn test_error_org_invalid_payload() {
-        // "org" response with invalid org structure should fail
+    fn test_org_invalid_payload_returns_none() {
+        // "org" response with invalid org structure should be silently ignored
         let json = r#"{"type": "org", "request_id": "req-001", "payload": {"invalid": true}}"#;
         let ws_msg = WsMessage::Text(json.to_string());
-        let result = Response::from_ws_message(ws_msg);
-
-        assert!(matches!(
-            result,
-            Err(WssConversionError::DeserializationFailed(_))
-        ));
+        let (parsed, _) = Response::from_ws_message(ws_msg).unwrap();
+        assert!(parsed.is_none());
     }
 
     #[test]
-    fn test_error_wallet_missing_payload() {
-        // "wallet" response without payload should fail
+    fn test_wallet_missing_payload_returns_none() {
+        // "wallet" response without payload should be silently ignored
         let json = r#"{"type": "wallet", "request_id": "req-001"}"#;
         let ws_msg = WsMessage::Text(json.to_string());
-        let result = Response::from_ws_message(ws_msg);
-
-        match result {
-            Err(WssConversionError::DeserializationFailed(msg)) => {
-                assert!(msg.contains("Missing payload"));
-            }
-            _ => panic!("Expected DeserializationFailed with missing payload"),
-        }
+        let (parsed, _) = Response::from_ws_message(ws_msg).unwrap();
+        assert!(parsed.is_none());
     }
 
     #[test]
-    fn test_error_wallet_invalid_payload() {
-        // "wallet" response with invalid wallet structure should fail
+    fn test_wallet_invalid_payload_returns_none() {
+        // "wallet" response with invalid wallet structure should be silently ignored
         let json = r#"{"type": "wallet", "request_id": "req-001", "payload": {"invalid": true}}"#;
         let ws_msg = WsMessage::Text(json.to_string());
-        let result = Response::from_ws_message(ws_msg);
-
-        assert!(matches!(
-            result,
-            Err(WssConversionError::DeserializationFailed(_))
-        ));
+        let (parsed, _) = Response::from_ws_message(ws_msg).unwrap();
+        assert!(parsed.is_none());
     }
 
     #[test]
-    fn test_error_user_missing_payload() {
-        // "user" response without payload should fail
+    fn test_user_missing_payload_returns_none() {
+        // "user" response without payload should be silently ignored
         let json = r#"{"type": "user", "request_id": "req-001"}"#;
         let ws_msg = WsMessage::Text(json.to_string());
-        let result = Response::from_ws_message(ws_msg);
-
-        match result {
-            Err(WssConversionError::DeserializationFailed(msg)) => {
-                assert!(msg.contains("Missing payload"));
-            }
-            _ => panic!("Expected DeserializationFailed with missing payload"),
-        }
+        let (parsed, _) = Response::from_ws_message(ws_msg).unwrap();
+        assert!(parsed.is_none());
     }
 
     #[test]
-    fn test_error_user_invalid_payload() {
-        // "user" response with invalid user structure should fail
+    fn test_user_invalid_payload_returns_none() {
+        // "user" response with invalid user structure should be silently ignored
         let json = r#"{"type": "user", "request_id": "req-001", "payload": {"invalid": true}}"#;
         let ws_msg = WsMessage::Text(json.to_string());
-        let result = Response::from_ws_message(ws_msg);
-
-        assert!(matches!(
-            result,
-            Err(WssConversionError::DeserializationFailed(_))
-        ));
+        let (parsed, _) = Response::from_ws_message(ws_msg).unwrap();
+        assert!(parsed.is_none());
     }
 
     #[test]
@@ -1936,7 +1963,7 @@ mod protocol_tests {
         let (parsed, request_id) = Response::from_ws_message(ws_msg).unwrap();
 
         // Verify roundtrip
-        assert!(matches!(parsed, Response::Pong));
+        assert!(matches!(parsed, Some(Response::Pong)));
         assert!(request_id.is_none());
 
         // Verify wire format against hardcoded JSON
@@ -2248,7 +2275,7 @@ mod protocol_tests {
 
         assert!(matches!(
             parsed,
-            Response::Connected { version: 1, user } if user == test_uuid(1)
+            Some(Response::Connected { version: 1, user }) if user == test_uuid(1)
         ));
         assert_eq!(request_id, Some("req-001".to_string()));
     }
@@ -2259,7 +2286,7 @@ mod protocol_tests {
         let ws_msg = response.to_ws_message(Some("req-002"));
         let (parsed, request_id) = Response::from_ws_message(ws_msg).unwrap();
 
-        assert!(matches!(parsed, Response::Pong));
+        assert!(matches!(parsed, Some(Response::Pong)));
         assert_eq!(request_id, Some("req-002".to_string()));
     }
 
@@ -2279,7 +2306,7 @@ mod protocol_tests {
         let (parsed, request_id) = Response::from_ws_message(ws_msg).unwrap();
 
         match parsed {
-            Response::Org { org: o } => assert_eq!(o, org),
+            Some(Response::Org { org: o }) => assert_eq!(o, org),
             _ => panic!("Expected Org response"),
         }
         assert_eq!(request_id, Some("req-003".to_string()));
@@ -2306,7 +2333,7 @@ mod protocol_tests {
         let (parsed, request_id) = Response::from_ws_message(ws_msg).unwrap();
 
         match parsed {
-            Response::Wallet { wallet: w } => assert_eq!(w, wallet),
+            Some(Response::Wallet { wallet: w }) => assert_eq!(w, wallet),
             _ => panic!("Expected Wallet response"),
         }
         assert_eq!(request_id, Some("req-004".to_string()));
@@ -2327,7 +2354,7 @@ mod protocol_tests {
         let (parsed, request_id) = Response::from_ws_message(ws_msg).unwrap();
 
         match parsed {
-            Response::User { user: u } => assert_eq!(u, user),
+            Some(Response::User { user: u }) => assert_eq!(u, user),
             _ => panic!("Expected User response"),
         }
         assert_eq!(request_id, Some("req-005".to_string()));
@@ -2347,7 +2374,7 @@ mod protocol_tests {
         let (parsed, request_id) = Response::from_ws_message(ws_msg).unwrap();
 
         match parsed {
-            Response::Error { error: e } => assert_eq!(e, error),
+            Some(Response::Error { error: e }) => assert_eq!(e, error),
             _ => panic!("Expected Error response"),
         }
         assert_eq!(request_id, Some("req-006".to_string()));
@@ -2363,7 +2390,7 @@ mod protocol_tests {
         let (parsed, request_id) = Response::from_ws_message(ws_msg).unwrap();
 
         match parsed {
-            Response::DeleteUserOrg { user, org } => {
+            Some(Response::DeleteUserOrg { user, org }) => {
                 assert_eq!(user, test_uuid(1));
                 assert_eq!(org, test_uuid(2));
             }
@@ -2378,7 +2405,7 @@ mod protocol_tests {
         let ws_msg = response.to_ws_message(None);
         let (parsed, request_id) = Response::from_ws_message(ws_msg).unwrap();
 
-        assert!(matches!(parsed, Response::Pong));
+        assert!(matches!(parsed, Some(Response::Pong)));
         assert!(request_id.is_none());
     }
 

--- a/liana-connect/src/ws_business/protocol.rs
+++ b/liana-connect/src/ws_business/protocol.rs
@@ -240,7 +240,7 @@ fn parse_edit_xpub_request(payload: Option<Value>) -> Result<Request, WssConvers
         .as_u64()
         .ok_or_else(|| WssConversionError::DeserializationFailed("Missing key_id".to_string()))?
         as u8;
-    let xpub = if let Some(xpub_value) = payload.get("xpub") {
+    let xpub = if let Some(xpub_value) = payload.get("xpub").filter(|v| !v.is_null()) {
         Some(
             serde_json::from_value(xpub_value.clone())
                 .map_err(|e| WssConversionError::DeserializationFailed(e.to_string()))?,
@@ -2501,6 +2501,27 @@ mod protocol_tests {
                 assert!(msg.contains("Missing wallet_id"));
             }
             _ => panic!("Expected DeserializationFailed with missing wallet_id"),
+        }
+    }
+
+    #[test]
+    fn test_request_from_ws_message_edit_xpub_null_xpub() {
+        // When the backend sends "xpub": null, it should be parsed as None
+        let json = r#"{"type": "edit_xpub", "token": "t", "request_id": "r", "payload": {"wallet_id": "12345678-1234-1234-1234-123456789001", "key_id": 0, "xpub": null}}"#;
+        let ws_msg = WsMessage::Text(json.to_string());
+        let (parsed, _, _) = Request::from_ws_message(ws_msg).unwrap();
+
+        match parsed {
+            Request::EditXpub {
+                wallet_id,
+                key_id,
+                xpub,
+            } => {
+                assert_eq!(wallet_id, test_uuid(1));
+                assert_eq!(key_id, 0);
+                assert!(xpub.is_none());
+            }
+            _ => panic!("Expected EditXpub"),
         }
     }
 

--- a/liana-gui/src/app/view/settings/mod.rs
+++ b/liana-gui/src/app/view/settings/mod.rs
@@ -48,13 +48,13 @@ fn header(title: &str, msg: SettingsMessage) -> Row<'static, Message> {
         .align_y(Alignment::Center)
         .push(
             Button::new(panel_title("Settings"))
-                .style(theme::button::transparent)
+                .style(theme::button::transparent_primary_text)
                 .on_press(Message::Menu(Menu::Settings)),
         )
         .push(icon::chevron_right().size(30))
         .push(
             Button::new(panel_title(title))
-                .style(theme::button::transparent)
+                .style(theme::button::transparent_primary_text)
                 .on_press(Message::Settings(msg)),
         )
 }
@@ -115,7 +115,7 @@ fn export_section(
 
 pub fn list(cache: &Cache, is_remote_backend: bool) -> Element<Message> {
     let header = Button::new(panel_title("Settings"))
-        .style(theme::button::transparent)
+        .style(theme::button::transparent_primary_text)
         .on_press(Message::Menu(Menu::Settings));
 
     let general = settings_section(

--- a/liana-ui/src/theme/button.rs
+++ b/liana-ui/src/theme/button.rs
@@ -98,6 +98,16 @@ pub fn transparent(theme: &Theme, status: Status) -> Style {
     )
 }
 
+pub fn transparent_primary_text(theme: &Theme, status: Status) -> Style {
+    let mut style = button(
+        &theme.colors.buttons.transparent,
+        status,
+        theme.button_border_width,
+    );
+    style.text_color = theme.colors.text.primary;
+    style
+}
+
 pub fn transparent_border(theme: &Theme, status: Status) -> Style {
     button(
         &theme.colors.buttons.transparent_border,

--- a/liana-ui/src/theme/palette/liana.rs
+++ b/liana-ui/src/theme/palette/liana.rs
@@ -477,6 +477,21 @@ impl Palette {
                     text: color::LIGHT_BLACK.into(),
                     border: color::GREEN.into(),
                 },
+                internal: ContainerPalette {
+                    background: color::TRANSPARENT,
+                    text: color::GREY_3.into(),
+                    border: color::GREY_3.into(),
+                },
+                external: ContainerPalette {
+                    background: color::TRANSPARENT,
+                    text: color::GREY_3.into(),
+                    border: color::GREY_3.into(),
+                },
+                safety_net: ContainerPalette {
+                    background: color::TRANSPARENT,
+                    text: color::GREY_3.into(),
+                    border: color::GREY_3.into(),
+                },
             },
             notifications: Notifications {
                 pending: ContainerPalette {

--- a/liana-ui/src/theme/palette/liana_business.rs
+++ b/liana-ui/src/theme/palette/liana_business.rs
@@ -42,6 +42,9 @@ color!(INPUT_BORDER, 0xCED4DA);
 pub const MENU_BG: Color = color::WHITE;
 color!(MENU_BG_HOVER, 0xE9ECEF);
 
+color!(EXTERNAL, 0x0F172A);
+color!(SAFETY_NET, 0x475569);
+
 impl Palette {
     pub fn business() -> Self {
         Self {
@@ -443,6 +446,21 @@ impl Palette {
                     background: color::DARK_GREEN,
                     text: color::WHITE.into(),
                     border: color::DARK_GREEN.into(),
+                },
+                internal: ContainerPalette {
+                    background: color::BUSINESS_BLUE,
+                    text: color::WHITE.into(),
+                    border: color::BUSINESS_BLUE.into(),
+                },
+                external: ContainerPalette {
+                    background: EXTERNAL,
+                    text: color::WHITE.into(),
+                    border: EXTERNAL.into(),
+                },
+                safety_net: ContainerPalette {
+                    background: SAFETY_NET,
+                    text: color::WHITE.into(),
+                    border: SAFETY_NET.into(),
                 },
             },
             notifications: Notifications {

--- a/liana-ui/src/theme/palette/mod.rs
+++ b/liana-ui/src/theme/palette/mod.rs
@@ -122,6 +122,9 @@ pub struct Pills {
     pub primary: ContainerPalette,
     pub success: ContainerPalette,
     pub warning: ContainerPalette,
+    pub internal: ContainerPalette,
+    pub external: ContainerPalette,
+    pub safety_net: ContainerPalette,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/liana-ui/src/theme/pill.rs
+++ b/liana-ui/src/theme/pill.rs
@@ -32,3 +32,15 @@ pub fn success(theme: &Theme) -> Style {
 pub fn warning(theme: &Theme) -> Style {
     pill(&theme.colors.pills.warning)
 }
+
+pub fn internal(theme: &Theme) -> Style {
+    pill(&theme.colors.pills.internal)
+}
+
+pub fn external(theme: &Theme) -> Style {
+    pill(&theme.colors.pills.external)
+}
+
+pub fn safety_net(theme: &Theme) -> Style {
+    pill(&theme.colors.pills.safety_net)
+}


### PR DESCRIPTION
this PR:
- reinstate the KeyIdentity variant replaced in previous commit while renaming the newly introduced
- display the token provider name in business-installer when available (close #2064)
- fix a parsing bug in ws_business
- make the ws_business protocol future proof
- use a different pill style for each key type:
<img width="1018" height="589" alt="image" src="https://github.com/user-attachments/assets/d76994da-eac4-4267-9207-e2a6ad761edb" />
- remove the description input in the key modal: (close #2072 )
<img width="564" height="401" alt="image" src="https://github.com/user-attachments/assets/21da280a-b0bb-4071-94b9-768874d81779" />

- fix setting breadcrumbs colors:
<img width="934" height="304" alt="image" src="https://github.com/user-attachments/assets/7f2c02d6-02de-478e-b3c9-553f93b9e83a" />


