### PR TITLE
prepare liana-business v0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "business-installer"
-version = "1.0.0"
+version = "0.2.0"
 dependencies = [
  "async-hwi",
  "chrono",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "liana-business"
-version = "1.0.0"
+version = "0.2.0"
 dependencies = [
  "async-hwi",
  "backtrace",

--- a/liana-business/Cargo.toml
+++ b/liana-business/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liana-business"
-version = "1.0.0"
+version = "0.2.0"
 edition = "2021"
 
 [package.metadata.winresource]

--- a/liana-business/business-installer/Cargo.toml
+++ b/liana-business/business-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "business-installer"
-version = "1.0.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
fix the cargo package version, so the
version is correctly displayed in the liana-business window title.