### PR TITLE
Rework sidebar responsive mechanism

### DIFF
--- a/liana-business/src/settings/mod.rs
+++ b/liana-business/src/settings/mod.rs
@@ -32,9 +32,9 @@ use liana_gui::{
     services::connect::client::backend::{api, BackendWalletClient},
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
+use std::{cell::Cell, collections::HashMap};
 
 /// Currencies supported by the business backend.
 ///
@@ -208,6 +208,7 @@ impl SettingsTrait for BusinessSettings {
                     last_tick: Instant::now(),
                 },
                 fiat_price: None,
+                pane_size: Cell::new(iced::window::Settings::default().size),
             };
 
             Ok(app::App::new(

--- a/liana-gui/src/app/cache.rs
+++ b/liana-gui/src/app/cache.rs
@@ -10,10 +10,10 @@ use crate::{
         Currency, PriceSource,
     },
 };
+use iced::Size;
 use liana::miniscript::bitcoin::Network;
 use lianad::commands::CoinStatus;
-use std::sync::Arc;
-use std::time::Instant;
+use std::{cell::Cell, sync::Arc, time::Instant};
 
 #[derive(Debug, Clone)]
 pub struct Cache {
@@ -24,6 +24,8 @@ pub struct Cache {
     pub last_poll_at_startup: Option<u32>,
     pub daemon_cache: DaemonCache,
     pub fiat_price: Option<FiatPrice>,
+    /// Last observed pane size
+    pub pane_size: Cell<Size>,
 }
 
 /// only used for tests.
@@ -36,6 +38,7 @@ impl std::default::Default for Cache {
             last_poll_at_startup: None,
             daemon_cache: DaemonCache::default(),
             fiat_price: None,
+            pane_size: Cell::new(iced::window::Settings::default().size),
         }
     }
 }

--- a/liana-gui/src/app/view/mod.rs
+++ b/liana-gui/src/app/view/mod.rs
@@ -20,7 +20,7 @@ pub use message::*;
 use warning::warn;
 
 use iced::{
-    widget::{column, responsive, row, scrollable, Space},
+    widget::{column, responsive, row, scrollable, stack, Space},
     Length,
 };
 
@@ -37,8 +37,6 @@ use crate::app::{
     error::Error,
     menu::{Menu, MenuWidth},
 };
-
-use std::cell::RefCell;
 
 pub fn sidebar<'a>(
     active: &Menu,
@@ -93,48 +91,53 @@ pub fn dashboard<'a, T: Into<Element<'a, Message>>>(
     warning: Option<&'a Error>,
     content: T,
 ) -> Element<'a, Message> {
-    let content_cell = RefCell::new(Some(content.into()));
-    responsive(move |size| {
-        let sidebar_width = MenuWidth::from_pane_width(size.width);
-        let content = content_cell
-            .borrow_mut()
-            .take()
-            .unwrap_or_else(|| Space::new(Length::Fill, Length::Shrink).into());
-        Row::new()
-            .push(
-                sidebar(menu, cache, sidebar_width)
-                    .height(Length::Fill)
-                    .width(Length::Fixed(sidebar_width.into())),
-            )
-            .push(
-                Column::new()
-                    .push(warn(warning))
-                    .push(
-                        Container::new(column![
-                            Space::with_height(25),
-                            Container::new(
-                                scrollable(row!(
-                                    Space::with_width(Length::FillPortion(1)),
-                                    column!(Space::with_height(Length::Fixed(150.0)), content)
-                                        .width(Length::FillPortion(8))
-                                        .max_width(1500),
-                                    Space::with_width(Length::FillPortion(1)),
-                                ))
-                                .on_scroll(|w| Message::Scroll(w.absolute_offset().y)),
-                            )
-                            .center_x(Length::Fill)
-                            .style(theme::container::panel_background)
-                            .height(Length::Fill)
-                        ])
-                        .style(theme::container::sidebar),
-                    )
-                    .width(Length::Fill),
-            )
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .into()
+    // The probe's closure fires during iced's layout pass, not synchronously
+    // here, so `sidebar_width` below always reads the size cached by the
+    // *previous* frame's layout. One-frame lag on resize is expected.
+    let pane_size_cell = &cache.pane_size;
+    let probe: Element<'a, Message> = responsive(move |size| {
+        pane_size_cell.set(size);
+        Space::new(Length::Fill, Length::Fill).into()
     })
-    .into()
+    .into();
+
+    let sidebar_width = MenuWidth::from_pane_width(cache.pane_size.get().width);
+
+    let view: Element<'a, Message> = Row::new()
+        .push(
+            sidebar(menu, cache, sidebar_width)
+                .height(Length::Fill)
+                .width(Length::Fixed(sidebar_width.into())),
+        )
+        .push(
+            Column::new()
+                .push(warn(warning))
+                .push(
+                    Container::new(column![
+                        Space::with_height(25),
+                        Container::new(
+                            scrollable(row!(
+                                Space::with_width(Length::FillPortion(1)),
+                                column!(Space::with_height(Length::Fixed(150.0)), content.into())
+                                    .width(Length::FillPortion(8))
+                                    .max_width(1500),
+                                Space::with_width(Length::FillPortion(1)),
+                            ))
+                            .on_scroll(|w| Message::Scroll(w.absolute_offset().y)),
+                        )
+                        .center_x(Length::Fill)
+                        .style(theme::container::panel_background)
+                        .height(Length::Fill)
+                    ])
+                    .style(theme::container::sidebar),
+                )
+                .width(Length::Fill),
+        )
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into();
+
+    stack![probe, view].into()
 }
 
 pub fn modal<'a, T: Into<Element<'a, Message>>, F: Into<Element<'a, Message>>>(

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -653,6 +653,7 @@ pub fn create_app_with_remote_backend(
                 last_tick: Instant::now(),
             },
             fiat_price: None,
+            pane_size: std::cell::Cell::new(iced::window::Settings::default().size),
         },
         Arc::new(
             Wallet::new(wallet.descriptor)

--- a/liana-gui/src/loader.rs
+++ b/liana-gui/src/loader.rs
@@ -451,6 +451,7 @@ pub async fn load_application(
             ..Default::default()
         },
         fiat_price: None,
+        pane_size: std::cell::Cell::new(iced::window::Settings::default().size),
     };
 
     Ok((Arc::new(wallet), cache, daemon, internal_bitcoind, backup))


### PR DESCRIPTION
This is preparatory work to try fixing an issue that arise while bumping iced version, see [this comment](https://github.com/wizardsardine/liana/pull/2086#issuecomment-4289945351).

Before we where draing the view from the closure passed to `responsive()`, now we use only `responsive()` as a "probe" to populate `Cache` with the pane size, and draw the view independently.