### PR TITLE
Debugger minimal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default-members = [
 [workspace.dependencies]
 # Internal crates
 liana = { path = "liana" }
-liana-gui = { path = "liana-gui" }
+liana-gui = { path = "liana-gui", default-features = false }
 liana-ui = { path = "liana-ui" }
 liana-connect = { path = "liana-connect" }
 

--- a/contrib/reproducible/guix/build.sh
+++ b/contrib/reproducible/guix/build.sh
@@ -30,11 +30,19 @@ EOF
 # We need to set RUSTC_BOOTSTRAP=1 as a workaround to be able to use unstable
 # features in the GUI dependencies
 for package_name in "lianad" "liana-gui" "liana-business"; do
+    # Disable default features for liana-gui and liana-business so the
+    # `debugger` feature (default-on for development) is not compiled into
+    # release artifacts.
+    case "$package_name" in
+        liana-gui|liana-business) extra_args="--no-default-features" ;;
+        *) extra_args="" ;;
+    esac
     RUSTC_BOOTSTRAP=1 cargo zigbuild -vvv \
         --color always \
         --frozen \
         --offline \
         -p "$package_name" \
+        $extra_args \
         --jobs "$JOBS" \
 	--target x86_64-unknown-linux-gnu.2.31 \
         --release \

--- a/liana-business/Cargo.toml
+++ b/liana-business/Cargo.toml
@@ -10,13 +10,17 @@ LegalCopyright = "Copyright © 2025"
 name = "liana-business"
 path = "src/main.rs"
 
+[features]
+default = ["debugger"]
+debugger = ["liana-gui/debugger", "business-installer/debugger"]
+
 [dependencies]
-business-installer = { path = "./business-installer" }
+business-installer = { path = "./business-installer", default-features = false }
 async-hwi = { workspace = true }
 iced = { workspace = true, default-features = false, features = ["tokio", "svg", "image", "wgpu", "tiny-skia", "x11", "wayland"] }
 iced_runtime = { workspace = true }
 liana = { path = "../liana" }
-liana-gui = { path = "../liana-gui", features = ["skip-windows-icon"] }
+liana-gui = { path = "../liana-gui", default-features = false, features = ["skip-windows-icon"] }
 liana-ui = { path = "../liana-ui" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/liana-business/business-installer/Cargo.toml
+++ b/liana-business/business-installer/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 name = "business_installer"
 path = "src/lib.rs"
 
+[features]
+default = ["debugger"]
+debugger = ["liana-gui/debugger"]
+
 [dependencies]
 crossbeam = { version = "0.8.4", features = ["crossbeam-channel"] }
 email_address = { workspace = true }

--- a/liana-business/src/main.rs
+++ b/liana-business/src/main.rs
@@ -64,7 +64,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     window_settings.icon = Some(image::liana_business_app_icon());
 
     if let Err(e) = iced::application(
-        move || LianaBusiness::new((config.clone(), log_level, VERSION)),
+        move || {
+            LianaBusiness::new(
+                (config.clone(), log_level, VERSION),
+                #[cfg(feature = "debugger")]
+                &[], // Pass liana-business debug stack later here
+            )
+        },
         LianaBusiness::update,
         LianaBusiness::view,
     )

--- a/liana-business/src/settings/mod.rs
+++ b/liana-business/src/settings/mod.rs
@@ -194,6 +194,9 @@ impl SettingsTrait for BusinessSettings {
                     .map_err(|e| SettingsError::Unexpected(e.to_string()))?,
             );
 
+            #[cfg(feature = "debugger")]
+            liana_gui::debug::set_variant(liana_ui::Variant::LianaBusiness);
+
             let cache = Cache {
                 variant: liana_ui::Variant::LianaBusiness,
                 network,

--- a/liana-gui/Cargo.toml
+++ b/liana-gui/Cargo.toml
@@ -73,6 +73,8 @@ tar = { workspace = true, default-features = false }
 flate2 = { workspace = true, default-features = false }
 
 [features]
+default = ["debugger"]
+debugger = []
 skip-windows-icon = []
 
 [build-dependencies]

--- a/liana-gui/src/debug/badges.rs
+++ b/liana-gui/src/debug/badges.rs
@@ -1,0 +1,68 @@
+//! Gallery of every badge constructor and pill style exposed by `liana-ui`.
+
+use liana_ui::{
+    component::{
+        badge::{self, badge},
+        text,
+    },
+    icon::tooltip_icon,
+    theme,
+    widget::*,
+};
+
+use crate::debug::{DebugMessage, Sample};
+
+fn pill_sample(
+    label: &'static str,
+    style: fn(&theme::Theme) -> iced::widget::container::Style,
+) -> Container<'static, DebugMessage> {
+    Container::new(text::p2_regular(label))
+        .padding(10)
+        .style(style)
+}
+
+#[rustfmt::skip]
+fn icon_badges() -> Sample<5> {
+    [
+        (badge(tooltip_icon()), "liana_ui::component::badge::badge(<icon>)"),
+        (badge::receive(), "liana_ui::component::badge::receive()"),
+        (badge::cycle(), "liana_ui::component::badge::cycle()"),
+        (badge::spend(), "liana_ui::component::badge::spend()"),
+        (badge::coin(), "liana_ui::component::badge::coin()"),
+    ]
+}
+
+#[rustfmt::skip]
+fn pill_badges() -> Sample<5> {
+    [
+        (badge::recovery(), "liana_ui::component::badge::recovery()"),
+        (badge::unconfirmed(), "liana_ui::component::badge::unconfirmed()"),
+        (badge::batch(), "liana_ui::component::badge::batch()"),
+        (badge::deprecated(), "liana_ui::component::badge::deprecated()"),
+        (badge::spent(), "liana_ui::component::badge::spent()"),
+    ]
+}
+
+#[rustfmt::skip]
+fn pill_styles() -> Sample<7> {
+    [
+        (pill_sample("  simple  ", theme::pill::simple), "liana_ui::theme::pill::simple"),
+        (pill_sample("  primary  ", theme::pill::primary), "liana_ui::theme::pill::primary"),
+        (pill_sample("  success  ", theme::pill::success), "liana_ui::theme::pill::success"),
+        (pill_sample("  warning  ", theme::pill::warning), "liana_ui::theme::pill::warning"),
+        (pill_sample("  internal  ", theme::pill::internal), "liana_ui::theme::pill::internal"),
+        (pill_sample("  external  ", theme::pill::external), "liana_ui::theme::pill::external"),
+        (pill_sample("  safety_net  ", theme::pill::safety_net), "liana_ui::theme::pill::safety_net"),
+    ]
+}
+
+crate::debug_page!(
+    "Badge debug view",
+    [
+        [
+            ("Icon badges", icon_badges()),
+            ("Pill badges", pill_badges()),
+        ],
+        [("Pill styles", pill_styles()),],
+    ],
+);

--- a/liana-gui/src/debug/example.rs
+++ b/liana-gui/src/debug/example.rs
@@ -1,0 +1,78 @@
+//! Example: a debug page built without [`crate::debug_page!`].
+//!
+//! The macro is just sugar over [`debug_section`] and [`layout_page`]. When
+//! the standard layout doesn't fit (asymmetric columns, custom chrome,
+//! interleaved widgets, no card background, etc.), declare the [`ENTRY`]
+//! and the view function by hand.
+//!
+//! This file is intentionally **not** wired into the registry — it isn't
+//! declared in `mod.rs` and `&example::ENTRY` isn't appended to
+//! [`crate::debug::PAGES`]. Copy it as a starting point for a new page.
+
+use iced::{Alignment, Length};
+use liana_ui::{component::text, theme, widget::*};
+
+use crate::debug::{debug_section, DebugMessage, DebugPageEntry, Sample};
+
+pub static ENTRY: DebugPageEntry = DebugPageEntry { view };
+
+#[rustfmt::skip]
+fn headings() -> Sample<5> {
+    [
+        (Container::new(text::h1("h1 — display heading")), "liana_ui::component::text::h1"),
+        (Container::new(text::h2("h2 — section heading")), "liana_ui::component::text::h2"),
+        (Container::new(text::h3("h3 — subsection")), "liana_ui::component::text::h3"),
+        (Container::new(text::h4_bold("h4_bold")), "liana_ui::component::text::h4_bold"),
+        (Container::new(text::h5_medium("h5_medium")), "liana_ui::component::text::h5_medium"),
+    ]
+}
+
+#[rustfmt::skip]
+fn paragraphs() -> Sample<4> {
+    [
+        (Container::new(text::p1_bold("p1_bold")), "liana_ui::component::text::p1_bold"),
+        (Container::new(text::p1_regular("p1_regular")), "liana_ui::component::text::p1_regular"),
+        (Container::new(text::p2_regular("p2_regular")), "liana_ui::component::text::p2_regular"),
+        (Container::new(text::caption("caption")), "liana_ui::component::text::caption"),
+    ]
+}
+
+/// Two ways to build the view:
+///
+/// **Option A** — reuse `crate::debug::layout_page` for the standard chrome +
+/// columns:
+/// ```ignore
+/// use crate::debug::{debug_section, layout_page};
+/// fn view() -> Element<'static, DebugMessage> {
+///     layout_page("Text styles", [
+///         vec![debug_section("Headings", headings())],
+///         vec![debug_section("Paragraphs", paragraphs())],
+///     ])
+/// }
+/// ```
+///
+/// **Option B** (used below) — go fully custom: build whatever `Element` you
+/// like; the only contract is the `fn() -> Element<'static, DebugMessage>`
+/// signature on [`ENTRY`].
+fn view() -> Element<'static, DebugMessage> {
+    let body = Row::new()
+        .spacing(40)
+        .push(debug_section("Headings", headings()))
+        .push(debug_section("Paragraphs", paragraphs()));
+
+    Container::new(
+        Column::new()
+            .spacing(20)
+            .padding(40)
+            .align_x(Alignment::Center)
+            .push(text::h2("Text styles — fully custom layout"))
+            .push(text::p2_regular(
+                "No card background, centered chrome, single row of sections.",
+            ))
+            .push(body),
+    )
+    .style(theme::container::background)
+    .width(Length::Fill)
+    .height(Length::Fill)
+    .into()
+}

