### PR TITLE
Fix reproducible Windows build by stripping COFF symbol table

### DIFF
--- a/nix/liana-business.nix
+++ b/nix/liana-business.nix
@@ -28,7 +28,7 @@ let
 
     SOURCE_DATE_EPOCH = 1;
     CARGO_BUILD_TARGET = "x86_64-pc-windows-gnu";
-    CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-C link-arg=-Wl,--no-insert-timestamp -C link-arg=-L${pkgs.pkgsCross.mingwW64.windows.pthreads}/lib";
+    CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-C link-arg=-Wl,--no-insert-timestamp -C link-arg=-Wl,--strip-all -C link-arg=-L${pkgs.pkgsCross.mingwW64.windows.pthreads}/lib";
 
     HOST_CC = "${pkgs.stdenv.cc}/bin/cc";
     TARGET_CC = "${pkgs.pkgsCross.mingwW64.stdenv.cc}/bin/${pkgs.pkgsCross.mingwW64.stdenv.cc.targetPrefix}cc";

--- a/nix/liana.nix
+++ b/nix/liana.nix
@@ -24,10 +24,7 @@ let
 
     SOURCE_DATE_EPOCH = 1;
     CARGO_BUILD_TARGET = "x86_64-pc-windows-gnu";
-    # CARGO_BUILD_RUSTFLAGS = "-C link-arg=-Wl,--no-insert-timestamp -C link-arg=-L${pkgs.pkgsCross.mingwW64.windows.pthreads}/lib";
-    # CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-C link-arg=-Wl,--no-insert-timestamp -C link-arg=-L${pkgs.pkgsCross.mingwW64.windows.pthreads}/lib";
-    # CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-C link-arg=-Wl,--no-insert-timestamp -C link-arg=-Wl,--image-base,0x10000 -C link-arg=-L${pkgs.pkgsCross.mingwW64.windows.pthreads}/lib";
-    CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-C link-arg=-Wl,--no-insert-timestamp -C link-arg=-L${pkgs.pkgsCross.mingwW64.windows.pthreads}/lib";
+    CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-C link-arg=-Wl,--no-insert-timestamp -C link-arg=-Wl,--strip-all -C link-arg=-L${pkgs.pkgsCross.mingwW64.windows.pthreads}/lib";
 
     HOST_CC = "${pkgs.stdenv.cc}/bin/cc";
     TARGET_CC = "${pkgs.pkgsCross.mingwW64.stdenv.cc}/bin/${pkgs.pkgsCross.mingwW64.stdenv.cc.targetPrefix}cc";


### PR DESCRIPTION
The GNU linker appends a COFF symbol table to the PE binary containing auxiliary symbol data (sizes, section offsets) that depends on compilation ordering. Since Rust/LLVM processes codegen units in parallel, this metadata varies between builds even with identical inputs.

The COFF symbol table is not used at runtime (Windows ignores it) and modern debugging uses separate PDB files instead. Stripping it with --strip-all removes the non-deterministic data and also reduces binary size significantly

this is a backport of #2084 