### PR TITLE
gui: disable policy edits while compiling

### DIFF
--- a/liana-gui/src/installer/view/editor/mod.rs
+++ b/liana-gui/src/installer/view/editor/mod.rs
@@ -45,22 +45,31 @@ impl std::fmt::Display for DescriptorKind {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn define_descriptor_advanced_settings<'a>(use_taproot: bool) -> Element<'a, Message> {
+pub fn define_descriptor_advanced_settings<'a>(
+    use_taproot: bool,
+    editable: bool,
+) -> Element<'a, Message> {
+    let descriptor_kind = if use_taproot {
+        DescriptorKind::Taproot
+    } else {
+        DescriptorKind::P2WSH
+    };
+    let descriptor_type: Element<_> = if editable {
+        pick_list::pick_list(&DESCRIPTOR_KINDS[..], Some(descriptor_kind), move |kind| {
+            Message::CreateTaprootDescriptor(kind == DescriptorKind::Taproot)
+        })
+        .padding(10)
+        .into()
+    } else {
+        card::simple(text(descriptor_kind.to_string()))
+            .padding(10)
+            .into()
+    };
+
     let col_wallet = Column::new()
         .spacing(10)
         .push(text("Descriptor type").bold())
-        .push(container(
-            pick_list::pick_list(
-                &DESCRIPTOR_KINDS[..],
-                Some(if use_taproot {
-                    DescriptorKind::Taproot
-                } else {
-                    DescriptorKind::P2WSH
-                }),
-                |kind| Message::CreateTaprootDescriptor(kind == DescriptorKind::Taproot),
-            )
-            .padding(10),
-        ));
+        .push(container(descriptor_type));
 
     container(
         Column::new()
@@ -88,13 +97,14 @@ pub fn path(
     threshold: usize,
     keys: Vec<Element<message::DefinePath>>,
     fixed: bool,
+    editable: bool,
 ) -> Element<message::DefinePath> {
     let keys_len = keys.len();
     Container::new(
         Column::new()
             .spacing(10)
             .push_maybe(title.map(|t| Row::new().push(Space::with_width(10)).push(p1_bold(t))))
-            .push(defined_sequence(sequence, warning))
+            .push(defined_sequence(sequence, warning, editable))
             .push(
                 Column::new()
                     .spacing(5)
@@ -105,13 +115,23 @@ pub fn path(
                 if keys_len == 1 {
                     None
                 } else {
-                    Some(Row::new().push(defined_threshold(color, fixed, (threshold, keys_len))))
+                    Some(Row::new().push(defined_threshold(
+                        color,
+                        fixed,
+                        (threshold, keys_len),
+                        editable,
+                    )))
                 }
             } else {
                 Some(
                     Row::new()
                         .spacing(10)
-                        .push(defined_threshold(color, fixed, (threshold, keys_len)))
+                        .push(defined_threshold(
+                            color,
+                            fixed,
+                            (threshold, keys_len),
+                            editable,
+                        ))
                         .push(
                             button::secondary(
                                 Some(icon::plus_icon()),
@@ -121,7 +141,7 @@ pub fn path(
                                     "Add key"
                                 },
                             )
-                            .on_press(message::DefinePath::AddKey),
+                            .on_press_maybe(editable.then_some(message::DefinePath::AddKey)),
                         ),
                 )
             }),
@@ -170,6 +190,7 @@ pub fn defined_key<'a>(
     title: impl Display,
     warning: Option<&'static str>,
     fixed: bool,
+    editable: bool,
 ) -> Element<'a, message::DefineKey> {
     card::simple(
         Row::new()
@@ -196,7 +217,7 @@ pub fn defined_key<'a>(
             })
             .push(
                 button::secondary(Some(icon::pencil_icon()), "Edit")
-                    .on_press(message::DefineKey::EditAlias),
+                    .on_press_maybe(editable.then_some(message::DefineKey::EditAlias)),
             )
             .push_maybe(if fixed {
                 None
@@ -205,7 +226,7 @@ pub fn defined_key<'a>(
                     Button::new(icon::trash_icon())
                         .style(theme::button::secondary)
                         .padding(5)
-                        .on_press(message::DefineKey::Delete),
+                        .on_press_maybe(editable.then_some(message::DefineKey::Delete)),
                 )
             }),
     )