--- a/liana-gui/src/debug/mod.rs
+++ b/liana-gui/src/debug/mod.rs
@@ -28,6 +28,7 @@ use liana_ui::{component::text, theme, widget::*};
 use crate::app::{cache::Cache, menu::Menu, view::Message as ViewMessage};
 
 pub mod badges;
+pub mod texts;
 
 /// Navigation hint shown in every debug page's chrome.
 pub const NAV_HINT: &str = "Ctrl + D + ←/→ pages · Ctrl + D + ↑/↓ stacks · Ctrl + D + Esc close";
@@ -310,6 +311,8 @@ pub const DESIGN_SYSTEM: DebugStack = DebugStack {
     #[rustfmt::skip]
     pages: &[
         &badges::ENTRY,
+        &texts::ENTRY_CONSTRUCTORS,
+        &texts::ENTRY_THEMES,
     ],
 };
 

--- a/liana-gui/src/debug/mod.rs
+++ b/liana-gui/src/debug/mod.rs
@@ -1,0 +1,592 @@
+//! Developer-only debug overlays.
+//!
+//! The whole module is gated by the `debugger` cargo feature, enabled by
+//! default. Reproducible and release builds disable it via
+//! `--no-default-features`, at which point this module does not compile.
+//!
+//! ## Pages and stacks
+//!
+//! Debug pages are organised into named [`DebugStack`]s. Within a stack,
+//! [`Ctrl + D + ←/→`] steps through pages; between stacks,
+//! [`Ctrl + D + ↑/↓`] cycles (wrapping at both ends). [`Ctrl + D + Esc`]
+//! closes the overlay.
+//!
+//! ## Adding a new page
+//!
+//! 1. Create `debug/foo.rs` and write a single [`debug_page!`] invocation in it.
+//! 2. Declare the module here (`pub mod foo;`).
+//! 3. Append `&foo::ENTRY` to the appropriate stack's `pages` slice below.
+//!
+//! The macro generates the view function and the [`DebugPageEntry`]; chord
+//! detection and dispatch read [`STACKS`] dynamically.
+
+use std::{cell::Cell, sync::OnceLock};
+
+use iced::{widget::scrollable, Alignment, Length};
+use liana_ui::{component::text, theme, widget::*};
+
+use crate::app::{cache::Cache, menu::Menu, view::Message as ViewMessage};
+
+pub mod badges;
+
+/// Navigation hint shown in every debug page's chrome.
+pub const NAV_HINT: &str = "Ctrl + D + ←/→ pages · Ctrl + D + ↑/↓ stacks · Ctrl + D + Esc close";
+
+thread_local! {
+    /// Current `(global_index, total)` position of the page being rendered,
+    /// set by [`render_location`] right before invoking the page's view fn
+    /// and cleared after. Chrome helpers read this to display
+    /// `<view_index>/<total>` next to the page title.
+    static CURRENT_POS: Cell<Option<(usize, usize)>> = const { Cell::new(None) };
+}
+
+/// 1-based page index within the current stack, formatted as
+/// `index/total` for display next to the title. Returns `None` outside a
+/// [`render_location`] dispatch. Empty stacks count as one slot (the
+/// placeholder page).
+fn current_position_label() -> Option<String> {
+    CURRENT_POS.with(Cell::get).map(|(i, t)| format!("{i}/{t}"))
+}
+
+fn compute_position(
+    stacks: &[&'static DebugStack],
+    stack_idx: usize,
+    page_idx: usize,
+) -> (usize, usize) {
+    let stack = stacks[stack_idx];
+    let total = stack.pages.len().max(1);
+    // page_idx is clamped to [0, total-1] for non-empty stacks; for empty
+    // stacks total==1 and page_idx==0 → contributes 1.
+    let index = page_idx.min(total - 1) + 1;
+    (index, total)
+}
+
+// Static `Menu` values so `dashboard_chrome` can hand out `&'static Menu`
+// references without leaking on every render. Menu is `Sync` (no interior
+// mutability), so a `static` is sound. They are `pub` so debug pages in
+// other crates (`liana-business`, `business-installer`) can pick the menu
+// entry their stack should highlight.
+pub static HOME_MENU: Menu = Menu::Home;
+pub static SEND_MENU: Menu = Menu::CreateSpendTx;
+pub static RECEIVE_MENU: Menu = Menu::Receive;
+pub static PSBTS_MENU: Menu = Menu::PSBTs;
+pub static RECOVERY_MENU: Menu = Menu::Recovery;
+pub static TRANSACTIONS_MENU: Menu = Menu::Transactions;
+pub static COINS_MENU: Menu = Menu::Coins;
+pub static SETTINGS_MENU: Menu = Menu::Settings;
+
+/// `Cache` contains a `Cell<Size>` (mutated by `dashboard`'s responsive
+/// callback during layout), so it is `!Sync`. iced renders on the main
+/// thread, so sharing one `&'static Cache` between debug-overlay frames is
+/// safe in practice — we wrap the cache in a unit struct with an `unsafe
+/// impl Sync` to satisfy `OnceLock`'s bound.
+struct CacheCell(Cache);
+// SAFETY: only accessed from the iced view/layout thread.
+unsafe impl Sync for CacheCell {}
+
+/// Per-binary `liana_ui::Variant` for the debug-overlay cache (controls
+/// e.g. which sidebar logo `view::dashboard` shows). Set from the same
+/// site that builds the running `Cache` for the App, so the overlay and
+/// the live App stay in sync without the binary's `main` having to know
+/// about variants. Defaults to [`liana_ui::Variant::Liana`] when unset.
+static DEBUG_VARIANT: OnceLock<liana_ui::Variant> = OnceLock::new();
+
+/// Set the [`liana_ui::Variant`] used by the debug-overlay's shared
+/// `Cache`. Called from the same function that constructs the running
+/// `Cache` for the App, alongside `Cache { variant: …, … }`. liana-gui
+/// never calls this; liana-business calls it from
+/// `BusinessSettings::create_app_for_remote_backend` so the dashboard
+/// sidebar in the debug overlay shows the blue business logo rather
+/// than the green liana-gui one.
+///
+/// Subsequent calls after the cache has been initialised are silently
+/// ignored — the cache is built once and the variant is baked in.
+pub fn set_variant(v: liana_ui::Variant) {
+    let _ = DEBUG_VARIANT.set(v);
+}
+
+fn static_cache() -> &'static Cache {
+    static CACHE: OnceLock<CacheCell> = OnceLock::new();
+    &CACHE
+        .get_or_init(|| {
+            let mut cache = Cache::default();
+            if let Some(v) = DEBUG_VARIANT.get() {
+                cache.variant = *v;
+            }
+            CacheCell(cache)
+        })
+        .0
+}
+
+/// Wrap a debug-page body in the production sidebar/dashboard chrome,
+/// highlighting the given menu entry. Sidebar click messages are swallowed
+/// at the boundary via `.map(|_| ())`.
+pub fn dashboard_chrome<B>(
+    menu: &'static Menu,
+    title: &'static str,
+    body: B,
+) -> Element<'static, DebugMessage>
+where
+    B: Into<Element<'static, DebugMessage>>,
+{
+    let body_msg: Element<'static, ViewMessage> = body.into().map(|_| ViewMessage::Reload);
+    let content: Column<'static, ViewMessage> = Column::new()
+        .spacing(30)
+        .push(header_row::<ViewMessage>(title, None))
+        .push(body_msg);
+    crate::app::view::dashboard(menu, static_cache(), None, content).map(|_| ())
+}
+
+/// Variant of [`debug_chrome`] for installer / wizard / modal pages.
+/// Uses the darker `theme::container::sidebar` background instead of
+/// `theme::container::background`. Modal cards drawn with
+/// `theme::card::modal` use the standard chrome background colour
+/// (LIGHT_BLACK), so the boundary disappears; switching to the sidebar
+/// colour (BLACK / `menu_background`) restores contrast. Useful for any
+/// debug page rendering a modal-style card directly on the chrome.
+///
+/// `path` is the qualified production function (e.g. `"liana_business::
+/// settings::views::wallet_view"`) that the page is rendering, surfaced
+/// under the title so developers can jump straight to the source.
+///
+/// A `Space::fill_height()` is appended after the body so the dark
+/// background covers the whole viewport even when the body is shorter
+/// than the page.
+pub fn installer_chrome<B>(
+    title: &'static str,
+    path: &'static str,
+    body: B,
+) -> Element<'static, DebugMessage>
+where
+    B: Into<Element<'static, DebugMessage>>,
+{
+    // No outer scrollable: the production wizard views (`layout_inner`)
+    // already wrap their content in a scrollable + Container with
+    // `height(Length::Fill)`. Wrapping that in another scrollable here
+    // collapses the inner Length::Fill (scrollable content height ==
+    // natural child height) and hides whichever rows the inner layout
+    // expected to receive vertical space — that's why account / org /
+    // wallet / key lists were rendering empty.
+    Container::new(
+        Column::new()
+            .spacing(15)
+            .padding(30)
+            .push(header_row::<DebugMessage>(title, Some(path)))
+            .push(body.into()),
+    )
+    .style(theme::container::background)
+    .width(Length::Fill)
+    .height(Length::Fill)
+    .into()
+}
+
+/// Wrap `modal_body` in a true [`liana_ui::widget::modal::Modal`] overlay
+/// on top of the production dashboard for `menu`. The modal widget paints
+/// `BLACK_80` over the base before drawing the centered modal body, so the
+/// modal card sits on a darker overlay distinct from its own
+/// `theme::card::modal` background. Use this for any debug page that
+/// represents a true modal in production (e.g. `verify_address_modal`,
+/// `register_wallet_modal`, `create_rbf_modal`).
+pub fn dashboard_with_modal<M>(
+    menu: &'static Menu,
+    title: &'static str,
+    modal_body: M,
+) -> Element<'static, DebugMessage>
+where
+    M: Into<Element<'static, DebugMessage>>,
+{
+    let placeholder: Element<'static, ViewMessage> =
+        text::p1_regular("(modal — production panel sits behind the dim overlay)").into();
+    let dash_content: Row<'static, ViewMessage> = Row::new()
+        .spacing(30)
+        .push(text::h2(title))
+        .push(text::p1_regular(NAV_HINT))
+        .push(placeholder);
+    let dashboard_elem: Element<'static, DebugMessage> =
+        crate::app::view::dashboard(menu, static_cache(), None, dash_content).map(|_| ());
+    iced::widget::stack![
+        dashboard_elem,
+        Modal::new_modal(modal_body.into()).into_element(),
+    ]
+    .into()
+}
+
+/// Like [`dashboard_with_modal`] but the base is the standalone
+/// [`installer_chrome`] (no sidebar) — for modals that, in production,
+/// overlay a wizard / installer page rather than a dashboard panel.
+pub fn installer_with_modal<M>(
+    title: &'static str,
+    path: &'static str,
+    modal_body: M,
+) -> Element<'static, DebugMessage>
+where
+    M: Into<Element<'static, DebugMessage>>,
+{
+    let placeholder: Element<'static, DebugMessage> =
+        text::p1_regular("(modal — production wizard step sits behind the dim overlay)").into();
+    let base = installer_chrome(title, path, placeholder);
+    iced::widget::stack![base, Modal::new_modal(modal_body.into()).into_element()].into()
+}
+
+/// Tiny wrapper around `liana_ui::widget::modal::Modal` whose only purpose
+/// is to convert a single overlay-style modal body into an `Element` that
+/// `iced::widget::stack` can pair with a base. We don't need a real Modal
+/// here because the dim overlay is drawn ourselves via [`DebugDimmer`]
+/// below — `Modal::new` requires base + overlay together, but in our case
+/// the base is already rendered as a stack sibling.
+struct DebugDimmer;
+
+impl DebugDimmer {
+    fn into_element() -> Element<'static, DebugMessage> {
+        Container::new(Column::new())
+            .style(|_: &theme::Theme| iced::widget::container::Style {
+                background: Some(iced::Background::Color(liana_ui::color::BLACK_80)),
+                ..Default::default()
+            })
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
+    }
+}
+
+mod _modal_helper {
+    use super::DebugMessage;
+    use liana_ui::widget::Element;
+
+    /// Marker that turns any `Element` into a centered overlay that
+    /// `iced::widget::stack` will draw on top of a base. This avoids
+    /// relying on `liana_ui::widget::modal::Modal`, which produces a
+    /// proper modal but layouts the base + overlay together — for our
+    /// case `stack![base, overlay]` is simpler and pictures the modal
+    /// the same way.
+    pub struct Modal;
+
+    impl Modal {
+        pub fn new_modal(body: Element<'static, DebugMessage>) -> CenteredOverlay {
+            CenteredOverlay { body }
+        }
+    }
+
+    pub struct CenteredOverlay {
+        body: Element<'static, DebugMessage>,
+    }
+
+    impl CenteredOverlay {
+        pub fn into_element(self) -> Element<'static, DebugMessage> {
+            use iced::Length;
+            use liana_ui::widget::Container;
+
+            // Draw the dim quad first, then center the modal body on top.
+            let dim = super::DebugDimmer::into_element();
+            let centered: Element<'static, DebugMessage> = Container::new(self.body)
+                .center_x(Length::Fill)
+                .center_y(Length::Fill)
+                .padding(20)
+                .into();
+            iced::widget::stack![dim, centered].into()
+        }
+    }
+}
+
+use _modal_helper::Modal;
+
+/// A named group of related debug pages. Stacks form the outer navigation
+/// axis (`Ctrl + D + ↑/↓`), pages within a stack form the inner axis
+/// (`Ctrl + D + ←/→`).
+///
+/// `menu` controls which sidebar entry is highlighted when the stack is
+/// rendered through [`dashboard_chrome`]; `None` means the stack uses the
+/// plain [`debug_chrome`] (no sidebar). It is also used by the empty-stack
+/// placeholder in [`render_location`].
+pub struct DebugStack {
+    pub name: &'static str,
+    pub menu: Option<&'static Menu>,
+    pub pages: &'static [&'static DebugPageEntry],
+}
+
+pub const DESIGN_SYSTEM: DebugStack = DebugStack {
+    name: "Design system",
+    menu: None,
+    #[rustfmt::skip]
+    pages: &[
+        &badges::ENTRY,
+    ],
+};
+
+pub const HOME_PANEL: DebugStack = DebugStack {
+    name: "Home panel",
+    menu: Some(&HOME_MENU),
+    pages: &[],
+};
+
+pub const SEND_PANEL: DebugStack = DebugStack {
+    name: "Send panel",
+    menu: Some(&SEND_MENU),
+    pages: &[],
+};
+
+pub const RECEIVE_PANEL: DebugStack = DebugStack {
+    name: "Receive panel",
+    menu: Some(&RECEIVE_MENU),
+    pages: &[],
+};
+
+pub const PSBT_PANEL: DebugStack = DebugStack {
+    name: "PSBT",
+    menu: Some(&PSBTS_MENU),
+    pages: &[],
+};
+
+pub const RECOVERY_PANEL: DebugStack = DebugStack {
+    name: "Recovery",
+    menu: Some(&RECOVERY_MENU),
+    pages: &[],
+};
+
+pub const TRANSACTIONS_PANEL: DebugStack = DebugStack {
+    name: "Transactions",
+    menu: Some(&TRANSACTIONS_MENU),
+    pages: &[],
+};
+
+pub const COINS_PANEL: DebugStack = DebugStack {
+    name: "Coins",
+    menu: Some(&COINS_MENU),
+    pages: &[],
+};
+
+pub const SETTINGS_PANEL: DebugStack = DebugStack {
+    name: "Settings",
+    menu: Some(&SETTINGS_MENU),
+    pages: &[],
+};
+
+pub const HW_MODALS: DebugStack = DebugStack {
+    name: "HW modals",
+    menu: None,
+    pages: &[],
+};
+
+pub const INSTALLER_MODALS: DebugStack = DebugStack {
+    name: "Installer modals",
+    menu: None,
+    pages: &[],
+};
+
+/// All registered debug stacks, in navigation order. `Ctrl + D + ↑/↓`
+/// cycles through this slice (wrapping at both ends).
+pub const STACKS: &[&DebugStack] = &[
+    &DESIGN_SYSTEM,
+    &HOME_PANEL,
+    &SEND_PANEL,
+    &RECEIVE_PANEL,
+    &PSBT_PANEL,
+    &RECOVERY_PANEL,
+    &TRANSACTIONS_PANEL,
+    &COINS_PANEL,
+    &SETTINGS_PANEL,
+    &HW_MODALS,
+    &INSTALLER_MODALS,
+];
+
+/// Render the page at `(stack_idx, page_idx)` within the given `stacks`
+/// slice. The slice is supplied by the host binary so that downstream
+/// crates (`liana-business`, `business-installer`) can extend the default
+/// [`STACKS`] without touching this module.
+///
+/// If the stack has no pages registered yet, render a placeholder so the
+/// stack is still reachable during navigation. Empty panel stacks (those
+/// with a `menu`) use the same dashboard chrome the real panels will
+/// eventually use, so navigation already shows the correct sidebar
+/// highlight.
+pub fn render_location(
+    stacks: &[&'static DebugStack],
+    stack_idx: usize,
+    page_idx: usize,
+) -> Element<'static, DebugMessage> {
+    let pos = compute_position(stacks, stack_idx, page_idx);
+    CURRENT_POS.with(|c| c.set(Some(pos)));
+    let result = (|| {
+        let stack = stacks[stack_idx];
+        if let Some(entry) = stack.pages.get(page_idx) {
+            return (entry.view)();
+        }
+        let placeholder = text::p1_regular("No debug pages registered for this stack yet.");
+        if let Some(menu) = stack.menu {
+            return dashboard_chrome(menu, stack.name, placeholder);
+        }
+        Container::new(scrollable(
+            Column::new()
+                .spacing(30)
+                .padding(30)
+                .push(header_row::<DebugMessage>(stack.name, None))
+                .push(placeholder),
+        ))
+        .style(theme::container::background)
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .into()
+    })();
+    CURRENT_POS.with(|c| c.set(None));
+    result
+}
+
+/// Single-row page header: title (h2), `index/total` position caption
+/// next to it, optional production function path, then a stretch and the
+/// chord-navigation reminder right-aligned. Aligned on the baseline so
+/// the big h2 reads naturally next to the smaller captions.
+fn header_row<T: 'static>(title: &'static str, path: Option<&'static str>) -> Row<'static, T> {
+    use liana_ui::widget::SpaceExt;
+    let mut row = Row::new()
+        .spacing(15)
+        .align_y(Alignment::End)
+        .push(text::h2(title));
+    if let Some(label) = current_position_label() {
+        row = row.push(text::caption(label).style(theme::text::secondary));
+    }
+    if let Some(path) = path {
+        row = row.push(text::caption(path).style(theme::text::secondary));
+    }
+    row = row
+        .push(iced::widget::Space::fill_width())
+        .push(text::p1_regular(NAV_HINT).style(theme::text::secondary));
+    row
+}
+
+/// Message type produced by debug widgets.
+///
+/// We use `()` so debug pages can render real interactive widgets (e.g. a
+/// `Button` with `on_press(())`) for showcase purposes. Clicks are swallowed
+/// at the GUI boundary by mapping to a no-op message.
+pub type DebugMessage = ();
+
+/// Standard array shape for a section: `N` `(widget, code-path)` pairs. Use
+/// this as the return type of helper fns that build a section's items.
+pub type Sample<const N: usize> = [(Container<'static, DebugMessage>, &'static str); N];
+
+/// One registered debug page. Constructed by the [`debug_page!`] macro.
+///
+/// Pages live inside a [`DebugStack`]; their position there determines the
+/// order encountered when stepping forward/backward (`Ctrl + D + ←/→`).
+pub struct DebugPageEntry {
+    /// Renders the page's overlay.
+    pub view: fn() -> Element<'static, DebugMessage>,
+}
+
+/// Render one labeled section. Each item is paired with the code path used to
+/// construct it; the conversion to [`Element`] is done here so callers can
+/// keep their arrays free of `.into()` noise.
+pub fn debug_section<T, I, W>(title: &'static str, items: I) -> Column<'static, T>
+where
+    T: 'static,
+    I: IntoIterator<Item = (W, &'static str)>,
+    W: Into<Element<'static, T>>,
+{
+    items.into_iter().fold(
+        Column::new().spacing(15).push(text::h3(title)),
+        |col, (sample, path)| {
+            col.push(
+                Row::new()
+                    .spacing(20)
+                    .align_y(Alignment::Center)
+                    .push(Container::new(sample.into()).width(Length::Fixed(160.0)))
+                    .push(text::p1_regular(path)),
+            )
+        },
+    )
+}
+
+/// Wrap an arbitrary body in the standard debug chrome (page title,
+/// navigation hint, scroll, card background). Use this directly when a page
+/// needs a layout that doesn't fit the columns-of-sections shape that
+/// [`layout_page`] produces.
+pub fn debug_chrome<T>(
+    title: &'static str,
+    body: impl Into<Element<'static, T>>,
+) -> Element<'static, T>
+where
+    T: 'static,
+{
+    Container::new(scrollable(
+        Column::new()
+            .spacing(30)
+            .padding(30)
+            .push(header_row::<T>(title, None))
+            .push(body.into()),
+    ))
+    .style(theme::container::background)
+    .width(Length::Fill)
+    .height(Length::Fill)
+    .into()
+}
+
+/// Lay out pre-built columns of sections inside the standard debug chrome.
+/// Each column is an iterator of [`Column`] sections; an empty column is
+/// allowed.
+pub fn layout_page<T, C, S>(title: &'static str, columns: C) -> Element<'static, T>
+where
+    T: 'static,
+    C: IntoIterator<Item = S>,
+    S: IntoIterator<Item = Column<'static, T>>,
+{
+    let body = columns
+        .into_iter()
+        .fold(Row::new().spacing(60), |row, sections| {
+            let column = sections
+                .into_iter()
+                .fold(Column::new().spacing(30), Column::push);
+            row.push(Container::new(column).width(Length::FillPortion(1)))
+        });
+    debug_chrome(title, body)
+}
+
+/// Define a debug page at module top level.
+///
+/// Generates a `pub static ENTRY: DebugPageEntry` and a private view function.
+///
+/// The macro cannot register the page on its own — there is no compile-time
+/// inventory in this crate. After calling it, the developer must add
+/// `&module_name::ENTRY` to the appropriate stack's `pages` slice in
+/// [`STACKS`] above; its position there determines the navigation order
+/// (`Ctrl + D + ←/→`).
+///
+/// Arguments (positional): `title`, then nested column arrays.
+///
+/// ```ignore
+/// debug_page!(
+///     "Badge debug view",
+///     [
+///         [
+///             ("Icon badges", icon_badges),
+///             ("Pill badges", pill_badges),
+///         ],
+///         [
+///             ("Pill styles", pill_styles),
+///         ],
+///     ],
+/// );
+/// ```
+#[macro_export]
+macro_rules! debug_page {
+    (
+        $title:literal,
+        [ $(
+            [ $( ( $section_title:expr , $items:expr ) ),* $(,)? ]
+        ),* $(,)? ] $(,)?
+    ) => {
+        pub static ENTRY: $crate::debug::DebugPageEntry = $crate::debug::DebugPageEntry {
+            view: __debug_view,
+        };
+
+        fn __debug_view() -> ::liana_ui::widget::Element<'static, $crate::debug::DebugMessage> {
+            $crate::debug::layout_page(
+                $title,
+                [ $(
+                    ::std::vec![
+                        $( $crate::debug::debug_section($section_title, $items) ),*
+                    ]
+                ),* ],
+            )
+        }
+    };
+}

--- a/liana-gui/src/debug/texts.rs
+++ b/liana-gui/src/debug/texts.rs
@@ -1,0 +1,159 @@
+//! Two galleries:
+//!
+//! - **Constructors** — every `liana_ui::component::text::*` helper, with
+//!   its size / font family / weight extracted from the helper's source.
+//! - **Themes** — every `liana_ui::theme::text::*` style applied to the same
+//!   sample, so palette colors can be compared side by side.
+
+use iced::{
+    font::{Family, Weight},
+    widget::Space,
+    Alignment, Font, Length,
+};
+use liana_ui::{
+    component::text::{
+        self, TextSpec, BUTTON_TEXT_SPEC, CAPTION_SPEC, H1_SPEC, H2_SPEC, H3_SPEC, H4_BOLD_SPEC,
+        H4_REGULAR_SPEC, H5_MEDIUM_SPEC, H5_REGULAR_SPEC, P1_BOLD_SPEC, P1_MEDIUM_SPEC,
+        P1_REGULAR_SPEC, P2_MEDIUM_SPEC, P2_REGULAR_SPEC, PANEL_TITLE_SPEC,
+    },
+    theme,
+    widget::*,
+};
+
+use crate::debug::{debug_chrome, DebugMessage, DebugPageEntry};
+
+pub static ENTRY_CONSTRUCTORS: DebugPageEntry = DebugPageEntry {
+    view: constructors_view,
+};
+pub static ENTRY_THEMES: DebugPageEntry = DebugPageEntry { view: themes_view };
+
+const ROW_SPACING: f32 = 5.0;
+const SAMPLE_WIDTH: Length = Length::Fixed(600.0);
+
+const SAMPLE: &str = "The quick brown fox jumps";
+
+/// Format a `Font` as `family · weight`, derived from its public fields.
+/// Auto-updates if a helper switches font constants.
+fn font_label(f: Font) -> String {
+    let family = match f.family {
+        Family::Name(n) => n.to_string(),
+        Family::Serif => "Serif".to_string(),
+        Family::SansSerif => "SansSerif".to_string(),
+        Family::Cursive => "Cursive".to_string(),
+        Family::Fantasy => "Fantasy".to_string(),
+        Family::Monospace => "Monospace".to_string(),
+    };
+    let weight = match f.weight {
+        Weight::Thin => "Thin",
+        Weight::ExtraLight => "ExtraLight",
+        Weight::Light => "Light",
+        Weight::Normal => "Regular",
+        Weight::Medium => "Medium",
+        Weight::Semibold => "Semibold",
+        Weight::Bold => "Bold",
+        Weight::ExtraBold => "ExtraBold",
+        Weight::Black => "Black",
+    };
+    format!("{family} · {weight}")
+}
+
+// ----- Page builders -------------------------------------------------------
+
+/// Render an iterator of pre-built rows inside the standard chrome at a fixed
+/// width of `2 × modal::BTN_W`.
+fn render(
+    title: &'static str,
+    rows: Vec<Row<'static, DebugMessage>>,
+) -> Element<'static, DebugMessage> {
+    let body = rows
+        .into_iter()
+        .fold(Column::new().spacing(ROW_SPACING), Column::push)
+        .width(Length::Fixed(650.0 * 2.0));
+    debug_chrome(title, body)
+}
+
+// ----- Constructors --------------------------------------------------------
+
+fn constructors_view() -> Element<'static, DebugMessage> {
+    #[rustfmt::skip]
+    let entries: Vec<(&'static str, TextSpec)> = vec![
+        ("liana_ui::component::text::h1",                         H1_SPEC),
+        ("liana_ui::component::text::h2",                         H2_SPEC),
+        ("liana_ui::component::text::panel_title",                PANEL_TITLE_SPEC),
+        ("liana_ui::component::text::h3",                         H3_SPEC),
+        ("liana_ui::component::text::h4_bold",                    H4_BOLD_SPEC),
+        ("liana_ui::component::text::h4_regular",                 H4_REGULAR_SPEC),
+        ("liana_ui::component::text::h5_medium",                  H5_MEDIUM_SPEC),
+        ("liana_ui::component::text::h5_regular",                 H5_REGULAR_SPEC),
+        ("liana_ui::component::text::p1_bold",                    P1_BOLD_SPEC),
+        ("liana_ui::component::text::p1_medium",                  P1_MEDIUM_SPEC),
+        ("liana_ui::component::text::p1_regular",                 P1_REGULAR_SPEC),
+        ("liana_ui::component::text::text (alias of p1_regular)", P1_REGULAR_SPEC),
+        ("liana_ui::component::text::p2_medium",                  P2_MEDIUM_SPEC),
+        ("liana_ui::component::text::p2_regular",                 P2_REGULAR_SPEC),
+        ("liana_ui::component::text::caption",                    CAPTION_SPEC),
+        ("liana_ui::component::text::button_text",                BUTTON_TEXT_SPEC),
+    ];
+
+    let rows = entries
+        .into_iter()
+        .map(|(path, spec)| {
+            let size_str = match spec.size {
+                Some(s) => format!("size {s}px"),
+                None => "size — (caller sets)".to_string(),
+            };
+            let row = Row::new()
+                .spacing(20)
+                .align_y(Alignment::Center)
+                .push(Space::with_width(30))
+                .push(Container::new(text::apply(SAMPLE, spec)).width(SAMPLE_WIDTH))
+                .push(
+                    Column::new().spacing(2).push(text::p1_regular(path)).push(
+                        text::caption(format!("{size_str} · {}", font_label(spec.font)))
+                            .style(theme::text::secondary),
+                    ),
+                )
+                .push(Space::with_width(30));
+            Row::new()
+                .push(
+                    liana_ui::component::card::simple(row)
+                        .padding(2)
+                        .width(Length::Fill),
+                )
+                .width(1350)
+        })
+        .collect();
+
+    render("Texts — constructors", rows)
+}
+
+// ----- Themes --------------------------------------------------------------
+
+type StyleFn = fn(&theme::Theme) -> iced::widget::text::Style;
+
+fn themes_view() -> Element<'static, DebugMessage> {
+    #[rustfmt::skip]
+    let entries: Vec<(&'static str, StyleFn)> = vec![
+        ("liana_ui::theme::text::default     (no color, inherits)", theme::text::default),
+        ("liana_ui::theme::text::primary",                          theme::text::primary),
+        ("liana_ui::theme::text::secondary",                        theme::text::secondary),
+        ("liana_ui::theme::text::success",                          theme::text::success),
+        ("liana_ui::theme::text::warning",                          theme::text::warning),
+        ("liana_ui::theme::text::destructive (alias of warning)",   theme::text::destructive),
+        ("liana_ui::theme::text::error",                            theme::text::error),
+        ("liana_ui::theme::text::accent",                           theme::text::accent),
+    ];
+
+    let rows = entries
+        .into_iter()
+        .map(|(path, style)| {
+            Row::new()
+                .spacing(20)
+                .align_y(Alignment::Center)
+                .push(Container::new(text::p1_regular(SAMPLE).style(style)).width(SAMPLE_WIDTH))
+                .push(text::p1_regular(path))
+        })
+        .collect();
+
+    render("Texts — themes", rows)
+}

