### PR TITLE
lianad: fix JSON-RPC server truncating responses larger than the kernel send buffer

### DIFF
--- a/lianad/src/jsonrpc/server/unix.rs
+++ b/lianad/src/jsonrpc/server/unix.rs
@@ -88,6 +88,15 @@ fn connection_handler(
     mut stream: net::UnixStream,
     shutdown: sync::Arc<atomic::AtomicBool>,
 ) -> Result<(), io::Error> {
+    // The listener is set non-blocking so `accept` can poll for
+    // shutdown; on macOS the accepted connection inherits that
+    // flag. Force blocking on the connection so the response write
+    // below doesn't see `WouldBlock` once the kernel send buffer
+    // fills (default `SO_SNDBUF` of 8 KiB on macOS), which would
+    // otherwise truncate any RPC response larger than 8 KiB —
+    // notably `createspend` PSBTs for any non-trivial multipath
+    // descriptor.
+    stream.set_nonblocking(false)?;
     let mut buf = vec![0; 2048];
     let mut end = 0;
     let mut cursor = 0;
@@ -111,7 +120,20 @@ fn connection_handler(
         let response =
             api::handle_request(&mut control, req).unwrap_or_else(|e| Response::error(req_id, e));
         log::trace!("JSONRPC response: {:?}", serde_json::to_string(&response));
-        if let Err(e) = serde_json::to_writer(&stream, &response) {
+        // Serialize fully then `write_all`, rather than
+        // `serde_json::to_writer(&stream, ...)` directly. The
+        // `Write` impl for `&UnixStream` calls `write(2)` once;
+        // `to_writer` does not loop on short writes, so a response
+        // partially accepted by the kernel ends up truncated on
+        // the wire. `write_all` loops until every byte is flushed.
+        let response_bytes = match serde_json::to_vec(&response) {
+            Ok(b) => b,
+            Err(e) => {
+                log::error!("Error serializing response: '{}'", e);
+                return Ok(());
+            }
+        };
+        if let Err(e) = io::Write::write_all(&mut &stream, &response_bytes) {
             log::error!("Error writing response: '{}'", e);
             return Ok(());
         }


### PR DESCRIPTION
## TL;DR

\`lianad\`'s Unix-domain JSON-RPC server silently truncates response bodies on macOS once they exceed the default \`SO_SNDBUF\` size (8 KiB). Reproduces deterministically with any \`createspend\` whose PSBT exceeds ~6 KiB pre-base64 — typical of multipath multi-key descriptors. Two interacting issues; this PR fixes both.

(I reported this privately to Edouard 2026-04-29 with a different — incorrect — hypothesis about \`BufWriter\` flushing. The mechanism described below is the actual one. Edouard cleared public disclosure today.)

## Mechanism

1. **Inherited non-blocking flag.** [\`server/unix.rs\`](https://github.com/wizardsardine/liana/blob/master/lianad/src/jsonrpc/server/unix.rs#L147) calls \`listener.set_nonblocking(true)\` so \`accept\` can poll for shutdown. On macOS, the accepted connection inherits \`O_NONBLOCK\` from the listener (\`accept(2)\` propagates the flag). Rust's \`std\` doesn't normalise this; on Linux \`accept4\` is preferred and the inheritance is opt-in via \`SOCK_NONBLOCK\`.
2. **Single-shot write.** [Line 114](https://github.com/wizardsardine/liana/blob/master/lianad/src/jsonrpc/server/unix.rs#L114) uses \`serde_json::to_writer(&stream, &response)\`, which under the hood calls \`Write::write\` once with the full serialized response. On a blocking socket, \`write\` is allowed to return a short count; on a non-blocking socket it can also return \`WouldBlock\`. Either way, \`to_writer\` does not loop, so the trailing bytes are silently dropped and the connection closes — leaving the client with truncated JSON.

## Fix

Two small changes to \`connection_handler\`:

1. **\`stream.set_nonblocking(false)?\`** — force the accepted connection to blocking so the kernel back-pressures the writer rather than returning \`WouldBlock\`.
2. **Serialize then \`write_all\`** — \`serde_json::to_vec\` into a \`Vec<u8>\`, then \`io::Write::write_all(&mut &stream, &bytes)\`. \`write_all\` loops on short writes; combined with the blocking socket this guarantees all bytes are flushed before the connection closes.

Either change in isolation is insufficient on macOS — the \`write_all\` loop alone still aborts on \`WouldBlock\` from a non-blocking socket, and the blocking-socket alone still relies on a single \`write\` call fully accepting the response (not guaranteed for any size).

## Reproducer

Tested on macOS 14, aarch64. Same Python script reproduces against any deathlock-style multipath descriptor:

\`\`\`python
import socket, json
def call(method, params):
    req = (json.dumps({\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": method, \"params\": params}) + \"\n\").encode()
    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
    s.connect(\"<socket path>\")
    s.sendall(req); s.shutdown(socket.SHUT_WR)
    buf = b\"\"
    while True:
        chunk = s.recv(65536)
        if not chunk: break
        buf += chunk
    return buf

addr = json.loads(call(\"getnewaddress\", {}))[\"result\"][\"address\"]
buf = call(\"createspend\", {\"outpoints\": [], \"destinations\": {addr: 250000}, \"feerate\": 2})
print(f\"bytes: {len(buf)}\")
try:
    json.loads(buf)
    print(\"ok\")
except json.JSONDecodeError as e:
    print(f\"truncated: {e}\")
\`\`\`

- **Pre-fix (v13.1, v14.0):** 8192 bytes; truncated mid-base64 inside the PSBT string.
- **Post-fix:** 38628 bytes; complete JSON; PSBT length 38368.

## Affected versions

v13.1 and v14.0 both have the buggy code unchanged at the same line numbers. The bug is macOS-specific in practice because Linux \`SO_SNDBUF\` defaults are higher and \`accept\` flag-inheritance differs, but the fix is correct on both platforms (\`set_nonblocking(false)\` is a no-op on Linux when the flag isn't inherited, and \`write_all\` is strictly an improvement over \`to_writer\` everywhere).

## Why it matters in practice

Per Edouard's reply on the private thread: lianad's RPC API is largely unused by Wizard Sardine's services, and the GUI uses the embedded daemon mode. Out-of-band consumers — \`liana-cli\` for PSBT-producing operations, or third-party Tauri/Electron wallets running lianad as a sidecar — do hit it. Our use case is the latter; the bug was a hard blocker on the wallet's check-in / sweep flow.

I'm happy to follow up with a Linux \`accept4\` migration as a separate PR if it's of interest, but that's a larger change. This PR is the minimal fix.