@@ -217,6 +238,7 @@ pub fn undefined_key<'a>(
     title: impl Into<Cow<'a, str>> + std::fmt::Display,
     active: bool,
     fixed: bool,
+    editable: bool,
 ) -> Element<'a, message::DefineKey> {
     card::simple(
         Row::new()
@@ -233,7 +255,7 @@ pub fn undefined_key<'a>(
             .push_maybe(if active {
                 Some(
                     button::primary(Some(icon::pencil_icon()), "Set")
-                        .on_press(message::DefineKey::Edit),
+                        .on_press_maybe(editable.then_some(message::DefineKey::Edit)),
                 )
             } else {
                 None
@@ -245,7 +267,7 @@ pub fn undefined_key<'a>(
                     Button::new(icon::trash_icon())
                         .style(theme::button::secondary)
                         .padding(5)
-                        .on_press(message::DefineKey::Delete),
+                        .on_press_maybe(editable.then_some(message::DefineKey::Delete)),
                 )
             }),
     )

--- a/liana-gui/src/installer/view/editor/template/custom.rs
+++ b/liana-gui/src/installer/view/editor/template/custom.rs
@@ -66,7 +66,7 @@ pub fn custom_template<'a>(
 ) -> Element<'a, Message> {
     let prim_keys_fixed = primary_path.keys.len() < 2; // can only delete a primary key if there are 2 or more
 
-    let advanced_settings = super::advanced_settings_collapse(use_taproot);
+    let advanced_settings = super::advanced_settings_collapse(use_taproot, !processing);
 
     let primary = path(
         color::GREEN,
@@ -90,6 +90,7 @@ pub fn custom_template<'a>(
                             None
                         },
                         prim_keys_fixed,
+                        !processing,
                     )
                 } else {
                     undefined_key(
@@ -97,12 +98,14 @@ pub fn custom_template<'a>(
                         "Primary key",
                         !primary_path.keys[0..i].iter().any(|k| k.is_none()),
                         prim_keys_fixed,
+                        !processing,
                     )
                 }
                 .map(move |msg| message::DefinePath::Key(i, msg))
             })
             .collect(),
         false,
+        !processing,
     )
     .map(|msg| Message::DefineDescriptor(message::DefineDescriptor::Path(0, msg)));
 
@@ -135,6 +138,7 @@ pub fn custom_template<'a>(
                                         None
                                     },
                                     fixed,
+                                    !processing,
                                 )
                             } else {
                                 undefined_key(
@@ -142,12 +146,14 @@ pub fn custom_template<'a>(
                                     "Recovery key",
                                     !p.keys[0..j].iter().any(|k| k.is_none()),
                                     fixed,
+                                    !processing,
                                 )
                             }
                             .map(move |msg| message::DefinePath::Key(j, msg))
                         })
                         .collect(),
                     false,
+                    !processing,
                 )
                 .map(move |msg| {
                     Message::DefineDescriptor(message::DefineDescriptor::Path(
@@ -159,21 +165,24 @@ pub fn custom_template<'a>(
         },
     );
 
+    let add_recovery_msg = (!processing).then_some(Message::DefineDescriptor(
+        message::DefineDescriptor::AddRecoveryPath,
+    ));
+    let add_safety_net_msg = (!processing).then_some(Message::DefineDescriptor(
+        message::DefineDescriptor::AddSafetyNetPath,
+    ));
+
     let btn_row = Row::new()
         .push(
             button::secondary(Some(icon::plus_icon()), "Add recovery option")
                 .width(210)
-                .on_press(Message::DefineDescriptor(
-                    message::DefineDescriptor::AddRecoveryPath,
-                )),
+                .on_press_maybe(add_recovery_msg),
         )
         .push_maybe(
             safety_net_path.is_none().then_some(tooltip::Tooltip::new(
                 button::secondary(Some(icon::plus_icon()), "Add Safety Net")
                     .width(210)
-                    .on_press(Message::DefineDescriptor(
-                        message::DefineDescriptor::AddSafetyNetPath,
-                    )),
+                    .on_press_maybe(add_safety_net_msg),
                 Container::new(text(SAFETY_NET_DESCRIPTION))
                     .style(theme::card::simple)
                     .padding(10),
@@ -208,6 +217,7 @@ pub fn custom_template<'a>(
                                 None
                             },
                             fixed,
+                            !processing,
                         )
                     } else {
                         undefined_key(
@@ -215,12 +225,14 @@ pub fn custom_template<'a>(
                             "Safety Net key",
                             !sn_path.keys[0..i].iter().any(|k| k.is_none()),
                             fixed,
+                            !processing,
                         )
                     }
                     .map(move |msg| message::DefinePath::Key(i, msg))
                 })
                 .collect(),
             false,