--- a/liana-gui/src/gui/mod.rs
+++ b/liana-gui/src/gui/mod.rs
@@ -19,6 +19,9 @@ mod cache;
 pub mod pane;
 pub mod tab;
 
+#[cfg(feature = "debugger")]
+use crate::debug;
+
 use crate::{
     app::{
         cache::{FiatPrice, FiatPriceRequest},
@@ -57,12 +60,32 @@ where
     window_config: Option<WindowConfig>,
     global_cache: GlobalCache,
     version: &'static str,
+    #[cfg(feature = "debugger")]
+    debug_view: Option<(usize, usize)>,
+    #[cfg(feature = "debugger")]
+    debug_stacks: &'static [&'static debug::DebugStack],
+    #[cfg(feature = "debugger")]
+    ctrl_d_held: bool,
     _phantom: PhantomData<M>,
 }
 
 #[derive(Debug)]
+#[cfg(not(feature = "debugger"))]
 pub enum Key {
     Tab(bool),
+}
+
+#[derive(Debug)]
+#[cfg(feature = "debugger")]
+pub enum Key {
+    Tab(bool),
+    CtrlDPressed,
+    CtrlDReleased,
+    DebugNext,
+    DebugPrev,
+    DebugStackNext,
+    DebugStackPrev,
+    DebugClose,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -77,6 +100,8 @@ where
     Pane(pane_grid::Pane, pane::Message<M>),
     KeyPressed(Key),
     Event(iced::Event),
+    #[cfg(feature = "debugger")]
+    DebugNoOp,
 
     Clicked(pane_grid::Pane),
     Dragged(pane_grid::DragEvent),
@@ -140,6 +165,7 @@ where
 
     pub fn new(
         (config, log_level, version): (Config, Option<LevelFilter>, &'static str),
+        #[cfg(feature = "debugger")] extra_stacks: &'static [&'static debug::DebugStack],
     ) -> (GUI<I, S, M>, Task<Message<M>>) {
         let log_level = log_level.unwrap_or(LevelFilter::INFO);
         if let Err(e) = setup_logger(log_level, config.liana_directory.clone()) {
@@ -155,6 +181,17 @@ where
         let window_config =
             GlobalSettings::load_window_config(&GlobalSettings::path(&config.liana_directory));
         let window_init = window_config.is_some().then_some(true);
+
+        #[cfg(feature = "debugger")]
+        let debug_stacks: &'static [&'static debug::DebugStack] = {
+            let combined: Vec<&'static debug::DebugStack> = debug::STACKS
+                .iter()
+                .copied()
+                .chain(extra_stacks.iter().copied())
+                .collect();
+            Box::leak(combined.into_boxed_slice())
+        };
+
         (
             Self {
                 panes,
@@ -165,6 +202,12 @@ where
                 window_config,
                 version,
                 global_cache: GlobalCache::default(),
+                #[cfg(feature = "debugger")]
+                debug_view: None,
+                #[cfg(feature = "debugger")]
+                debug_stacks,
+                #[cfg(feature = "debugger")]
+                ctrl_d_held: false,
                 _phantom: PhantomData,
             },
             Task::batch(cmds),
@@ -257,6 +300,66 @@ where
                 } else {
                     focus_next()
                 }
+            }
+            #[cfg(feature = "debugger")]
+            Message::KeyPressed(Key::CtrlDPressed) => {
+                self.ctrl_d_held = true;
+                Task::none()
+            }
+            #[cfg(feature = "debugger")]
+            Message::KeyPressed(Key::CtrlDReleased) => {
+                self.ctrl_d_held = false;
+                Task::none()
+            }
+            #[cfg(feature = "debugger")]
+            Message::KeyPressed(Key::DebugNext) => {
+                if self.ctrl_d_held {
+                    self.debug_view = match self.debug_view {
+                        None => Some((0, 0)),
+                        Some((s, p)) => {
+                            let last = self.debug_stacks[s].pages.len().saturating_sub(1);
+                            Some((s, p.saturating_add(1).min(last)))
+                        }
+                    };
+                }
+                Task::none()
+            }
+            #[cfg(feature = "debugger")]
+            Message::KeyPressed(Key::DebugPrev) => {
+                if self.ctrl_d_held {
+                    self.debug_view = self.debug_view.map(|(s, p)| (s, p.saturating_sub(1)));
+                }
+                Task::none()
+            }
+            #[cfg(feature = "debugger")]
+            Message::KeyPressed(Key::DebugStackNext) => {
+                if self.ctrl_d_held {
+                    self.debug_view = self
+                        .debug_view
+                        .map(|(s, _)| ((s + 1) % self.debug_stacks.len(), 0));
+                }
+                Task::none()
+            }
+            #[cfg(feature = "debugger")]
+            Message::KeyPressed(Key::DebugStackPrev) => {
+                if self.ctrl_d_held {
+                    self.debug_view = self.debug_view.map(|(s, _)| {
+                        let prev = if s == 0 {
+                            self.debug_stacks.len() - 1
+                        } else {
+                            s - 1
+                        };
+                        (prev, 0)
+                    });
+                }
+                Task::none()
+            }
+            #[cfg(feature = "debugger")]
+            Message::KeyPressed(Key::DebugClose) => {
+                if self.ctrl_d_held {
+                    self.debug_view = None;
+                }
+                Task::none()
             }
             Message::Fiat(FiatMessage::GetPriceResult(price)) => {
                 if self
@@ -507,6 +610,8 @@ where
                 }
                 Task::none()
             }
+            #[cfg(feature = "debugger")]
+            Message::DebugNoOp => Task::none(),
             Message::Tick => {
                 let mut tasks = vec![];
 
@@ -598,6 +703,72 @@ where
                     }),
                     event::Status::Ignored,
                 ) => Some(Message::KeyPressed(Key::Tab(modifiers.shift()))),
