### PR TITLE
gui: chunk address displays

### DIFF
--- a/liana-gui/src/app/view/coins.rs
+++ b/liana-gui/src/app/view/coins.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use iced::{widget::Space, Alignment, Length};
 
 use liana_ui::{
-    component::{amount::*, badge, button, form, pill, text::*},
+    component::{address::address as address_view, amount::*, badge, button, form, pill, text::*},
     icon, theme,
     widget::*,
 };
@@ -200,7 +200,7 @@ fn coin_list_view<'a>(
                                             Row::new()
                                                 .align_y(Alignment::Center)
                                                 .push(
-                                                    p2_regular(address.clone())
+                                                    address_view(address.clone())
                                                         .style(theme::text::secondary),
                                                 )
                                                 .push(

--- a/liana-gui/src/app/view/psbt.rs
+++ b/liana-gui/src/app/view/psbt.rs
@@ -16,6 +16,7 @@ use liana::{
 
 use liana_ui::{
     component::{
+        address::address as address_view,
         amount::*,
         button, card,
         collapse::Collapse,
@@ -800,7 +801,7 @@ fn input_view<'a>(
                                 .width(Length::Fill)
                                 .spacing(5)
                                 .push(p1_bold("Address:").style(theme::text::secondary))
-                                .push(p2_regular(addr.clone()).style(theme::text::secondary))
+                                .push(address_view(addr.clone()).style(theme::text::secondary))
                                 .push(
                                     Button::new(
                                         icon::clipboard_icon().style(theme::text::secondary),
@@ -889,7 +890,7 @@ fn payment_view<'a>(
                                 .width(Length::Fill)
                                 .spacing(5)
                                 .push(p1_bold("Address:").style(theme::text::secondary))
-                                .push(p2_regular(addr.clone()).style(theme::text::secondary))
+                                .push(address_view(addr.clone()).style(theme::text::secondary))
                                 .push(
                                     Button::new(
                                         icon::clipboard_icon().style(theme::text::secondary),
@@ -938,7 +939,7 @@ fn change_view(output: &TxOut, network: Network) -> Element<'_, Message> {
                         .width(Length::Fill)
                         .spacing(5)
                         .push(p1_bold("Address:").style(theme::text::secondary))
-                        .push(p2_regular(addr.clone()).style(theme::text::secondary))
+                        .push(address_view(addr.clone()).style(theme::text::secondary))
                         .push(
                             Button::new(icon::clipboard_icon().style(theme::text::secondary))
                                 .on_press(Message::Clipboard(addr))

--- a/liana-gui/src/app/view/receive.rs
+++ b/liana-gui/src/app/view/receive.rs
@@ -17,6 +17,7 @@ use liana::miniscript::bitcoin::{
 
 use liana_ui::{
     component::{
+        address::address as address_view,
         button, card, form, scrollable,
         text::{self, *},
     },
@@ -55,7 +56,11 @@ fn address_card<'a>(
                         Container::new(scrollable::horizontal_thin(
                             Column::new()
                                 .push(Space::with_height(Length::Fixed(10.0)))
-                                .push(p2_regular(address).small().style(theme::text::secondary)),
+                                .push(
+                                    address_view(addr.clone())
+                                        .small()
+                                        .style(theme::text::secondary),
+                                ),
                         ))
                         .width(Length::Fill),
                     )
@@ -94,8 +99,6 @@ pub fn receive<'a>(
     is_last_page: bool,
     processing: bool,
 ) -> Element<'a, Message> {
-    // Number of start and end address characters to show in collapsed view.
-    const NUM_ADDR_CHARS: usize = 16;
     let mut addresses_count = 0; // for counting number of new addresses generated
     Column::new()
         .push(
@@ -159,27 +162,15 @@ pub fn receive<'a>(
                             Row::new()
                                 .spacing(10)
                                 .push(
-                                    {
-                                        let addr = address.to_string();
-                                        let addr_len = addr.chars().count();
-                                        Container::new(
-                                            p2_regular(if addr_len > 2 * NUM_ADDR_CHARS {
-                                                format!(
-                                                    "{}...{}",
-                                                    addr.chars()
-                                                        .take(NUM_ADDR_CHARS)
-                                                        .collect::<String>(),
-                                                    addr.chars()
-                                                        .skip(addr_len - NUM_ADDR_CHARS)
-                                                        .collect::<String>(),
-                                                )
-                                            } else {
-                                                addr
-                                            })
-                                            .small()
-                                            .style(theme::text::secondary),
-                                        )
-                                    }
+                                    Container::new(scrollable::horizontal_thin(
+                                        Column::new()
+                                            .push(Space::with_height(Length::Fixed(10.0)))
+                                            .push(
+                                                address_view(address.to_string())
+                                                    .small()
+                                                    .style(theme::text::secondary),
+                                            ),
+                                    ))
                                     .padding(10)
                                     .width(Length::Fixed(350.0)),
                                 )
@@ -279,9 +270,10 @@ pub fn verify_address_modal<'a>(
                                         .push(
                                             Row::new()
                                                 .align_y(Alignment::Center)
-                                                .push(Container::new(
-                                                    text(address.to_string()).small(),
-                                                ))
+                                                .push(Container::new({
+                                                    let addr = address.to_string();
+                                                    address_view(addr.clone()).small()
+                                                }))
                                                 .push(
                                                     Button::new(icon::clipboard_icon())
                                                         .on_press(Message::Clipboard(
@@ -336,7 +328,7 @@ pub fn verify_address_modal<'a>(
         .into()
 }
 
-pub fn qr_modal<'a>(qr: &'a qr_code::Data, address: &'a String) -> Element<'a, Message> {
+pub fn qr_modal<'a>(qr: &'a qr_code::Data, address: &'a str) -> Element<'a, Message> {
     Column::new()
         .push(
             Row::new()
@@ -348,7 +340,7 @@ pub fn qr_modal<'a>(qr: &'a qr_code::Data, address: &'a String) -> Element<'a, M
                 .push(Space::with_width(Length::Fill)),
         )
         .push(Space::with_height(Length::Fixed(15.0)))
-        .push(Container::new(text(address).size(15)).center_x(Length::Fill))
+        .push(Container::new(address_view(address.to_owned()).size(15)).center_x(Length::Fill))
         .width(Length::Fill)
         .max_width(400)
         .into()

--- a/liana-ui/src/component/address.rs
+++ b/liana-ui/src/component/address.rs
@@ -1,0 +1,246 @@
+use iced::{
+    advanced::{
+        layout, mouse, renderer,
+        widget::{tree, Tree, Widget},
+        Clipboard, Layout, Shell,
+    },
+    Alignment, Element, Event, Length, Rectangle, Size,
+};
+
+use crate::{
+    component::text::{self, p2_regular},
+    theme,
+    widget::{Element as LianaElement, Row},
+};
+
+const CHUNK_SIZE: usize = 4;
+type TextStyle = fn(&theme::Theme) -> iced::widget::text::Style;
+
+#[derive(Debug, Clone)]
+struct AddressState {
+    addr: String,
+    plain: bool,
+}
+
+pub struct Address<'a, Message> {
+    addr: String,
+    size: Option<u32>,
+    style: TextStyle,
+    plain: Element<'a, Message, theme::Theme, iced::Renderer>,
+    chunked: Element<'a, Message, theme::Theme, iced::Renderer>,
+}
+
+pub fn address<'a, Message: 'a>(addr: impl Into<String>) -> Address<'a, Message> {
+    Address::new(addr)
+}
+
+impl<'a, Message: 'a> Address<'a, Message> {
+    pub fn new(addr: impl Into<String>) -> Self {
+        Self::with_size(addr, None)
+    }
+
+    pub fn small(self) -> Self {
+        self.size(text::P1_SIZE)
+    }
+
+    pub fn size(mut self, size: u32) -> Self {
+        self.size = Some(size);
+        self.rebuild_children();
+        self
+    }
+
+    pub fn style(mut self, style: TextStyle) -> Self {
+        self.style = style;
+        self.rebuild_children();
+        self
+    }
+
+    fn with_size(addr: impl Into<String>, size: Option<u32>) -> Self {
+        let addr = addr.into();
+
+        Self {
+            addr: addr.clone(),
+            size,
+            style: theme::text::default,
+            plain: plain_address(&addr, size, theme::text::default),
+            chunked: chunked_address(&addr, size, theme::text::default),
+        }
+    }
+
+    fn rebuild_children(&mut self) {
+        self.plain = plain_address(&self.addr, self.size, self.style);
+        self.chunked = chunked_address(&self.addr, self.size, self.style);
+    }
+}
+
+fn plain_address<'a, Message: 'a>(
+    addr: &str,
+    size: Option<u32>,
+    style: TextStyle,
+) -> Element<'a, Message, theme::Theme, iced::Renderer> {
+    let mut text = p2_regular(addr.to_owned()).style(style);
+    if let Some(size) = size {
+        text = text.size(size);
+    }
+    text.into()
+}
+
+fn chunked_address<'a, Message: 'a>(
+    addr: &str,
+    size: Option<u32>,
+    style: TextStyle,
+) -> Element<'a, Message, theme::Theme, iced::Renderer> {
+    addr.chars()
+        .collect::<Vec<_>>()
+        .chunks(CHUNK_SIZE)
+        .enumerate()
+        .fold(
+            Row::new().align_y(Alignment::Center).spacing(5),
+            |row, (i, chunk)| {
+                let text = chunk.iter().collect::<String>();
+                let style = if i % 2 == 0 {
+                    style
+                } else {
+                    theme::text::card_secondary
+                };
+
+                let mut text = p2_regular(text).style(style);
+                if let Some(size) = size {
+                    text = text.size(size);
+                }
+
+                row.push(text)
+            },
+        )
+        .width(Length::Shrink)
+        .into()
+}
+
+impl<'a, Message: 'a> Widget<Message, theme::Theme, iced::Renderer> for Address<'a, Message> {
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<AddressState>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(AddressState {
+            addr: self.addr.clone(),
+            plain: false,
+        })
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        vec![Tree::new(&self.plain), Tree::new(&self.chunked)]
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        let state = tree.state.downcast_mut::<AddressState>();
+        if state.addr != self.addr {
+            state.addr.clone_from(&self.addr);
+            state.plain = false;
+        }
+
+        tree.diff_children(&[&self.plain, &self.chunked]);
+    }
+
+    fn size(&self) -> Size<Length> {
+        Size::new(Length::Shrink, Length::Shrink)
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        renderer: &iced::Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let state = tree.state.downcast_ref::<AddressState>();
+        let child = if state.plain { 0 } else { 1 };
+
+        self.child_mut(state.plain)
+            .layout(&mut tree.children[child], renderer, limits)
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        _renderer: &iced::Renderer,
+        _clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        _viewport: &Rectangle,
+    ) {
+        if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) = event {
+            if cursor.is_over(layout.bounds()) {
+                let state = tree.state.downcast_mut::<AddressState>();
+                state.plain = !state.plain;
+                shell.invalidate_layout();
+                shell.request_redraw();
+                shell.capture_event();
+            }
+        }
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut iced::Renderer,
+        theme: &theme::Theme,
+        defaults: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        let state = tree.state.downcast_ref::<AddressState>();
+        let child = if state.plain { 0 } else { 1 };
+
+        self.child(state.plain).draw(
+            &tree.children[child],
+            renderer,
+            theme,
+            defaults,
+            layout,
+            cursor,
+            viewport,
+        );
+    }
+
+    fn mouse_interaction(
+        &self,
+        _tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+        _renderer: &iced::Renderer,
+    ) -> mouse::Interaction {
+        if cursor.is_over(layout.bounds()) {
+            mouse::Interaction::Pointer
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+}
+
+impl<'a, Message> Address<'a, Message> {
+    fn child(&self, plain: bool) -> &dyn Widget<Message, theme::Theme, iced::Renderer> {
+        if plain {
+            self.plain.as_widget()
+        } else {
+            self.chunked.as_widget()
+        }
+    }
+
+    fn child_mut(&mut self, plain: bool) -> &mut dyn Widget<Message, theme::Theme, iced::Renderer> {
+        if plain {
+            self.plain.as_widget_mut()
+        } else {
+            self.chunked.as_widget_mut()
+        }
+    }
+}
+
+impl<'a, Message: 'a> From<Address<'a, Message>> for LianaElement<'a, Message> {
+    fn from(address: Address<'a, Message>) -> Self {
+        LianaElement::new(address)
+    }
+}

--- a/liana-ui/src/component/mod.rs
+++ b/liana-ui/src/component/mod.rs
@@ -1,3 +1,4 @@
+pub mod address;
 pub mod amount;
 pub mod badge;
 pub mod button;


### PR DESCRIPTION
Display wallet addresses in 4-character chunks, dimming odd chunks for visual verification.

Clicking an address toggles that widget between chunked and plain display.