+            !processing,
         )
         .map(move |msg| {
             // Add 1 to index to account for primary path.

--- a/liana-gui/src/installer/view/editor/template/inheritance.rs
+++ b/liana-gui/src/installer/view/editor/template/inheritance.rs
@@ -77,7 +77,7 @@ pub fn inheritance_template<'a>(
         None
     };
 
-    let advanced_settings = super::advanced_settings_collapse(use_taproot);
+    let advanced_settings = super::advanced_settings_collapse(use_taproot, !processing);
 
     let primary = path(
         color::GREEN,
@@ -96,12 +96,14 @@ pub fn inheritance_template<'a>(
                     None
                 },
                 true,
+                !processing,
             )
         } else {
-            undefined_key(color::GREEN, "Primary key", true, true)
+            undefined_key(color::GREEN, "Primary key", true, true, !processing)
         }
         .map(|msg| message::DefinePath::Key(0, msg))],
         true,
+        !processing,
     )
     .map(|msg| Message::DefineDescriptor(message::DefineDescriptor::Path(0, msg)));
 
@@ -122,12 +124,20 @@ pub fn inheritance_template<'a>(
                     None
                 },
                 true,
+                !processing,
             )
         } else {
-            undefined_key(color::WHITE, "Inheritance key", primary_key.is_some(), true)
+            undefined_key(
+                color::WHITE,
+                "Inheritance key",
+                primary_key.is_some(),
+                true,
+                !processing,
+            )
         }
         .map(|msg| message::DefinePath::Key(0, msg))],
         true,
+        !processing,
     )
     .map(|msg| Message::DefineDescriptor(message::DefineDescriptor::Path(1, msg)));
 

--- a/liana-gui/src/installer/view/editor/template/mod.rs
+++ b/liana-gui/src/installer/view/editor/template/mod.rs
@@ -29,7 +29,7 @@ pub const MAX_WIDTH: f32 = 1000.0;
 /// Bottom padding below the footer of the editor templates.
 pub const BOTTOM_PADDING: f32 = 100.0;
 