+                #[cfg(feature = "debugger")]
+                (
+                    Event::Keyboard(keyboard::Event::KeyPressed {
+                        key: iced::keyboard::Key::Character(c),
+                        modifiers,
+                        ..
+                    }),
+                    event::Status::Ignored,
+                ) if modifiers.command() && c.as_str().eq_ignore_ascii_case("d") => {
+                    Some(Message::KeyPressed(Key::CtrlDPressed))
+                }
+                #[cfg(feature = "debugger")]
+                (
+                    Event::Keyboard(keyboard::Event::KeyReleased {
+                        key: iced::keyboard::Key::Character(c),
+                        ..
+                    }),
+                    _,
+                ) if c.as_str().eq_ignore_ascii_case("d") => {
+                    Some(Message::KeyPressed(Key::CtrlDReleased))
+                }
+                #[cfg(feature = "debugger")]
+                (
+                    Event::Keyboard(keyboard::Event::KeyPressed {
+                        key: iced::keyboard::Key::Named(iced::keyboard::key::Named::ArrowRight),
+                        modifiers,
+                        ..
+                    }),
+                    event::Status::Ignored,
+                ) if modifiers.command() => Some(Message::KeyPressed(Key::DebugNext)),
+                #[cfg(feature = "debugger")]
+                (
+                    Event::Keyboard(keyboard::Event::KeyPressed {
+                        key: iced::keyboard::Key::Named(iced::keyboard::key::Named::ArrowLeft),
+                        modifiers,
+                        ..
+                    }),
+                    event::Status::Ignored,
+                ) if modifiers.command() => Some(Message::KeyPressed(Key::DebugPrev)),
+                #[cfg(feature = "debugger")]
+                (
+                    Event::Keyboard(keyboard::Event::KeyPressed {
+                        key: iced::keyboard::Key::Named(iced::keyboard::key::Named::ArrowDown),
+                        modifiers,
+                        ..
+                    }),
+                    event::Status::Ignored,
+                ) if modifiers.command() => Some(Message::KeyPressed(Key::DebugStackNext)),
+                #[cfg(feature = "debugger")]
+                (
+                    Event::Keyboard(keyboard::Event::KeyPressed {
+                        key: iced::keyboard::Key::Named(iced::keyboard::key::Named::ArrowUp),
+                        modifiers,
+                        ..
+                    }),
+                    event::Status::Ignored,
+                ) if modifiers.command() => Some(Message::KeyPressed(Key::DebugStackPrev)),
+                #[cfg(feature = "debugger")]
+                (
+                    Event::Keyboard(keyboard::Event::KeyPressed {
+                        key: iced::keyboard::Key::Named(iced::keyboard::key::Named::Escape),
+                        modifiers,
+                        ..
+                    }),
+                    event::Status::Ignored,
+                ) if modifiers.command() => Some(Message::KeyPressed(Key::DebugClose)),
                 (
                     iced::Event::Window(iced::window::Event::CloseRequested),
                     event::Status::Ignored,
@@ -618,7 +789,25 @@ where
         Subscription::batch(vec)
     }
 
