### PR TITLE
gui: add non-file import/export fallbacks for text workflows

### DIFF
--- a/liana-gui/src/app/state/export.rs
+++ b/liana-gui/src/app/state/export.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use iced::{Subscription, Task};
+use liana_ui::component::form;
 use liana_ui::{widget::modal::Modal, widget::Element};
 use tokio::task::JoinHandle;
 
@@ -19,6 +20,7 @@ use crate::{
 #[derive(Debug)]
 pub struct ExportModal {
     path: Option<PathBuf>,
+    manual_path: form::Value<String>,
     handle: Option<Arc<Mutex<JoinHandle<()>>>>,
     state: ImportExportState,
     error: Option<export::Error>,
@@ -62,6 +64,7 @@ impl ExportModal {
     ) -> Self {
         Self {
             path: None,
+            manual_path: form::Value::default(),
             handle: None,
             state: ImportExportState::Init,
             error: None,
@@ -204,7 +207,30 @@ impl ExportModal {
                     self.path = Some(path);
                     self.start();
                 } else {
-                    return Task::perform(async {}, |_| ImportExportMessage::Close.into());
+                    self.manual_path.value = match self.import_export_type {
+                        ImportExportType::Transactions
+                        | ImportExportType::ExportPsbt(_)
+                        | ImportExportType::ExportEncryptedDescriptor(_)
+                        | ImportExportType::ExportProcessBackup(..)
+                        | ImportExportType::ExportXpub(_)
+                        | ImportExportType::Descriptor(_)
+                        | ImportExportType::ExportLabels => self.default_filename(),
+                        _ => String::new(),
+                    };
+                    self.manual_path.valid = true;
+                    self.state = ImportExportState::ManualPath;
+                }
+            }
+            ImportExportMessage::PathEdited(path) => {
+                self.manual_path.value = path;
+                self.manual_path.valid = true;
+            }
+            ImportExportMessage::ConfirmPath => {
+                if !self.manual_path.value.trim().is_empty() {
+                    self.path = Some(self.manual_path.value.trim().into());
+                    self.start();
+                } else {
+                    self.manual_path.valid = false;
                 }
             }
             ImportExportMessage::Close | ImportExportMessage::Open => { /* unreachable */ }
@@ -289,6 +315,7 @@ impl ExportModal {
                 self.error.as_ref(),
                 self.modal_title(),
                 &self.import_export_type,
+                &self.manual_path,
             ),
         );
         match self.state {

--- a/liana-gui/src/app/view/export.rs
+++ b/liana-gui/src/app/view/export.rs
@@ -5,7 +5,7 @@ use iced::{
 };
 use liana_ui::{
     component::{
-        button, card,
+        button, card, form,
         text::{h4_bold, text},
     },
     icon,
@@ -21,6 +21,7 @@ pub fn export_modal<'a, Message: From<ImportExportMessage> + Clone + 'static>(
     error: Option<&'a Error>,
     title: &str,
     import_export_type: &ImportExportType,
+    manual_path: &'a form::Value<String>,
 ) -> Element<'a, Message> {
     let cancel = match state {
         ImportExportState::Started | ImportExportState::Progress(_) => {
@@ -47,6 +48,9 @@ pub fn export_modal<'a, Message: From<ImportExportMessage> + Clone + 'static>(
             ImportExportState::Init => "".to_string(),
             ImportExportState::ChoosePath => {
                 "Select the path you want to export in the popup window...".into()
+            }
+            ImportExportState::ManualPath => {
+                "The file picker returned no path. Enter one manually or close this dialog.".into()
             }
             ImportExportState::Path(_) => "".into(),
             ImportExportState::Started => "Starting export...".into(),
@@ -103,12 +107,34 @@ pub fn export_modal<'a, Message: From<ImportExportMessage> + Clone + 'static>(
             .align_x(Horizontal::Center)
             .width(Length::Fill)
     });
+    let manual_path_form = matches!(state, ImportExportState::ManualPath).then(|| {
+        form::Form::<Message>::new_trimmed("Path", manual_path, |path| {
+            Message::from(ImportExportMessage::PathEdited(path))
+        })
+        .warning("Please enter a filesystem path")
+        .padding(10)
+    });
+    let manual_path_actions = matches!(state, ImportExportState::ManualPath).then(|| {
+        Container::new(
+            Row::new()
+                .spacing(10)
+                .push(Space::with_width(Length::Fill))
+                .push(button::secondary(None, "Close").on_press(ImportExportMessage::Close.into()))
+                .push(
+                    button::secondary(None, "Use path")
+                        .on_press(ImportExportMessage::ConfirmPath.into()),
+                ),
+        )
+        .align_x(Horizontal::Center)
+        .width(Length::Fill)
+    });
 
     let mut p = match state {
         ImportExportState::Init => 0.0,
-        ImportExportState::ChoosePath | ImportExportState::Path(_) | ImportExportState::Started => {
-            5.0
-        }
+        ImportExportState::ChoosePath
+        | ImportExportState::ManualPath
+        | ImportExportState::Path(_)
+        | ImportExportState::Started => 5.0,
         ImportExportState::Progress(p) => *p,
         ImportExportState::TimedOut
         | ImportExportState::Aborted
@@ -138,7 +164,9 @@ pub fn export_modal<'a, Message: From<ImportExportMessage> + Clone + 'static>(
             .push(progress_bar_row)
             .push(Space::with_height(Length::Fill))
             .push(Row::new().push(text(msg)))
+            .push_maybe(manual_path_form)
             .push(Space::with_height(Length::Fill))
+            .push_maybe(manual_path_actions)
             .push_maybe(button)
             .push(Space::with_height(5)),
     )

--- a/liana-gui/src/export.rs
+++ b/liana-gui/src/export.rs
@@ -82,6 +82,8 @@ pub enum ImportExportMessage {
     TimedOut,
     UserStop,
     Path(Option<PathBuf>),
+    PathEdited(String),
+    ConfirmPath,
     Close,
     Overwrite,
     Ignore,
@@ -99,6 +101,7 @@ impl From<ImportExportMessage> for view::Message {
 pub enum ImportExportState {
     Init,
     ChoosePath,
+    ManualPath,
     Path(PathBuf),
     Started,
     Progress(f32),

--- a/liana-gui/src/installer/step/descriptor/mod.rs
+++ b/liana-gui/src/installer/step/descriptor/mod.rs
@@ -37,6 +37,7 @@ pub struct ImportDescriptor {
     imported_descriptor: form::Value<String>,
     imported_backup: Option<Backup>,
     imported_aliases: Option<HashMap<Fingerprint, KeySetting>>,
+    descriptor_from_backup: bool,
 }
 
 impl ImportDescriptor {
@@ -49,6 +50,7 @@ impl ImportDescriptor {
             modal: ImportDescriptorModal::None,
             imported_backup: None,
             imported_aliases: None,
+            descriptor_from_backup: false,
         }
     }
 
@@ -78,6 +80,30 @@ impl ImportDescriptor {
             None
         }
     }
+
+    fn clear_imported_backup(&mut self) {
+        self.imported_backup = None;
+        self.imported_aliases = None;
+        if self.descriptor_from_backup {
+            self.imported_descriptor.value.clear();
+            self.check_descriptor(self.network);
+            self.descriptor_from_backup = false;
+        }
+    }
+
+    fn set_imported_backup(
+        &mut self,
+        descriptor: LianaDescriptor,
+        aliases: Option<HashMap<Fingerprint, KeySetting>>,
+        backup: Backup,
+    ) {
+        self.imported_descriptor.value = descriptor.to_string();
+        self.check_descriptor(self.network);
+        self.imported_backup = Some(backup);
+        self.imported_aliases = aliases;
+        self.descriptor_from_backup = true;
+        self.error = None;
+    }
 }
 
 impl Step for ImportDescriptor {
@@ -98,13 +124,15 @@ impl Step for ImportDescriptor {
                 if desc != self.imported_descriptor.value {
                     self.imported_backup = None;
                     self.imported_aliases = None;
+                    self.descriptor_from_backup = false;
                 }
                 self.imported_descriptor.value = desc;
                 self.check_descriptor(self.network);
                 None
             }
             Message::ImportBackup => {
-                self.imported_backup = None;
+                self.clear_imported_backup();
+                self.error = None;
                 let modal = ExportModal::new(None, ImportExportType::FromBackup);
                 let launch = modal.launch(false);
                 self.modal = ImportDescriptorModal::Export(modal);
@@ -118,9 +146,7 @@ impl Step for ImportDescriptor {
                 let (descriptor, network, aliases, backup) = r;
                 if let Some(n) = network {
                     if self.network == n {
-                        self.imported_backup = Some(backup);
-                        self.imported_descriptor.value = descriptor.to_string();
-                        self.imported_aliases = Some(aliases);
+                        self.set_imported_backup(descriptor, Some(aliases), backup);
                     } else {
                         self.error = Some(BACKUP_NETWORK_NOT_MATCH.into());
                     }
@@ -128,9 +154,7 @@ impl Step for ImportDescriptor {
                     // The backup have been inferred from a bare descriptor, we check whether
                     // the descriptor match any test network
                     if self.network != Network::Bitcoin {
-                        self.imported_backup = Some(backup);
-                        self.imported_descriptor.value = descriptor.to_string();
-                        self.imported_aliases = Some(aliases);
+                        self.set_imported_backup(descriptor, Some(aliases), backup);
                     } else {
                         self.error = Some(BACKUP_NETWORK_NOT_MATCH.into());
                     }
@@ -170,9 +194,9 @@ impl Step for ImportDescriptor {
                         // as non Mainnet keys / descriptor are parsed as Signet
                         backup.network = self.network;
 
-                        self.imported_descriptor.value = desc;
-                        self.imported_backup = Some(backup);
-                        self.imported_aliases = None;
+                        let descriptor = LianaDescriptor::from_str(&desc)
+                            .expect("backup descriptor must stay valid");
+                        self.set_imported_backup(descriptor, None, backup);
                         self.modal = ImportDescriptorModal::None;
                     } else {
                         self.modal = ImportDescriptorModal::None;

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -417,6 +417,14 @@ pub fn signer_xpubs<'a>(
                                         .width(Length::Shrink),
                                 )
                                 .padding(10),
+                            )
+                            .push(
+                                Container::new(
+                                    button::secondary(Some(icon::clipboard_icon()), "Copy")
+                                        .on_press(Message::Clipboard(xpub.clone()))
+                                        .width(Length::Shrink),
+                                )
+                                .padding(10),
                             ),
                     )
                 }))
@@ -514,6 +522,14 @@ pub fn hardware_wallet_xpubs<'a>(
                                 Container::new(
                                     button::primary(Some(icon::backup_icon()), "Export")
                                         .on_press(Message::ExportXpub(xpub.clone()))
+                                        .width(Length::Shrink),
+                                )
+                                .padding(10),
+                            )
+                            .push(
+                                Container::new(
+                                    button::secondary(Some(icon::clipboard_icon()), "Copy")
+                                        .on_press(Message::Clipboard(xpub.clone()))
                                         .width(Length::Shrink),
                                 )
                                 .padding(10),


### PR DESCRIPTION
## Summary
This PR reduces Liana GUI's dependence on native file pickers for text-based workflows and keeps the shared import/export modal usable when the picker does not return a path.

On non-Nixos nix setups the wallet does not have a working file picker widget, so Export/Import buttons showed a window and immediately closed it:

```
ERROR rfd::backend::xdg_desktop_portal:248: pick_folder error No such file or directory (os error 2)
```

On Linux, Liana currently relies on rfd's XDG portal backend for file selection. In some environments that portal request fails at runtime; rfd then falls back to spawning zenity. If zenity is not available, rfd returns no path and the existing GUI treats that the same as a normal chooser cancel, so the import/export modal closes immediately. This PR adds non-file clipboard flows for text-based workflows and keeps the modal usable by falling back to manual path entry when no path is returned.

## What changed
- Add direct `Copy` actions for shared xpubs in the installer share step while keeping the existing export buttons.
- Add PSBT clipboard flows by exposing direct copy, adding explicit paste-based import and update paths, trimming pasted input before validation, and preserving the existing file-based import flow.
- Add clipboard paths for wallet backup JSON and labels JSONL exports in settings, and add a paste-backup flow in the installer import step that reuses the same parsing path as file imports.
- Allow wallet restore in settings to start from pasted backup text.
- Keep the shared import/export modal open when the native chooser returns no path and switch it to a minimal manual path entry fallback instead of closing immediately.