-pub fn advanced_settings_collapse<'a>(use_taproot: bool) -> Element<'a, Message> {
+pub fn advanced_settings_collapse<'a>(use_taproot: bool, editable: bool) -> Element<'a, Message> {
     fn collapse<'a>(collapsed: bool) -> Element<'a, Message> {
         let icn = if collapsed {
             icon::collapsed_icon()
@@ -44,20 +44,22 @@ pub fn advanced_settings_collapse<'a>(use_taproot: bool) -> Element<'a, Message>
     collapse::Collapse::new(
         collapse(false),
         collapse(true),
-        define_descriptor_advanced_settings(use_taproot),
+        define_descriptor_advanced_settings(use_taproot, editable),
     )
     .style(theme::button::transparent)
     .into()
 }
 
 pub fn template_footer<'a>(valid: bool, processing: bool, customize: bool) -> Row<'a, Message> {
-    let clear_all = btn_clear_all(Some(Message::DefineDescriptor(
-        message::DefineDescriptor::Reset,
-    )));
+    let clear_all = btn_clear_all(
+        (!processing).then_some(Message::DefineDescriptor(message::DefineDescriptor::Reset)),
+    );
 
-    let customize = customize.then_some(btn_customize(Some(Message::DefineDescriptor(
-        message::DefineDescriptor::ChangeTemplate(context::DescriptorTemplate::Custom),
-    ))));
+    let customize = customize.then_some(btn_customize((!processing).then_some(
+        Message::DefineDescriptor(message::DefineDescriptor::ChangeTemplate(
+            context::DescriptorTemplate::Custom,
+        )),
+    )));
 
     let msg = (!processing & valid).then_some(Message::Next);
     let msg_label = if processing {

--- a/liana-gui/src/installer/view/editor/template/multisig_security_wallet.rs
+++ b/liana-gui/src/installer/view/editor/template/multisig_security_wallet.rs
@@ -78,7 +78,7 @@ pub fn multisig_security_template<'a>(
     valid: bool,
     processing: bool,
 ) -> Element<'a, Message> {
-    let advanced_settings = super::advanced_settings_collapse(use_taproot);
+    let advanced_settings = super::advanced_settings_collapse(use_taproot, !processing);
 
     let primary = path(
         color::GREEN,
@@ -102,6 +102,7 @@ pub fn multisig_security_template<'a>(
                             None
                         },
                         true,
+                        !processing,
                     )
                 } else {
                     undefined_key(
@@ -109,12 +110,14 @@ pub fn multisig_security_template<'a>(
                         format!("Primary key #{}", i + 1),
                         !primary_path.keys[0..i].iter().any(|k| k.is_none()),
                         true,
+                        !processing,
                     )
                 }
                 .map(move |msg| message::DefinePath::Key(i, msg))
             })
             .collect(),
         true,
+        !processing,
     )
     .map(move |msg| {
         if let message::DefinePath::Key(i, message::DefineKey::Edit) = msg {
@@ -161,6 +164,7 @@ pub fn multisig_security_template<'a>(
                                 None
                             },
                             true,
+                            !processing,
                         )
                     }
                 } else {
@@ -174,12 +178,14 @@ pub fn multisig_security_template<'a>(
                         !(primary_path.keys.iter().any(|k| k.is_none())
                             || recovery_path.keys[0..j].iter().any(|k| k.is_none())),
                         true,
+                        !processing,
                     )
                 }
                 .map(move |msg| message::DefinePath::Key(j, msg))
             })
             .collect(),
         true,
+        !processing,
     )
     .map(move |msg| {
         if let message::DefinePath::Key(i, message::DefineKey::Edit) = msg {

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -1452,6 +1452,7 @@ pub fn defined_threshold<'a>(
     color: iced::Color,
     fixed: bool,
     threshold: (usize, usize),
+    editable: bool,
 ) -> Element<'a, message::DefinePath> {
     if !fixed && threshold.1 > 1 {
         Button::new(
@@ -1473,7 +1474,7 @@ pub fn defined_threshold<'a>(
                 .push(icon::pencil_icon()),
         )
         .padding(10)
-        .on_press(message::DefinePath::EditThreshold)
+        .on_press_maybe(editable.then_some(message::DefinePath::EditThreshold))
         .style(theme::button::secondary)
         .into()
     } else {
@@ -1502,6 +1503,7 @@ pub fn defined_threshold<'a>(
 pub fn defined_sequence<'a>(
     sequence: PathSequence,
     warning: Option<PathWarning>,
+    editable: bool,
 ) -> Element<'a, message::DefinePath> {
     let duration_row = Row::new()
         .padding(5)
@@ -1536,7 +1538,9 @@ pub fn defined_sequence<'a>(
                             .push(
                                 Button::new(duration_row.push(icon::pencil_icon()))
                                     .style(theme::button::secondary)
-                                    .on_press(message::DefinePath::EditSequence),
+                                    .on_press_maybe(
+                                        editable.then_some(message::DefinePath::EditSequence),
+                                    ),
                             ),
                     )
                     .width(Length::Fill)


### PR DESCRIPTION
The descriptor editor can accept policy-edit actions while compilation is pending.

Fixes #2163