+    #[cfg(not(feature = "debugger"))]
     pub fn view(&self) -> Element<'_, Message<M>> {
+        self.base_view()
+    }
+
+    #[cfg(feature = "debugger")]
+    pub fn view(&self) -> Element<'_, Message<M>> {
+        let base = self.base_view();
+        match self.debug_view {
+            Some((stack, page)) => {
+                let overlay = debug::render_location(self.debug_stacks, stack, page)
+                    .map(|_| Message::DebugNoOp);
+                iced::widget::stack![base, overlay].into()
+            }
+            None => base,
+        }
+    }
+
+    fn base_view(&self) -> Element<'_, Message<M>> {
         if self.panes.len() == 1 {
             if let Some((&id, pane)) = self.panes.iter().nth(0) {
                 return Column::new()

--- a/liana-gui/src/lib.rs
+++ b/liana-gui/src/lib.rs
@@ -2,6 +2,8 @@ pub mod app;
 pub mod args;
 pub mod backup;
 pub mod daemon;
+#[cfg(feature = "debugger")]
+pub mod debug;
 pub mod delete;
 pub mod dir;
 pub mod download;

--- a/liana-gui/src/main.rs
+++ b/liana-gui/src/main.rs
@@ -42,7 +42,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let window_settings = create_window_settings("Liana", initial_size);
 
     if let Err(e) = iced::application(
-        move || LianaGUI::new((config.clone(), log_level, VERSION)),
+        move || {
+            LianaGUI::new(
+                (config.clone(), log_level, VERSION),
+                #[cfg(feature = "debugger")]
+                &[],
+            )
+        },
         LianaGUI::update,
         LianaGUI::view,
     )

--- a/liana-ui/src/component/text.rs
+++ b/liana-ui/src/component/text.rs
@@ -1,5 +1,6 @@
 use crate::{font, theme::Theme};
 use iced::advanced::text::Shaping;
+use iced::Font;
 use std::fmt::Display;
 
 pub const H1_SIZE: u32 = 40;
@@ -11,102 +12,111 @@ pub const P1_SIZE: u32 = 16;
 pub const P2_SIZE: u32 = 14;
 pub const CAPTION_SIZE: u32 = 12;
 
-pub fn panel_title<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
+/// Per-helper typography spec: the font and (optionally) size that a text
+/// helper applies. This is useful for the debugger being able to
+/// display font spec without hradcoding it in the debug view.
+#[derive(Debug, Clone, Copy)]
+pub struct TextSpec {
+    pub size: Option<u32>,
+    pub font: Font,
+}
+
+#[rustfmt::skip]
+pub const PANEL_TITLE_SPEC: TextSpec = TextSpec { size: Some(H2_SIZE),      font: font::MANROPE_BOLD };
+#[rustfmt::skip]
+pub const H1_SPEC:          TextSpec = TextSpec { size: Some(H1_SIZE),      font: font::BOLD };
+#[rustfmt::skip]
+pub const H2_SPEC:          TextSpec = TextSpec { size: Some(H2_SIZE),      font: font::BOLD };
+#[rustfmt::skip]
+pub const H3_SPEC:          TextSpec = TextSpec { size: Some(H3_SIZE),      font: font::BOLD };
+#[rustfmt::skip]
+pub const H4_BOLD_SPEC:     TextSpec = TextSpec { size: Some(H4_SIZE),      font: font::BOLD };
+#[rustfmt::skip]
+pub const H4_REGULAR_SPEC:  TextSpec = TextSpec { size: Some(H4_SIZE),      font: font::REGULAR };
+#[rustfmt::skip]
+pub const H5_MEDIUM_SPEC:   TextSpec = TextSpec { size: Some(H5_SIZE),      font: font::MEDIUM };
+#[rustfmt::skip]
+pub const H5_REGULAR_SPEC:  TextSpec = TextSpec { size: Some(H5_SIZE),      font: font::REGULAR };
+#[rustfmt::skip]
+pub const P1_BOLD_SPEC:     TextSpec = TextSpec { size: Some(P1_SIZE),      font: font::BOLD };
+#[rustfmt::skip]
+pub const P1_MEDIUM_SPEC:   TextSpec = TextSpec { size: Some(P1_SIZE),      font: font::MEDIUM };
+#[rustfmt::skip]
+pub const P1_REGULAR_SPEC:  TextSpec = TextSpec { size: Some(P1_SIZE),      font: font::REGULAR };
+#[rustfmt::skip]
+pub const P2_MEDIUM_SPEC:   TextSpec = TextSpec { size: Some(P2_SIZE),      font: font::MEDIUM };
+#[rustfmt::skip]
+pub const P2_REGULAR_SPEC:  TextSpec = TextSpec { size: Some(P2_SIZE),      font: font::REGULAR };
+#[rustfmt::skip]
+pub const CAPTION_SPEC:     TextSpec = TextSpec { size: Some(CAPTION_SIZE), font: font::REGULAR };
+#[rustfmt::skip]
+pub const BUTTON_TEXT_SPEC: TextSpec = TextSpec { size: None,               font: font::MEDIUM };
+
+/// Build a text widget from a [`TextSpec`].
+pub fn apply<'a>(content: impl Display, spec: TextSpec) -> iced::widget::Text<'a, Theme> {
+    let mut t = iced::widget::text!("{}", content)
         .shaping(Shaping::Advanced)
-        .font(font::MANROPE_BOLD)
-        .size(H2_SIZE)
+        .font(spec.font);
+    if let Some(s) = spec.size {
+        t = t.size(s);
+    }
+    t
+}
+
+pub fn panel_title<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
+    apply(content, PANEL_TITLE_SPEC)
 }
 
 pub fn h1<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::BOLD)
-        .size(H1_SIZE)
+    apply(content, H1_SPEC)
 }
 
 pub fn h2<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::BOLD)
-        .size(H2_SIZE)
+    apply(content, H2_SPEC)
 }
 
 pub fn h3<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::BOLD)
-        .size(H3_SIZE)
+    apply(content, H3_SPEC)
 }
 
 pub fn h4_bold<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::BOLD)
-        .size(H4_SIZE)
+    apply(content, H4_BOLD_SPEC)
 }
 
 pub fn h4_regular<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::REGULAR)
-        .size(H4_SIZE)
+    apply(content, H4_REGULAR_SPEC)
 }
 
 pub fn h5_medium<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::MEDIUM)
-        .size(H5_SIZE)
+    apply(content, H5_MEDIUM_SPEC)
 }
 
 pub fn h5_regular<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::REGULAR)
-        .size(H5_SIZE)
+    apply(content, H5_REGULAR_SPEC)
 }
 
 pub fn p1_bold<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::BOLD)
-        .size(P1_SIZE)
+    apply(content, P1_BOLD_SPEC)
 }
 
 pub fn p1_medium<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::MEDIUM)
-        .size(P1_SIZE)
+    apply(content, P1_MEDIUM_SPEC)
 }
 
 pub fn p1_regular<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::REGULAR)
-        .size(P1_SIZE)
+    apply(content, P1_REGULAR_SPEC)
 }
 
 pub fn p2_medium<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::MEDIUM)
-        .size(P2_SIZE)
+    apply(content, P2_MEDIUM_SPEC)
 }
 
 pub fn p2_regular<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::REGULAR)
-        .size(P2_SIZE)
+    apply(content, P2_REGULAR_SPEC)
 }
 
 pub fn caption<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::REGULAR)
-        .size(CAPTION_SIZE)
+    apply(content, CAPTION_SPEC)
 }
 
 pub fn text<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
@@ -115,9 +125,7 @@ pub fn text<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
 
 /// Text for use inside buttons - no color style applied so button can control color
 pub fn button_text<'a>(content: impl Display) -> iced::widget::Text<'a, Theme> {
-    iced::widget::text!("{}", content)
-        .shaping(Shaping::Advanced)
-        .font(font::MEDIUM)
+    apply(content, BUTTON_TEXT_SPEC)
 }
 
 pub trait Text {

--- a/nix/liana-business.nix
+++ b/nix/liana-business.nix
@@ -57,7 +57,7 @@ let
 
     cargoArtifacts = windowsDeps;
 
-    cargoExtraArgs = "-p liana-business";
+    cargoExtraArgs = "-p liana-business --no-default-features";
 
     installPhaseCommand = ''
       mkdir -p $out/x86_64-pc-windows-gnu
@@ -70,7 +70,7 @@ let
     inherit (lianaBusinessInfo) pname version;
 
     CARGO_BUILD_TARGET = "x86_64-apple-darwin";
-    buildPhaseCargoCommand = "cargo zigbuild --release --message-format json-render-diagnostics";
+    buildPhaseCargoCommand = "cargo zigbuild --release -p liana-business --no-default-features --message-format json-render-diagnostics";
     doNotPostBuildInstallCargoBinaries = true;
 
     depsBuildBuild = [
@@ -103,7 +103,7 @@ let
     inherit (lianaBusinessInfo) pname version;
 
     CARGO_BUILD_TARGET = "aarch64-apple-darwin";
-    buildPhaseCargoCommand = "cargo zigbuild --release --message-format json-render-diagnostics";
+    buildPhaseCargoCommand = "cargo zigbuild --release -p liana-business --no-default-features --message-format json-render-diagnostics";
     doNotPostBuildInstallCargoBinaries = true;
 
     depsBuildBuild = [

--- a/nix/liana.nix
+++ b/nix/liana.nix
@@ -33,7 +33,7 @@ let
     TOOLKIT_x86_64_pc_windows_gnu = "${pkgs.pkgsCross.mingwW64.stdenv.cc.bintools.bintools}/bin";
     WINDRES_x86_64_pc_windows_gnu = "${pkgs.pkgsCross.mingwW64.stdenv.cc.targetPrefix}windres";
 
-    cargoExtraArgs = "-p liana-gui";
+    cargoExtraArgs = "-p liana-gui --no-default-features";
     depsBuildBuild = with pkgs; [
       pkgsCross.mingwW64.stdenv.cc
       pkgsCross.mingwW64.buildPackages.binutils
@@ -51,7 +51,10 @@ let
     inherit (lianaInfo) pname version;
 
     CARGO_BUILD_TARGET = "x86_64-apple-darwin";
-    buildPhaseCargoCommand = "cargo zigbuild --release --message-format json-render-diagnostics";
+    buildPhaseCargoCommand = ''
+      cargo zigbuild --release -p liana-gui --no-default-features --message-format json-render-diagnostics
+      cargo zigbuild --release -p lianad --message-format json-render-diagnostics
+    '';
     doNotPostBuildInstallCargoBinaries = true;
 
     depsBuildBuild = [
@@ -86,7 +89,10 @@ let
     inherit (lianaInfo) pname version;
 
     CARGO_BUILD_TARGET = "aarch64-apple-darwin";
-    buildPhaseCargoCommand = "cargo zigbuild --release --message-format json-render-diagnostics";
+    buildPhaseCargoCommand = ''
+      cargo zigbuild --release -p liana-gui --no-default-features --message-format json-render-diagnostics
+      cargo zigbuild --release -p lianad --message-format json-render-diagnostics
+    '';
     doNotPostBuildInstallCargoBinaries = true;
 
     depsBuildBuild = [


### PR DESCRIPTION
This pr introduce debug view that are displayed as an overlay on top of the wallet.
All the introduced code in feature gated under a `debug` feature that is disabled during reproducible builds. 

It uses a system composed of several "stacks" of debug views.

Access to debug view is done by maintaining CTRL + D pressed and:
- right arrow permit to open the initial view of the first stack , then navigating down the stack.
- left click permit to navigate up the stack
- up/down permit to switch between 2 stacks
- escape close the debug view