### PR TITLE
gui: link liana-connect credentials by JWT user_id

### DIFF
--- a/liana-business/business-installer/src/client.rs
+++ b/liana-business/business-installer/src/client.rs
@@ -281,6 +281,7 @@ impl Client {
                                 &new_tokens,
                                 &auth_client,
                                 false,
+                                None,
                             )
                             .await
                             {
@@ -421,6 +422,7 @@ impl Client {
                                 &new_tokens,
                                 &auth_client,
                                 false,
+                                None,
                             )
                             .await
                             {
@@ -654,6 +656,7 @@ fn try_get_cached_token(data: &TokenRetrievalData) -> Option<String> {
                                     &new_tokens,
                                     &client,
                                     false,
+                                    None,
                                 )
                                 .await
                                 {
@@ -1781,7 +1784,7 @@ impl Backend for Client {
             // Update cache if network_dir is available
             let access_token = if let Some(ref network_dir) = network_dir {
                 tracing::debug!("auth_code: updating token cache");
-                match update_connect_cache(network_dir, &tokens, &auth_client, false).await {
+                match update_connect_cache(network_dir, &tokens, &auth_client, false, None).await {
                     Ok(updated_tokens) => updated_tokens.access_token,
                     Err(e) => {
                         // Cache update failed, but we still have tokens

--- a/liana-business/business-installer/src/client.rs
+++ b/liana-business/business-installer/src/client.rs
@@ -247,7 +247,7 @@ impl Client {
 
                 // Check and refresh token
                 let result = futures::executor::block_on(async {
-                    let account = match Account::from_cache(&network_dir, &email) {
+                    let account = match Account::from_cache_by_email(&network_dir, &email) {
                         Ok(Some(acc)) => acc,
                         _ => return false,
                     };
@@ -473,30 +473,47 @@ impl Client {
             }
         };
 
-        // Get current valid accounts and compute emails to keep
-        let valid_emails: std::collections::HashSet<String> = {
-            match ConnectCache::from_file(&network_dir) {
-                Ok(cache) => cache
-                    .accounts
-                    .into_iter()
-                    .map(|a| a.email)
-                    .filter(|e| !emails_to_remove.contains(e))
-                    .collect(),
+        // Compute the two retain sets from the current cache, excluding the
+        // emails marked for removal. Accounts with `user_id` are keyed by it;
+        // legacy accounts (no user_id) keep using email.
+        let (valid_user_ids, valid_legacy_emails): (
+            std::collections::HashSet<String>,
+            std::collections::HashSet<String>,
+        ) = {
+            let cache = match ConnectCache::from_file(&network_dir) {
+                Ok(cache) => cache,
                 Err(e) => {
                     tracing::debug!("clear_invalid_tokens: failed to read cache: {:?}", e);
                     return;
                 }
+            };
+            let mut user_ids = std::collections::HashSet::new();
+            let mut legacy = std::collections::HashSet::new();
+            for a in cache.accounts {
+                if emails_to_remove.contains(&a.email) {
+                    continue;
+                }
+                match a.user_id {
+                    Some(uid) => {
+                        user_ids.insert(uid);
+                    }
+                    None => {
+                        legacy.insert(a.email);
+                    }
+                }
             }
+            (user_ids, legacy)
         };
 
         tracing::debug!(
-            "clear_invalid_tokens: keeping {} valid accounts",
-            valid_emails.len()
+            "clear_invalid_tokens: keeping {} migrated and {} legacy accounts",
+            valid_user_ids.len(),
+            valid_legacy_emails.len()
         );
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
-            let _ = filter_connect_cache(&network_dir, &valid_emails).await;
+            let _ = filter_connect_cache(&network_dir, &valid_user_ids, &valid_legacy_emails).await;
         });
 
         tracing::debug!("clear_invalid_tokens: cache updated");
@@ -606,7 +623,7 @@ fn try_get_cached_token(data: &TokenRetrievalData) -> Option<String> {
 
     let result = futures::executor::block_on(async {
         // Try to get cached account
-        match Account::from_cache(&network_dir, &email) {
+        match Account::from_cache_by_email(&network_dir, &email) {
             Ok(Some(account)) => {
                 let tokens = &account.tokens;
                 let now = chrono::Utc::now().timestamp();

--- a/liana-business/business-installer/src/installer.rs
+++ b/liana-business/business-installer/src/installer.rs
@@ -149,6 +149,10 @@ impl Installer<'_, Message> for BusinessInstaller {
                 datadir: self.datadir.clone(),
                 network: self.network,
                 wallet_id,
+                // user_id will be populated lazily on the next connect via
+                // `backfill_local_link`, since the business installer flow
+                // does not currently retain a connected BackendClient here.
+                user_id: None,
                 email,
             });
         }

--- a/liana-business/src/settings/mod.rs
+++ b/liana-business/src/settings/mod.rs
@@ -161,6 +161,7 @@ impl SettingsTrait for BusinessSettings {
                 .collect();
 
             let auth_cfg = AuthConfig {
+                user_id: Some(remote_backend.user_id().to_string()),
                 email: remote_backend.user_email().to_string(),
                 wallet_id: remote_backend.wallet_id(),
                 refresh_token: None,

--- a/liana-connect/src/wallets/api.rs
+++ b/liana-connect/src/wallets/api.rs
@@ -57,6 +57,7 @@ pub const DEFAULT_LABEL_ITEMS_LIMIT: usize = 50;
 #[derive(Deserialize)]
 pub struct Claims {
     pub sub: String,
+    pub email: String,
 }
 
 /// Fiat currency setting for a user's wallet.

--- a/liana-gui/src/app/settings/mod.rs
+++ b/liana-gui/src/app/settings/mod.rs
@@ -244,6 +244,10 @@ where
 pub struct AuthConfig {
     pub email: String,
     pub wallet_id: String,
+    // Stable Liana-Connect user identifier (JWT `sub`). Optional only to allow
+    // legacy settings files (pre user_id) to deserialize; populated on next login.
+    #[serde(default)]
+    pub user_id: Option<String>,
     // legacy field, refresh_token is now stored in the connect cache file
     // Keep it in case, user want to open the wallet with a previous Liana-GUI version.
     // Field cannot be ignored as the settings file is override during settings update.
@@ -252,10 +256,11 @@ pub struct AuthConfig {
 }
 
 impl AuthConfig {
-    pub fn new(email: String, wallet_id: String) -> Self {
+    pub fn new(user_id: String, email: String, wallet_id: String) -> Self {
         Self {
             email,
             wallet_id,
+            user_id: Some(user_id),
             refresh_token: None,
         }
     }

--- a/liana-gui/src/delete.rs
+++ b/liana-gui/src/delete.rs
@@ -66,27 +66,30 @@ pub async fn delete_failed_install(
         )?;
     }
 
-    let mut remaining_accounts = HashSet::<String>::new();
+    let mut remaining_user_ids = HashSet::<String>::new();
+    let mut legacy_emails = HashSet::<String>::new();
     settings::update_settings_file(network_dir, |mut settings: LianaSettings| {
         settings
             .wallets
             .retain(|settings| settings.wallet_id() != *wallet_id);
-        remaining_accounts = settings
-            .wallets
-            .iter()
-            .filter_map(|settings| {
-                settings
-                    .remote_backend_auth
-                    .as_ref()
-                    .map(|auth| auth.email.clone())
-            })
-            .collect();
+        for w in settings.wallets.iter() {
+            if let Some(auth) = w.remote_backend_auth.as_ref() {
+                match &auth.user_id {
+                    Some(uid) => {
+                        remaining_user_ids.insert(uid.clone());
+                    }
+                    None => {
+                        legacy_emails.insert(auth.email.clone());
+                    }
+                }
+            }
+        }
         settings
     })
     .await
     .map_err(DeleteError::Settings)?;
 
-    cache::filter_connect_cache(network_dir, &remaining_accounts)
+    cache::filter_connect_cache(network_dir, &remaining_user_ids, &legacy_emails)
         .await
         .map_err(DeleteError::ConnectCache)?;
 
@@ -137,7 +140,7 @@ pub async fn delete_wallet(
             );
             if let BackendState::WalletExists(client, _, _, _) = connect_with_credentials(
                 client,
-                auth.wallet_id.clone(),
+                auth.clone(),
                 service_config.backend_api_url,
                 network,
                 network_dir,
@@ -156,27 +159,30 @@ pub async fn delete_wallet(
         }
     }
 
-    let mut remaining_accounts = HashSet::<String>::new();
+    let mut remaining_user_ids = HashSet::<String>::new();
+    let mut legacy_emails = HashSet::<String>::new();
     settings::update_settings_file(network_dir, |mut settings: LianaSettings| {
         settings
             .wallets
             .retain(|settings| settings.wallet_id() != wallet_id);
-        remaining_accounts = settings
-            .wallets
-            .iter()
-            .filter_map(|settings| {
-                settings
-                    .remote_backend_auth
-                    .as_ref()
-                    .map(|auth| auth.email.clone())
-            })
-            .collect();
+        for w in settings.wallets.iter() {
+            if let Some(auth) = w.remote_backend_auth.as_ref() {
+                match &auth.user_id {
+                    Some(uid) => {
+                        remaining_user_ids.insert(uid.clone());
+                    }
+                    None => {
+                        legacy_emails.insert(auth.email.clone());
+                    }
+                }
+            }
+        }
         settings
     })
     .await
     .map_err(DeleteError::Settings)?;
 
-    cache::filter_connect_cache(network_dir, &remaining_accounts)
+    cache::filter_connect_cache(network_dir, &remaining_user_ids, &legacy_emails)
         .await
         .map_err(DeleteError::ConnectCache)?;
 

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -723,25 +723,16 @@ async fn connect_for_business(
 
     // Get tokens from cache: user_id-first, then legacy-email fallback.
     let network_dir = datadir.network_directory(network);
-    let cached = {
-        let by_uid = match &user_id {
-            Some(uid) => connect_cache::Account::from_cache_by_user_id(&network_dir, uid),
-            None => Ok(None),
-        }
-        .map_err(|e| match e {
-            connect_cache::ConnectCacheError::NotFound => login::Error::CredentialsMissing,
-            _ => e.into(),
-        })?;
-        match by_uid {
-            Some(a) => a,
-            None => connect_cache::Account::from_cache_by_email(&network_dir, &email)
-                .map_err(|e| match e {
-                    connect_cache::ConnectCacheError::NotFound => login::Error::CredentialsMissing,
-                    _ => e.into(),
-                })?
-                .ok_or(login::Error::CredentialsMissing)?,
-        }
-    };
+    let cached = connect_cache::Account::from_cache_by_uid_or_email(
+        &network_dir,
+        user_id.as_deref(),
+        &email,
+    )
+    .map_err(|e| match e {
+        connect_cache::ConnectCacheError::NotFound => login::Error::CredentialsMissing,
+        _ => e.into(),
+    })?
+    .ok_or(login::Error::CredentialsMissing)?;
     let mut tokens = cached.tokens;
 
     // Refresh if expired

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -763,17 +763,22 @@ async fn connect_for_business(
         .ok_or_else(|| login::Error::Unexpected(format!("Wallet {wallet_id} not found")))?;
 
     // Wallet confirmed to belong to the connected user — safe to stamp the
-    // local cache and settings entry. The by_email fallback in the cache
-    // lookup above could otherwise have produced tokens for a different sub.
-    let backfill_auth_cfg = crate::app::settings::AuthConfig {
-        user_id: user_id.clone(),
-        email: email.clone(),
-        wallet_id: wallet_id.clone(),
-        refresh_token: None,
-    };
-    if let Err(e) = login::backfill_local_link(&network_dir, &client, &backfill_auth_cfg).await {
+    // connect-token cache with the authoritative user_id/email. The by_email
+    // fallback in the cache lookup above could otherwise have produced tokens
+    // for a different sub. Business settings are backend-managed, so (unlike
+    // the GUI path) there is no settings.json entry to backfill — only
+    // connect.json.
+    if let Err(e) = connect_cache::stamp_account_identity(
+        &network_dir,
+        user_id.as_deref(),
+        &email,
+        client.user_id(),
+        client.user_email(),
+    )
+    .await
+    {
         // Non-fatal: the wallet still works for this session.
-        tracing::warn!("Failed to backfill Liana-Connect link: {}", e);
+        tracing::warn!("Failed to stamp Liana-Connect cache: {}", e);
     }
 
     // Create wallet client

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -327,11 +327,13 @@ where
                             datadir,
                             network,
                             wallet_id,
+                            user_id,
                             email,
                         } => {
                             // Spawn async task to connect using cached tokens
                             let datadir_clone = datadir.clone();
                             let wallet_id_clone = wallet_id.clone();
+                            let user_id_clone = user_id.clone();
                             let email_clone = email.clone();
                             Task::perform(
                                 async move {
@@ -339,6 +341,7 @@ where
                                         datadir_clone.clone(),
                                         network,
                                         wallet_id_clone.clone(),
+                                        user_id_clone.clone(),
                                         email_clone.clone(),
                                         I::backend_type(),
                                     )
@@ -477,6 +480,9 @@ where
                         let directory_wallet_id =
                             crate::app::settings::WalletId::new(wallet_id.clone(), None);
 
+                        // Capture user_id before moving the backend client.
+                        let user_id = backend_client.user_id().to_string();
+
                         // Use the trait method to create App
                         let result = S::create_app_for_remote_backend(
                             directory_wallet_id,
@@ -498,6 +504,7 @@ where
                                 tracing::error!("Failed to create app: {}", e);
                                 // Fall back to login flow
                                 let auth_cfg = crate::app::settings::AuthConfig {
+                                    user_id: Some(user_id),
                                     email,
                                     wallet_id,
                                     refresh_token: None,
@@ -686,6 +693,7 @@ async fn connect_for_business(
     datadir: LianaDirectory,
     network: bitcoin::Network,
     wallet_id: String,
+    user_id: Option<String>,
     email: String,
     backend_type: crate::services::connect::client::BackendType,
 ) -> Result<
@@ -713,15 +721,28 @@ async fn connect_for_business(
         backend_type.user_agent(),
     );
 
-    // Get tokens from cache
+    // Get tokens from cache: user_id-first, then legacy-email fallback.
     let network_dir = datadir.network_directory(network);
-    let mut tokens = connect_cache::Account::from_cache(&network_dir, &email)
+    let cached = {
+        let by_uid = match &user_id {
+            Some(uid) => connect_cache::Account::from_cache_by_user_id(&network_dir, uid),
+            None => Ok(None),
+        }
         .map_err(|e| match e {
             connect_cache::ConnectCacheError::NotFound => login::Error::CredentialsMissing,
             _ => e.into(),
-        })?
-        .ok_or(login::Error::CredentialsMissing)?
-        .tokens;
+        })?;
+        match by_uid {
+            Some(a) => a,
+            None => connect_cache::Account::from_cache_by_email(&network_dir, &email)
+                .map_err(|e| match e {
+                    connect_cache::ConnectCacheError::NotFound => login::Error::CredentialsMissing,
+                    _ => e.into(),
+                })?
+                .ok_or(login::Error::CredentialsMissing)?,
+        }
+    };
+    let mut tokens = cached.tokens;
 
     // Refresh if expired
     if tokens.expires_at < chrono::Utc::now().timestamp() {
@@ -734,6 +755,18 @@ async fn connect_for_business(
         BackendClient::connect(auth_client, service_config.backend_api_url, tokens, network)
             .await
             .map_err(|e| login::Error::Unexpected(e.to_string()))?;
+
+    // Backfill connect.json + settings.json with the authoritative user_id and email.
+    let backfill_auth_cfg = crate::app::settings::AuthConfig {
+        user_id: user_id.clone(),
+        email: email.clone(),
+        wallet_id: wallet_id.clone(),
+        refresh_token: None,
+    };
+    if let Err(e) = login::backfill_local_link(&network_dir, &client, &backfill_auth_cfg).await {
+        // Non-fatal: the wallet still works for this session.
+        tracing::warn!("Failed to backfill Liana-Connect link: {}", e);
+    }
 
     // Find the wallet
     let wallet = client

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -762,7 +762,18 @@ async fn connect_for_business(
             .await
             .map_err(|e| login::Error::Unexpected(e.to_string()))?;
 
-    // Backfill connect.json + settings.json with the authoritative user_id and email.
+    // Find the wallet
+    let wallet = client
+        .list_wallets()
+        .await
+        .map_err(|e| login::Error::Unexpected(e.to_string()))?
+        .into_iter()
+        .find(|w| w.id == wallet_id)
+        .ok_or_else(|| login::Error::Unexpected(format!("Wallet {wallet_id} not found")))?;
+
+    // Wallet confirmed to belong to the connected user — safe to stamp the
+    // local cache and settings entry. The by_email fallback in the cache
+    // lookup above could otherwise have produced tokens for a different sub.
     let backfill_auth_cfg = crate::app::settings::AuthConfig {
         user_id: user_id.clone(),
         email: email.clone(),
@@ -773,15 +784,6 @@ async fn connect_for_business(
         // Non-fatal: the wallet still works for this session.
         tracing::warn!("Failed to backfill Liana-Connect link: {}", e);
     }
-
-    // Find the wallet
-    let wallet = client
-        .list_wallets()
-        .await
-        .map_err(|e| login::Error::Unexpected(e.to_string()))?
-        .into_iter()
-        .find(|w| w.id == wallet_id)
-        .ok_or_else(|| login::Error::Unexpected(format!("Wallet {wallet_id} not found")))?;
 
     // Create wallet client
     let (wallet_client, wallet) = client.connect_wallet(wallet);

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -746,8 +746,14 @@ async fn connect_for_business(
 
     // Refresh if expired
     if tokens.expires_at < chrono::Utc::now().timestamp() {
-        tokens =
-            connect_cache::update_connect_cache(&network_dir, &tokens, &auth_client, true).await?;
+        tokens = connect_cache::update_connect_cache(
+            &network_dir,
+            &tokens,
+            &auth_client,
+            true,
+            user_id.as_deref(),
+        )
+        .await?;
     }
 
     // Connect to backend

--- a/liana-gui/src/installer/mod.rs
+++ b/liana-gui/src/installer/mod.rs
@@ -86,6 +86,9 @@ pub enum NextState {
         network: Network,
         /// The Connect wallet ID (UUID)
         wallet_id: String,
+        /// Stable Liana-Connect user identifier (JWT `sub`). `None` for legacy
+        /// installer paths; cache lookup falls back to email and backfills.
+        user_id: Option<String>,
         /// User's email for token lookup and re-auth
         email: String,
     },
@@ -818,6 +821,7 @@ pub async fn create_remote_wallet(
         keys: Vec::new(),
         hardware_wallets: Vec::new(),
         remote_backend_auth: Some(AuthConfig::new(
+            remote_backend.user_id().to_string(),
             remote_backend.user_email().to_string(),
             remote_backend.wallet_id(),
         )),
@@ -898,6 +902,7 @@ pub async fn import_remote_wallet(
         keys: Vec::new(),
         hardware_wallets: Vec::new(),
         remote_backend_auth: Some(AuthConfig::new(
+            backend.user_id().to_string(),
             backend.user_email().to_string(),
             backend.wallet_id(),
         )),

--- a/liana-gui/src/installer/mod.rs
+++ b/liana-gui/src/installer/mod.rs
@@ -843,6 +843,7 @@ pub async fn create_remote_wallet(
         backend.auth.read().await.deref(),
         backend.auth_client(),
         false,
+        Some(remote_backend.user_id()),
     )
     .await
     {
@@ -939,6 +940,7 @@ pub async fn import_remote_wallet(
         backend.auth.read().await.deref(),
         backend.auth_client(),
         false,
+        Some(backend.user_id()),
     )
     .await
     {

--- a/liana-gui/src/installer/step/backend.rs
+++ b/liana-gui/src/installer/step/backend.rs
@@ -441,7 +441,10 @@ pub async fn connect_with_existing_account(
         .tokens;
 
     if tokens.expires_at < chrono::Utc::now().timestamp() {
-        tokens = cache::update_connect_cache(&network_dir, &tokens, &client, true)
+        // BackendClient::connect runs right after this, so we don't yet know
+        // the user_id from the JWT. `upsert_credential` preserves whatever
+        // user_id the existing row already carries.
+        tokens = cache::update_connect_cache(&network_dir, &tokens, &client, true, None)
             .await
             .map_err(|e| Error::Unexpected(format!("Failed to update cache: {e}")))?;
     }

--- a/liana-gui/src/installer/step/backend.rs
+++ b/liana-gui/src/installer/step/backend.rs
@@ -435,7 +435,7 @@ pub async fn connect_with_existing_account(
         client::BackendType::LianaConnect.user_agent(),
     );
 
-    let mut tokens = cache::Account::from_cache(&network_dir, &client.email)
+    let mut tokens = cache::Account::from_cache_by_email(&network_dir, &client.email)
         .map_err(|_| Error::Unexpected("Account must be in cache".to_string()))?
         .ok_or(Error::Unexpected("Account must be in cache".to_string()))?
         .tokens;

--- a/liana-gui/src/launcher.rs
+++ b/liana-gui/src/launcher.rs
@@ -663,7 +663,7 @@ pub async fn check_membership(
             auth.email.to_string(),
             backend_type.user_agent(),
         ),
-        auth.wallet_id.clone(),
+        auth.clone(),
         service_config.backend_api_url,
         network,
         network_dir,

--- a/liana-gui/src/services/connect/client/backend/mod.rs
+++ b/liana-gui/src/services/connect/client/backend/mod.rs
@@ -77,6 +77,10 @@ pub struct BackendClient {
     unauthenticated: Arc<AtomicBool>,
 
     user_id: String,
+    /// Email as reported by `/v1/me` — the authoritative server-side value,
+    /// which can differ from `auth_client.email` (the email the user typed
+    /// or that we read out of local settings) after a server-side change.
+    user_email: String,
 }
 
 impl BackendClient {
@@ -100,14 +104,14 @@ impl BackendClient {
             return Err(DaemonError::NoAnswer);
         }
         let res: api::Claims = response.json().await?;
-        let user_id = res.sub;
 
         Ok(Self {
             auth: Arc::new(RwLock::new(credentials)),
             auth_client,
             network,
             url,
-            user_id,
+            user_id: res.sub,
+            user_email: res.email,
             http,
             unauthenticated: Arc::new(AtomicBool::new(false)),
         })
@@ -118,7 +122,7 @@ impl BackendClient {
     }
 
     pub fn user_email(&self) -> &str {
-        &self.auth_client.email
+        &self.user_email
     }
 
     pub fn user_id(&self) -> &str {

--- a/liana-gui/src/services/connect/client/backend/mod.rs
+++ b/liana-gui/src/services/connect/client/backend/mod.rs
@@ -573,6 +573,7 @@ impl Daemon for BackendWalletClient {
                         &old,
                         &self.inner.auth_client,
                         true, // refresh the token
+                        Some(self.inner.user_id()),
                     )
                     .await
                     .map_err(|e| {

--- a/liana-gui/src/services/connect/client/backend/mod.rs
+++ b/liana-gui/src/services/connect/client/backend/mod.rs
@@ -121,6 +121,10 @@ impl BackendClient {
         &self.auth_client.email
     }
 
+    pub fn user_id(&self) -> &str {
+        &self.user_id
+    }
+
     pub async fn connect_first(self) -> Result<(BackendWalletClient, api::Wallet), DaemonError> {
         let wallets = self.list_wallets().await?;
         let first = wallets.first().cloned().ok_or(DaemonError::NoAnswer)?;

--- a/liana-gui/src/services/connect/client/cache.rs
+++ b/liana-gui/src/services/connect/client/cache.rs
@@ -91,6 +91,128 @@ impl Account {
         ConnectCache::from_file(network_dir)
             .map(|cache| cache.accounts.into_iter().find(|c| c.email == email))
     }
+
+    /// Preferred `user_id` lookup with an email fallback. The email path covers
+    /// caches written before the user_id stamp landed and the picker-by-email
+    /// flow. A missing cache file surfaces as `ConnectCacheError::NotFound`.
+    pub fn from_cache_by_uid_or_email(
+        network_dir: &NetworkDirectory,
+        user_id: Option<&str>,
+        email: &str,
+    ) -> Result<Option<Self>, ConnectCacheError> {
+        if let Some(uid) = user_id {
+            if let Some(account) = Self::from_cache_by_user_id(network_dir, uid)? {
+                return Ok(Some(account));
+            }
+        }
+        Self::from_cache_by_email(network_dir, email)
+    }
+}
+
+/// Guard returned by [`open_locked_cache`]; holds the exclusive file lock.
+type LockedCache = async_fd_lock::RwLockWriteGuard<tokio::fs::File>;
+
+/// Open the connect cache under an exclusive write lock and return the parsed
+/// contents alongside the still-locked handle. Returns `None` when the file is
+/// absent and `create_if_missing` is false; an unparsable or empty file yields
+/// an empty cache rather than an error.
+async fn open_locked_cache(
+    network_dir: &NetworkDirectory,
+    create_if_missing: bool,
+) -> Result<Option<(LockedCache, ConnectCache)>, ConnectCacheError> {
+    let mut path = network_dir.path().to_path_buf();
+    path.push(CONNECT_CACHE_FILENAME);
+
+    let file_exists = tokio::fs::try_exists(&path).await.unwrap_or(false);
+    if !file_exists && !create_if_missing {
+        return Ok(None);
+    }
+
+    if create_if_missing {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| ConnectCacheError::WritingFile(format!("Creating directory: {e}")))?;
+        }
+    }
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(create_if_missing)
+        .truncate(false)
+        .open(&path)
+        .await
+        .map_err(|e| ConnectCacheError::ReadingFile(format!("Opening file: {e}")))?
+        .lock_write()
+        .await
+        .map_err(|e| ConnectCacheError::ReadingFile(format!("Locking file: {e:?}")))?;
+
+    let mut file_content = Vec::new();
+    file.read_to_end(&mut file_content)
+        .await
+        .map_err(|e| ConnectCacheError::ReadingFile(format!("Reading file content: {e}")))?;
+
+    let cache = if file_content.is_empty() {
+        ConnectCache::default()
+    } else {
+        match serde_json::from_slice::<ConnectCache>(&file_content) {
+            Ok(cache) => cache,
+            Err(e) => {
+                tracing::warn!("Something wrong with Liana-Connect cache file: {:?}", e);
+                tracing::warn!("Liana-Connect cache file is reset");
+                ConnectCache::default()
+            }
+        }
+    };
+
+    Ok(Some((file, cache)))
+}
+
+/// Serialize `cache` back over the locked file, truncating any trailing bytes.
+async fn write_cache_back(
+    file: &mut LockedCache,
+    cache: &ConnectCache,
+) -> Result<(), ConnectCacheError> {
+    let content = serde_json::to_vec_pretty(cache).map_err(|e| {
+        ConnectCacheError::WritingFile(format!("Failed to serialize settings: {e}"))
+    })?;
+
+    file.seek(SeekFrom::Start(0)).await.map_err(|e| {
+        ConnectCacheError::WritingFile(format!("Failed to seek to start of file: {e}"))
+    })?;
+
+    file.write_all(&content).await.map_err(|e| {
+        tracing::warn!("failed to write to file: {:?}", e);
+        ConnectCacheError::WritingFile(e.to_string())
+    })?;
+
+    file.inner_mut()
+        .set_len(content.len() as u64)
+        .await
+        .map_err(|e| ConnectCacheError::WritingFile(format!("Failed to truncate file: {e}")))?;
+
+    Ok(())
+}
+
+/// Read-modify-write the cache under lock, persisting only when `mutate`
+/// returns `true`. For mutations that need to `.await` while holding the lock,
+/// use [`open_locked_cache`]/[`write_cache_back`] directly.
+async fn with_locked_cache<F>(
+    network_dir: &NetworkDirectory,
+    create_if_missing: bool,
+    mutate: F,
+) -> Result<(), ConnectCacheError>
+where
+    F: FnOnce(&mut ConnectCache) -> bool,
+{
+    let Some((mut file, mut cache)) = open_locked_cache(network_dir, create_if_missing).await?
+    else {
+        return Ok(());
+    };
+    if mutate(&mut cache) {
+        write_cache_back(&mut file, &cache).await?;
+    }
+    Ok(())
 }
 
 pub async fn update_connect_cache(
@@ -101,45 +223,11 @@ pub async fn update_connect_cache(
     user_id: Option<&str>,
 ) -> Result<AccessTokenResponse, ConnectCacheError> {
     let email = &client.email;
-    let mut path = network_dir.path().to_path_buf();
-    path.push(CONNECT_CACHE_FILENAME);
 
-    // Create parent directory if it doesn't exist
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| ConnectCacheError::WritingFile(format!("Creating directory: {e}")))?;
-    }
-
-    let file_exists = tokio::fs::try_exists(&path).await.unwrap_or(false);
-
-    let mut file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(&path)
-        .await
-        .map_err(|e| ConnectCacheError::ReadingFile(format!("Opening file: {e}")))?
-        .lock_write()
-        .await
-        .map_err(|e| ConnectCacheError::ReadingFile(format!("Locking file: {e:?}")))?;
-
-    let mut cache = if file_exists {
-        let mut file_content = Vec::new();
-        file.read_to_end(&mut file_content)
-            .await
-            .map_err(|e| ConnectCacheError::ReadingFile(format!("Reading file content: {e}")))?;
-
-        match serde_json::from_slice::<ConnectCache>(&file_content) {
-            Ok(cache) => cache,
-            Err(e) => {
-                tracing::warn!("Something wrong with Liana-Connect cache file: {:?}", e);
-                tracing::warn!("Liana-Connect cache file is reset");
-                ConnectCache::default()
-            }
-        }
-    } else {
-        ConnectCache::default()
+    let Some((mut file, mut cache)) = open_locked_cache(network_dir, true).await? else {
+        return Err(ConnectCacheError::Unexpected(
+            "connect cache file missing despite create".to_string(),
+        ));
     };
 
     let existing = cache.accounts.iter().position(|cred| cred.email == *email);
@@ -179,23 +267,7 @@ pub async fn update_connect_cache(
     };
 
     if write_needed {
-        let content = serde_json::to_vec_pretty(&cache).map_err(|e| {
-            ConnectCacheError::WritingFile(format!("Failed to serialize settings: {e}"))
-        })?;
-
-        file.seek(SeekFrom::Start(0)).await.map_err(|e| {
-            ConnectCacheError::WritingFile(format!("Failed to seek to start of file: {e}"))
-        })?;
-
-        file.write_all(&content).await.map_err(|e| {
-            tracing::warn!("failed to write to file: {:?}", e);
-            ConnectCacheError::WritingFile(e.to_string())
-        })?;
-
-        file.inner_mut()
-            .set_len(content.len() as u64)
-            .await
-            .map_err(|e| ConnectCacheError::WritingFile(format!("Failed to truncate file: {e}")))?;
+        write_cache_back(&mut file, &cache).await?;
     }
 
     Ok(tokens_to_return)
@@ -206,71 +278,14 @@ pub async fn filter_connect_cache(
     user_ids: &HashSet<String>,
     legacy_emails: &HashSet<String>,
 ) -> Result<(), ConnectCacheError> {
-    let mut path = network_dir.path().to_path_buf();
-    path.push(CONNECT_CACHE_FILENAME);
-
-    // Create parent directory if it doesn't exist
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| ConnectCacheError::WritingFile(format!("Creating directory: {e}")))?;
-    }
-
-    let file_exists = tokio::fs::try_exists(&path).await.unwrap_or(false);
-
-    let mut file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(&path)
-        .await
-        .map_err(|e| ConnectCacheError::ReadingFile(format!("Opening file: {e}")))?
-        .lock_write()
-        .await
-        .map_err(|e| ConnectCacheError::ReadingFile(format!("Locking file: {e:?}")))?;
-
-    let mut cache = if file_exists {
-        let mut file_content = Vec::new();
-        file.read_to_end(&mut file_content)
-            .await
-            .map_err(|e| ConnectCacheError::ReadingFile(format!("Reading file content: {e}")))?;
-
-        match serde_json::from_slice::<ConnectCache>(&file_content) {
-            Ok(cache) => cache,
-            Err(e) => {
-                tracing::warn!("Something wrong with Liana-Connect cache file: {:?}", e);
-                tracing::warn!("Liana-Connect cache file is reset");
-                ConnectCache::default()
-            }
-        }
-    } else {
-        ConnectCache::default()
-    };
-
-    cache.accounts.retain(|a| match &a.user_id {
-        Some(uid) => user_ids.contains(uid),
-        None => legacy_emails.contains(&a.email),
-    });
-
-    let content = serde_json::to_vec_pretty(&cache).map_err(|e| {
-        ConnectCacheError::WritingFile(format!("Failed to serialize settings: {e}"))
-    })?;
-
-    file.seek(SeekFrom::Start(0)).await.map_err(|e| {
-        ConnectCacheError::WritingFile(format!("Failed to seek to start of file: {e}"))
-    })?;
-
-    file.write_all(&content).await.map_err(|e| {
-        tracing::warn!("failed to write to file: {:?}", e);
-        ConnectCacheError::WritingFile(e.to_string())
-    })?;
-
-    file.inner_mut()
-        .set_len(content.len() as u64)
-        .await
-        .map_err(|e| ConnectCacheError::WritingFile(format!("Failed to truncate file: {e}")))?;
-
-    Ok(())
+    with_locked_cache(network_dir, true, |cache| {
+        cache.accounts.retain(|a| match &a.user_id {
+            Some(uid) => user_ids.contains(uid),
+            None => legacy_emails.contains(&a.email),
+        });
+        true
+    })
+    .await
 }
 
 /// Stamp the authoritative `user_id` and `email` reported by Liana-Connect onto
@@ -287,68 +302,10 @@ pub async fn stamp_account_identity(
     new_user_id: &str,
     new_email: &str,
 ) -> Result<(), ConnectCacheError> {
-    let mut path = network_dir.path().to_path_buf();
-    path.push(CONNECT_CACHE_FILENAME);
-
-    let file_exists = tokio::fs::try_exists(&path).await.unwrap_or(false);
-    if !file_exists {
-        return Ok(());
-    }
-
-    let mut file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(false)
-        .truncate(false)
-        .open(&path)
-        .await
-        .map_err(|e| ConnectCacheError::ReadingFile(format!("Opening file: {e}")))?
-        .lock_write()
-        .await
-        .map_err(|e| ConnectCacheError::ReadingFile(format!("Locking file: {e:?}")))?;
-
-    let mut file_content = Vec::new();
-    file.read_to_end(&mut file_content)
-        .await
-        .map_err(|e| ConnectCacheError::ReadingFile(format!("Reading file content: {e}")))?;
-
-    let mut cache = match serde_json::from_slice::<ConnectCache>(&file_content) {
-        Ok(cache) => cache,
-        Err(e) => {
-            tracing::warn!("Cannot parse Liana-Connect cache file: {:?}", e);
-            return Ok(());
-        }
-    };
-
-    if !stamp_in_memory(
-        &mut cache,
-        lookup_user_id,
-        lookup_email,
-        new_user_id,
-        new_email,
-    ) {
-        return Ok(());
-    }
-
-    let content = serde_json::to_vec_pretty(&cache).map_err(|e| {
-        ConnectCacheError::WritingFile(format!("Failed to serialize settings: {e}"))
-    })?;
-
-    file.seek(SeekFrom::Start(0)).await.map_err(|e| {
-        ConnectCacheError::WritingFile(format!("Failed to seek to start of file: {e}"))
-    })?;
-
-    file.write_all(&content).await.map_err(|e| {
-        tracing::warn!("failed to write to file: {:?}", e);
-        ConnectCacheError::WritingFile(e.to_string())
-    })?;
-
-    file.inner_mut()
-        .set_len(content.len() as u64)
-        .await
-        .map_err(|e| ConnectCacheError::WritingFile(format!("Failed to truncate file: {e}")))?;
-
-    Ok(())
+    with_locked_cache(network_dir, false, |cache| {
+        stamp_in_memory(cache, lookup_user_id, lookup_email, new_user_id, new_email)
+    })
+    .await
 }
 
 /// In-memory stamp + dedup. Returns true if anything changed.

--- a/liana-gui/src/services/connect/client/cache.rs
+++ b/liana-gui/src/services/connect/client/cache.rs
@@ -142,44 +142,63 @@ pub async fn update_connect_cache(
         ConnectCache::default()
     };
 
-    if let Some(c) = cache.accounts.iter().find(|cred| cred.email == *email) {
-        // Another process updated the tokens
-        if current_tokens.expires_at < c.tokens.expires_at {
-            tracing::debug!("Liana-Connect authentication tokens are up to date, nothing to do");
-            return Ok(c.tokens.clone());
-        }
-    }
+    let existing = cache.accounts.iter().position(|cred| cred.email == *email);
 
-    let tokens = if refresh {
-        client
-            .refresh_token(&current_tokens.refresh_token)
-            .await
-            .map_err(ConnectCacheError::Updating)?
-    } else {
-        current_tokens.clone()
+    let (tokens_to_return, write_needed) = match existing {
+        Some(idx) if current_tokens.expires_at < cache.accounts[idx].tokens.expires_at => {
+            // Another process already wrote fresher tokens. Use those, but
+            // still stamp user_id in place if we just learned it and the row
+            // is still legacy — otherwise the freshness shortcut would leave
+            // an unstamped row and filter_connect_cache could drop it on a
+            // sibling wallet's deletion.
+            let needs_stamp = matches!(
+                (user_id, cache.accounts[idx].user_id.as_deref()),
+                (Some(_), None)
+            );
+            if let (true, Some(uid)) = (needs_stamp, user_id) {
+                cache.accounts[idx].user_id = Some(uid.to_string());
+            } else {
+                tracing::debug!(
+                    "Liana-Connect authentication tokens are up to date, nothing to do"
+                );
+            }
+            (cache.accounts[idx].tokens.clone(), needs_stamp)
+        }
+        _ => {
+            let tokens = if refresh {
+                client
+                    .refresh_token(&current_tokens.refresh_token)
+                    .await
+                    .map_err(ConnectCacheError::Updating)?
+            } else {
+                current_tokens.clone()
+            };
+            cache.upsert_credential(user_id, email, tokens.clone());
+            (tokens, true)
+        }
     };
 
-    cache.upsert_credential(user_id, email, tokens.clone());
+    if write_needed {
+        let content = serde_json::to_vec_pretty(&cache).map_err(|e| {
+            ConnectCacheError::WritingFile(format!("Failed to serialize settings: {e}"))
+        })?;
 
-    let content = serde_json::to_vec_pretty(&cache).map_err(|e| {
-        ConnectCacheError::WritingFile(format!("Failed to serialize settings: {e}"))
-    })?;
+        file.seek(SeekFrom::Start(0)).await.map_err(|e| {
+            ConnectCacheError::WritingFile(format!("Failed to seek to start of file: {e}"))
+        })?;
 
-    file.seek(SeekFrom::Start(0)).await.map_err(|e| {
-        ConnectCacheError::WritingFile(format!("Failed to seek to start of file: {e}"))
-    })?;
+        file.write_all(&content).await.map_err(|e| {
+            tracing::warn!("failed to write to file: {:?}", e);
+            ConnectCacheError::WritingFile(e.to_string())
+        })?;
 
-    file.write_all(&content).await.map_err(|e| {
-        tracing::warn!("failed to write to file: {:?}", e);
-        ConnectCacheError::WritingFile(e.to_string())
-    })?;
+        file.inner_mut()
+            .set_len(content.len() as u64)
+            .await
+            .map_err(|e| ConnectCacheError::WritingFile(format!("Failed to truncate file: {e}")))?;
+    }
 
-    file.inner_mut()
-        .set_len(content.len() as u64)
-        .await
-        .map_err(|e| ConnectCacheError::WritingFile(format!("Failed to truncate file: {e}")))?;
-
-    Ok(tokens)
+    Ok(tokens_to_return)
 }
 
 pub async fn filter_connect_cache(

--- a/liana-gui/src/services/connect/client/cache.rs
+++ b/liana-gui/src/services/connect/client/cache.rs
@@ -245,10 +245,12 @@ pub async fn filter_connect_cache(
 }
 
 /// Stamp the authoritative `user_id` and `email` reported by Liana-Connect onto
-/// the cache row for this user, locating it by `lookup_user_id` (preferred) or
-/// the previous `lookup_email` (legacy / pre-migration). No-op if no row
-/// matches, since the cache write that normally precedes this call inserts the
-/// row keyed by email.
+/// the cache row for this user. Locates the row by `lookup_user_id` (preferred)
+/// and falls back to `lookup_email` (covers legacy rows that lack `user_id`).
+/// Also consolidates duplicates: after an OTP re-auth with a changed email
+/// `update_connect_cache` may insert a fresh email-keyed row alongside the
+/// existing user_id row — we keep the freshest tokens on a single canonical
+/// row and drop the rest. No-op if no row matches.
 pub async fn stamp_account_identity(
     network_dir: &NetworkDirectory,
     lookup_user_id: Option<&str>,
@@ -289,20 +291,15 @@ pub async fn stamp_account_identity(
         }
     };
 
-    let row = cache.accounts.iter_mut().find(|a| match lookup_user_id {
-        Some(uid) => a.user_id.as_deref() == Some(uid),
-        None => a.email == lookup_email,
-    });
-
-    let Some(row) = row else {
-        return Ok(());
-    };
-
-    if row.user_id.as_deref() == Some(new_user_id) && row.email == new_email {
+    if !stamp_in_memory(
+        &mut cache,
+        lookup_user_id,
+        lookup_email,
+        new_user_id,
+        new_email,
+    ) {
         return Ok(());
     }
-    row.user_id = Some(new_user_id.to_string());
-    row.email = new_email.to_string();
 
     let content = serde_json::to_vec_pretty(&cache).map_err(|e| {
         ConnectCacheError::WritingFile(format!("Failed to serialize settings: {e}"))
@@ -323,6 +320,78 @@ pub async fn stamp_account_identity(
         .map_err(|e| ConnectCacheError::WritingFile(format!("Failed to truncate file: {e}")))?;
 
     Ok(())
+}
+
+/// In-memory stamp + dedup. Returns true if anything changed.
+fn stamp_in_memory(
+    cache: &mut ConnectCache,
+    lookup_user_id: Option<&str>,
+    lookup_email: &str,
+    new_user_id: &str,
+    new_email: &str,
+) -> bool {
+    // Locate the canonical row: prefer the stable user_id, fall back to the
+    // previous email so legacy (unstamped) rows can be promoted in place.
+    let canonical_pos = lookup_user_id
+        .and_then(|uid| {
+            cache
+                .accounts
+                .iter()
+                .position(|a| a.user_id.as_deref() == Some(uid))
+        })
+        .or_else(|| cache.accounts.iter().position(|a| a.email == lookup_email));
+
+    let Some(canonical_pos) = canonical_pos else {
+        return false;
+    };
+
+    // Among all rows that could plausibly be the same user (matching the new
+    // identity, the previous email, or — when given — the previous user_id),
+    // keep the freshest tokens.
+    let is_candidate = |a: &Account| {
+        a.user_id.as_deref() == Some(new_user_id)
+            || a.email == new_email
+            || a.email == lookup_email
+            || lookup_user_id.is_some_and(|uid| a.user_id.as_deref() == Some(uid))
+    };
+    let freshest_tokens = cache
+        .accounts
+        .iter()
+        .filter(|a| is_candidate(a))
+        .map(|a| a.tokens.clone())
+        .max_by_key(|t| t.expires_at)
+        .unwrap_or_else(|| cache.accounts[canonical_pos].tokens.clone());
+
+    let current = &cache.accounts[canonical_pos];
+    let needs_update = current.user_id.as_deref() != Some(new_user_id)
+        || current.email != new_email
+        || current.tokens.expires_at != freshest_tokens.expires_at
+        || cache.accounts.iter().enumerate().any(|(i, a)| {
+            i != canonical_pos
+                && (a.user_id.as_deref() == Some(new_user_id) || a.email == new_email)
+        });
+    if !needs_update {
+        return false;
+    }
+
+    cache.accounts[canonical_pos] = Account {
+        user_id: Some(new_user_id.to_string()),
+        email: new_email.to_string(),
+        tokens: freshest_tokens,
+    };
+
+    // Drop any other rows that now collide on user_id or email with the
+    // canonical row. Only dedupe by user_id or by the *new* email — never by
+    // the previous email alone, which could belong to an unrelated user.
+    let mut i = 0;
+    cache.accounts.retain(|a| {
+        let keep = i == canonical_pos
+            || (a.user_id.as_deref() != Some(new_user_id) && a.email != new_email);
+        i += 1;
+        keep
+    });
+
+    true
 }
 
 #[derive(Debug, Clone)]
@@ -385,5 +454,93 @@ mod tests {
         // user_id starts unset; backfill stamps it later via stamp_account_identity.
         assert!(cache.accounts[0].user_id.is_none());
         assert_eq!(cache.accounts[0].email, "a@x");
+    }
+
+    // Bug 1: settings already has user_id but the cache row is still legacy
+    // (user_id=None). The user_id lookup misses; we must fall back to the
+    // previous email so the legacy row gets stamped.
+    #[test]
+    fn stamp_promotes_legacy_row_when_user_id_lookup_misses() {
+        let mut cache = ConnectCache {
+            accounts: vec![Account {
+                user_id: None,
+                email: "old@x".to_string(),
+                tokens: tok(100),
+            }],
+        };
+
+        let changed = stamp_in_memory(&mut cache, Some("uid-1"), "old@x", "uid-1", "new@x");
+
+        assert!(changed);
+        assert_eq!(cache.accounts.len(), 1);
+        assert_eq!(cache.accounts[0].user_id.as_deref(), Some("uid-1"));
+        assert_eq!(cache.accounts[0].email, "new@x");
+    }
+
+    // Bug 2: forced OTP re-auth after server-side email change.
+    // `update_connect_cache` (called just before `stamp_account_identity`)
+    // inserted a fresh row keyed by the new email while the previously
+    // stamped row still carries the same user_id with stale tokens. After
+    // stamping there must be exactly ONE row, with the freshest tokens.
+    #[test]
+    fn stamp_dedupes_after_otp_with_changed_email() {
+        let mut cache = ConnectCache {
+            accounts: vec![
+                Account {
+                    user_id: Some("uid-1".to_string()),
+                    email: "old@x".to_string(),
+                    tokens: tok(100),
+                },
+                Account {
+                    // Just inserted by `update_connect_cache`.
+                    user_id: None,
+                    email: "new@x".to_string(),
+                    tokens: tok(500),
+                },
+            ],
+        };
+
+        let changed = stamp_in_memory(&mut cache, None, "new@x", "uid-1", "new@x");
+
+        assert!(changed);
+        assert_eq!(cache.accounts.len(), 1);
+        let row = &cache.accounts[0];
+        assert_eq!(row.user_id.as_deref(), Some("uid-1"));
+        assert_eq!(row.email, "new@x");
+        assert_eq!(row.tokens.expires_at, 500);
+    }
+
+    #[test]
+    fn stamp_idempotent_when_already_canonical() {
+        let mut cache = ConnectCache {
+            accounts: vec![Account {
+                user_id: Some("uid-1".to_string()),
+                email: "a@x".to_string(),
+                tokens: tok(500),
+            }],
+        };
+
+        let changed = stamp_in_memory(&mut cache, Some("uid-1"), "a@x", "uid-1", "a@x");
+
+        assert!(!changed);
+        assert_eq!(cache.accounts.len(), 1);
+    }
+
+    #[test]
+    fn stamp_noop_when_nothing_matches() {
+        let mut cache = ConnectCache {
+            accounts: vec![Account {
+                user_id: Some("other-uid".to_string()),
+                email: "other@x".to_string(),
+                tokens: tok(100),
+            }],
+        };
+
+        let changed = stamp_in_memory(&mut cache, Some("uid-1"), "old@x", "uid-1", "new@x");
+
+        assert!(!changed);
+        assert_eq!(cache.accounts.len(), 1);
+        // The unrelated row is untouched.
+        assert_eq!(cache.accounts[0].user_id.as_deref(), Some("other-uid"));
     }
 }

--- a/liana-gui/src/services/connect/client/cache.rs
+++ b/liana-gui/src/services/connect/client/cache.rs
@@ -17,16 +17,25 @@ pub struct ConnectCache {
 }
 
 impl ConnectCache {
-    /// Upsert tokens for the row matching `email`. Preserves the existing
-    /// `user_id` field — user_id stamping is handled separately by
-    /// `stamp_account_identity` (called from the login backfill path), so
-    /// this function does not need to know the user_id.
-    fn upsert_credential(&mut self, email: &str, tokens: AccessTokenResponse) {
+    /// Upsert tokens for the row matching `email`. When `user_id` is known
+    /// (the caller has just spoken to the backend), stamp it onto the row at
+    /// write time — both for fresh inserts and to promote legacy rows that
+    /// still lack a user_id. Refresh callers that don't know the user_id pass
+    /// `None`; in that case the existing user_id is preserved.
+    fn upsert_credential(
+        &mut self,
+        user_id: Option<&str>,
+        email: &str,
+        tokens: AccessTokenResponse,
+    ) {
         if let Some(c) = self.accounts.iter_mut().find(|c| c.email == email) {
             c.tokens = tokens;
+            if let Some(uid) = user_id {
+                c.user_id = Some(uid.to_string());
+            }
         } else {
             self.accounts.push(Account {
-                user_id: None,
+                user_id: user_id.map(|s| s.to_string()),
                 email: email.to_string(),
                 tokens,
             });
@@ -89,6 +98,7 @@ pub async fn update_connect_cache(
     current_tokens: &AccessTokenResponse,
     client: &AuthClient,
     refresh: bool,
+    user_id: Option<&str>,
 ) -> Result<AccessTokenResponse, ConnectCacheError> {
     let email = &client.email;
     let mut path = network_dir.path().to_path_buf();
@@ -149,7 +159,7 @@ pub async fn update_connect_cache(
         current_tokens.clone()
     };
 
-    cache.upsert_credential(email, tokens.clone());
+    cache.upsert_credential(user_id, email, tokens.clone());
 
     let content = serde_json::to_vec_pretty(&cache).map_err(|e| {
         ConnectCacheError::WritingFile(format!("Failed to serialize settings: {e}"))
@@ -427,7 +437,7 @@ mod tests {
     }
 
     #[test]
-    fn upsert_replaces_tokens_for_existing_email() {
+    fn upsert_preserves_existing_user_id_when_caller_passes_none() {
         let mut cache = ConnectCache {
             accounts: vec![Account {
                 user_id: Some("uid-1".to_string()),
@@ -436,22 +446,48 @@ mod tests {
             }],
         };
 
-        cache.upsert_credential("a@x", tok(200));
+        cache.upsert_credential(None, "a@x", tok(200));
 
         assert_eq!(cache.accounts.len(), 1);
-        // Existing user_id is preserved — upsert no longer touches it.
         assert_eq!(cache.accounts[0].user_id.as_deref(), Some("uid-1"));
         assert_eq!(cache.accounts[0].tokens.expires_at, 200);
     }
 
     #[test]
-    fn upsert_inserts_with_no_user_id_for_new_email() {
-        let mut cache = ConnectCache { accounts: vec![] };
+    fn upsert_stamps_user_id_on_legacy_row() {
+        let mut cache = ConnectCache {
+            accounts: vec![Account {
+                user_id: None,
+                email: "a@x".to_string(),
+                tokens: tok(100),
+            }],
+        };
 
-        cache.upsert_credential("a@x", tok(200));
+        cache.upsert_credential(Some("uid-1"), "a@x", tok(200));
 
         assert_eq!(cache.accounts.len(), 1);
-        // user_id starts unset; backfill stamps it later via stamp_account_identity.
+        assert_eq!(cache.accounts[0].user_id.as_deref(), Some("uid-1"));
+        assert_eq!(cache.accounts[0].tokens.expires_at, 200);
+    }
+
+    #[test]
+    fn upsert_inserts_with_user_id_when_provided() {
+        let mut cache = ConnectCache { accounts: vec![] };
+
+        cache.upsert_credential(Some("uid-1"), "a@x", tok(200));
+
+        assert_eq!(cache.accounts.len(), 1);
+        assert_eq!(cache.accounts[0].user_id.as_deref(), Some("uid-1"));
+        assert_eq!(cache.accounts[0].email, "a@x");
+    }
+
+    #[test]
+    fn upsert_inserts_with_no_user_id_when_caller_lacks_it() {
+        let mut cache = ConnectCache { accounts: vec![] };
+
+        cache.upsert_credential(None, "a@x", tok(200));
+
+        assert_eq!(cache.accounts.len(), 1);
         assert!(cache.accounts[0].user_id.is_none());
         assert_eq!(cache.accounts[0].email, "a@x");
     }

--- a/liana-gui/src/services/connect/client/cache.rs
+++ b/liana-gui/src/services/connect/client/cache.rs
@@ -17,14 +17,19 @@ pub struct ConnectCache {
 }
 
 impl ConnectCache {
+    /// Upsert tokens for the row matching `email`. Preserves the existing
+    /// `user_id` field — user_id stamping is handled separately by
+    /// `stamp_account_identity` (called from the login backfill path), so
+    /// this function does not need to know the user_id.
     fn upsert_credential(&mut self, email: &str, tokens: AccessTokenResponse) {
         if let Some(c) = self.accounts.iter_mut().find(|c| c.email == email) {
             c.tokens = tokens;
         } else {
             self.accounts.push(Account {
+                user_id: None,
                 email: email.to_string(),
                 tokens,
-            })
+            });
         }
     }
 
@@ -47,12 +52,30 @@ impl ConnectCache {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Account {
+    #[serde(default)]
+    pub user_id: Option<String>,
     pub email: String,
     pub tokens: AccessTokenResponse,
 }
 
 impl Account {
-    pub fn from_cache(
+    /// Primary lookup, by stable Liana-Connect user identifier.
+    pub fn from_cache_by_user_id(
+        network_dir: &NetworkDirectory,
+        user_id: &str,
+    ) -> Result<Option<Self>, ConnectCacheError> {
+        ConnectCache::from_file(network_dir).map(|cache| {
+            cache
+                .accounts
+                .into_iter()
+                .find(|c| c.user_id.as_deref() == Some(user_id))
+        })
+    }
+
+    /// Lookup by email — used by the account-picker UI and as a migration
+    /// fallback when `user_id` is not yet known locally. Safe because emails
+    /// are unique per Liana-Connect account (enforced by the backend).
+    pub fn from_cache_by_email(
         network_dir: &NetworkDirectory,
         email: &str,
     ) -> Result<Option<Self>, ConnectCacheError> {
@@ -151,7 +174,8 @@ pub async fn update_connect_cache(
 
 pub async fn filter_connect_cache(
     network_dir: &NetworkDirectory,
-    emails: &HashSet<String>,
+    user_ids: &HashSet<String>,
+    legacy_emails: &HashSet<String>,
 ) -> Result<(), ConnectCacheError> {
     let mut path = network_dir.path().to_path_buf();
     path.push(CONNECT_CACHE_FILENAME);
@@ -194,7 +218,91 @@ pub async fn filter_connect_cache(
         ConnectCache::default()
     };
 
-    cache.accounts.retain(|a| emails.contains(&a.email));
+    cache.accounts.retain(|a| match &a.user_id {
+        Some(uid) => user_ids.contains(uid),
+        None => legacy_emails.contains(&a.email),
+    });
+
+    let content = serde_json::to_vec_pretty(&cache).map_err(|e| {
+        ConnectCacheError::WritingFile(format!("Failed to serialize settings: {e}"))
+    })?;
+
+    file.seek(SeekFrom::Start(0)).await.map_err(|e| {
+        ConnectCacheError::WritingFile(format!("Failed to seek to start of file: {e}"))
+    })?;
+
+    file.write_all(&content).await.map_err(|e| {
+        tracing::warn!("failed to write to file: {:?}", e);
+        ConnectCacheError::WritingFile(e.to_string())
+    })?;
+
+    file.inner_mut()
+        .set_len(content.len() as u64)
+        .await
+        .map_err(|e| ConnectCacheError::WritingFile(format!("Failed to truncate file: {e}")))?;
+
+    Ok(())
+}
+
+/// Stamp the authoritative `user_id` and `email` reported by Liana-Connect onto
+/// the cache row for this user, locating it by `lookup_user_id` (preferred) or
+/// the previous `lookup_email` (legacy / pre-migration). No-op if no row
+/// matches, since the cache write that normally precedes this call inserts the
+/// row keyed by email.
+pub async fn stamp_account_identity(
+    network_dir: &NetworkDirectory,
+    lookup_user_id: Option<&str>,
+    lookup_email: &str,
+    new_user_id: &str,
+    new_email: &str,
+) -> Result<(), ConnectCacheError> {
+    let mut path = network_dir.path().to_path_buf();
+    path.push(CONNECT_CACHE_FILENAME);
+
+    let file_exists = tokio::fs::try_exists(&path).await.unwrap_or(false);
+    if !file_exists {
+        return Ok(());
+    }
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(false)
+        .truncate(false)
+        .open(&path)
+        .await
+        .map_err(|e| ConnectCacheError::ReadingFile(format!("Opening file: {e}")))?
+        .lock_write()
+        .await
+        .map_err(|e| ConnectCacheError::ReadingFile(format!("Locking file: {e:?}")))?;
+
+    let mut file_content = Vec::new();
+    file.read_to_end(&mut file_content)
+        .await
+        .map_err(|e| ConnectCacheError::ReadingFile(format!("Reading file content: {e}")))?;
+
+    let mut cache = match serde_json::from_slice::<ConnectCache>(&file_content) {
+        Ok(cache) => cache,
+        Err(e) => {
+            tracing::warn!("Cannot parse Liana-Connect cache file: {:?}", e);
+            return Ok(());
+        }
+    };
+
+    let row = cache.accounts.iter_mut().find(|a| match lookup_user_id {
+        Some(uid) => a.user_id.as_deref() == Some(uid),
+        None => a.email == lookup_email,
+    });
+
+    let Some(row) = row else {
+        return Ok(());
+    };
+
+    if row.user_id.as_deref() == Some(new_user_id) && row.email == new_email {
+        return Ok(());
+    }
+    row.user_id = Some(new_user_id.to_string());
+    row.email = new_email.to_string();
 
     let content = serde_json::to_vec_pretty(&cache).map_err(|e| {
         ConnectCacheError::WritingFile(format!("Failed to serialize settings: {e}"))
@@ -234,5 +342,48 @@ impl std::fmt::Display for ConnectCacheError {
             Self::Unexpected(e) => write!(f, "Unexpected error: {e}"),
             Self::Updating(e) => write!(f, "Error while updating cache file: {e}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tok(expires_at: i64) -> AccessTokenResponse {
+        AccessTokenResponse {
+            access_token: format!("access-{expires_at}"),
+            expires_at,
+            refresh_token: format!("refresh-{expires_at}"),
+        }
+    }
+
+    #[test]
+    fn upsert_replaces_tokens_for_existing_email() {
+        let mut cache = ConnectCache {
+            accounts: vec![Account {
+                user_id: Some("uid-1".to_string()),
+                email: "a@x".to_string(),
+                tokens: tok(100),
+            }],
+        };
+
+        cache.upsert_credential("a@x", tok(200));
+
+        assert_eq!(cache.accounts.len(), 1);
+        // Existing user_id is preserved — upsert no longer touches it.
+        assert_eq!(cache.accounts[0].user_id.as_deref(), Some("uid-1"));
+        assert_eq!(cache.accounts[0].tokens.expires_at, 200);
+    }
+
+    #[test]
+    fn upsert_inserts_with_no_user_id_for_new_email() {
+        let mut cache = ConnectCache { accounts: vec![] };
+
+        cache.upsert_credential("a@x", tok(200));
+
+        assert_eq!(cache.accounts.len(), 1);
+        // user_id starts unset; backfill stamps it later via stamp_account_identity.
+        assert!(cache.accounts[0].user_id.is_none());
+        assert_eq!(cache.accounts[0].email, "a@x");
     }
 }

--- a/liana-gui/src/services/connect/login.rs
+++ b/liana-gui/src/services/connect/login.rs
@@ -176,12 +176,12 @@ impl LianaLiteLogin {
                     let client = AuthClient::new(
                         service_config.auth_api_url,
                         service_config.auth_api_public_key,
-                        auth_cfg.email,
+                        auth_cfg.email.clone(),
                         backend_type.user_agent(),
                     );
                     connect_with_credentials(
                         client,
-                        auth_cfg.wallet_id,
+                        auth_cfg,
                         service_config.backend_api_url,
                         network,
                         &datadir.network_directory(network),
@@ -496,6 +496,35 @@ pub async fn connect(
         BackendClient::connect(auth.clone(), backend_api_url, access.clone(), network).await?;
 
     update_connect_cache(&network_dir, &access, &auth, false).await?;
+    // Stamp user_id onto the freshly-written cache row so that the next session
+    // can locate it via the stable user_id key rather than the mutable email.
+    if let Err(e) = cache::stamp_account_identity(
+        &network_dir,
+        None,
+        &auth.email,
+        client.user_id(),
+        client.user_email(),
+    )
+    .await
+    {
+        tracing::warn!("Failed to stamp user_id on Liana-Connect cache: {}", e);
+    }
+
+    // If the user OTP'd in for a known local wallet (post email-change or
+    // refresh-token revocation), update its settings.json entry too so the
+    // next launch's user_id-keyed lookup succeeds.
+    if !connect_wallet_id.is_empty() {
+        if let Err(e) = backfill_settings_for_wallet(
+            &network_dir,
+            &connect_wallet_id,
+            client.user_id(),
+            client.user_email(),
+        )
+        .await
+        {
+            tracing::warn!("Failed to update settings.json after OTP: {}", e);
+        }
+    }
 
     let wallets = client.list_wallets().await?;
     if wallets.is_empty() {
@@ -532,18 +561,34 @@ pub async fn connect(
 
 pub async fn connect_with_credentials(
     auth: AuthClient,
-    wallet_id: String,
+    auth_cfg: settings::AuthConfig,
     backend_api_url: String,
     network: Network,
     network_dir: &NetworkDirectory,
 ) -> Result<BackendState, Error> {
-    let mut tokens = cache::Account::from_cache(network_dir, &auth.email)
+    let cached = {
+        let by_uid = match &auth_cfg.user_id {
+            Some(uid) => cache::Account::from_cache_by_user_id(network_dir, uid),
+            None => Ok(None),
+        }
         .map_err(|e| match e {
             ConnectCacheError::NotFound => Error::CredentialsMissing,
             _ => e.into(),
-        })?
-        .ok_or(Error::CredentialsMissing)?
-        .tokens;
+        })?;
+        // Email lookup is the migration fallback: covers caches written before
+        // the user_id stamp landed, plus the picker-by-email flow.
+        match by_uid {
+            Some(a) => a,
+            None => cache::Account::from_cache_by_email(network_dir, &auth.email)
+                .map_err(|e| match e {
+                    ConnectCacheError::NotFound => Error::CredentialsMissing,
+                    _ => e.into(),
+                })?
+                .ok_or(Error::CredentialsMissing)?,
+        }
+    };
+
+    let mut tokens = cached.tokens;
 
     if tokens.expires_at < chrono::Utc::now().timestamp() {
         tokens = cache::update_connect_cache(network_dir, &tokens, &auth, true).await?;
@@ -551,11 +596,13 @@ pub async fn connect_with_credentials(
 
     let client = BackendClient::connect(auth, backend_api_url, tokens, network).await?;
 
+    backfill_local_link(network_dir, &client, &auth_cfg).await?;
+
     if let Some(wallet) = client
         .list_wallets()
         .await?
         .into_iter()
-        .find(|w| w.id == wallet_id)
+        .find(|w| w.id == auth_cfg.wallet_id)
     {
         let (wallet_client, wallet) = client.connect_wallet(wallet);
         let coins = coins_to_cache(Arc::new(wallet_client.clone())).await?;
@@ -569,4 +616,64 @@ pub async fn connect_with_credentials(
     } else {
         Ok(BackendState::NoWallet(client))
     }
+}
+
+/// After a successful `BackendClient::connect`, ensure both the connect cache
+/// and the per-wallet settings carry the latest `user_id` (JWT `sub`) and email
+/// reported by the backend. Lazily migrates legacy entries that lack `user_id`
+/// and refreshes a stale email if it has been changed on Liana-Connect.
+pub async fn backfill_local_link(
+    network_dir: &NetworkDirectory,
+    client: &BackendClient,
+    auth_cfg: &settings::AuthConfig,
+) -> Result<(), Error> {
+    let server_user_id = client.user_id();
+    let server_email = client.user_email();
+
+    cache::stamp_account_identity(
+        network_dir,
+        auth_cfg.user_id.as_deref(),
+        &auth_cfg.email,
+        server_user_id,
+        server_email,
+    )
+    .await?;
+
+    if auth_cfg.user_id.as_deref() != Some(server_user_id) || auth_cfg.email != server_email {
+        backfill_settings_for_wallet(
+            network_dir,
+            &auth_cfg.wallet_id,
+            server_user_id,
+            server_email,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+/// Patch the `remote_backend_auth` of the wallet identified by `wallet_id` in
+/// settings.json so its `user_id` and `email` match the backend's. Idempotent.
+pub async fn backfill_settings_for_wallet(
+    network_dir: &NetworkDirectory,
+    wallet_id: &str,
+    user_id: &str,
+    email: &str,
+) -> Result<(), Error> {
+    let wallet_id = wallet_id.to_string();
+    let user_id = user_id.to_string();
+    let email = email.to_string();
+    settings::update_settings_file(network_dir, move |mut s: settings::LianaSettings| {
+        for w in s.wallets.iter_mut() {
+            if let Some(a) = w.remote_backend_auth.as_mut() {
+                if a.wallet_id == wallet_id {
+                    a.user_id = Some(user_id.clone());
+                    a.email = email.clone();
+                }
+            }
+        }
+        s
+    })
+    .await
+    .map_err(Error::Settings)
 }

--- a/liana-gui/src/services/connect/login.rs
+++ b/liana-gui/src/services/connect/login.rs
@@ -495,9 +495,10 @@ pub async fn connect(
     let client =
         BackendClient::connect(auth.clone(), backend_api_url, access.clone(), network).await?;
 
-    update_connect_cache(&network_dir, &access, &auth, false).await?;
-    // Stamp user_id onto the freshly-written cache row so that the next session
-    // can locate it via the stable user_id key rather than the mutable email.
+    update_connect_cache(&network_dir, &access, &auth, false, Some(client.user_id())).await?;
+    // If the user just OTP'd in with a different email than a previously
+    // stamped row (server-side email change), `update_connect_cache` will have
+    // written a second row sharing the same user_id. Dedupe here.
     if let Err(e) = cache::stamp_account_identity(
         &network_dir,
         None,
@@ -591,7 +592,14 @@ pub async fn connect_with_credentials(
     let mut tokens = cached.tokens;
 
     if tokens.expires_at < chrono::Utc::now().timestamp() {
-        tokens = cache::update_connect_cache(network_dir, &tokens, &auth, true).await?;
+        tokens = cache::update_connect_cache(
+            network_dir,
+            &tokens,
+            &auth,
+            true,
+            auth_cfg.user_id.as_deref(),
+        )
+        .await?;
     }
 
     let client = BackendClient::connect(auth, backend_api_url, tokens, network).await?;

--- a/liana-gui/src/services/connect/login.rs
+++ b/liana-gui/src/services/connect/login.rs
@@ -511,22 +511,6 @@ pub async fn connect(
         tracing::warn!("Failed to stamp user_id on Liana-Connect cache: {}", e);
     }
 
-    // If the user OTP'd in for a known local wallet (post email-change or
-    // refresh-token revocation), update its settings.json entry too so the
-    // next launch's user_id-keyed lookup succeeds.
-    if !connect_wallet_id.is_empty() {
-        if let Err(e) = backfill_settings_for_wallet(
-            &network_dir,
-            &connect_wallet_id,
-            client.user_id(),
-            client.user_email(),
-        )
-        .await
-        {
-            tracing::warn!("Failed to update settings.json after OTP: {}", e);
-        }
-    }
-
     let wallets = client.list_wallets().await?;
     if wallets.is_empty() {
         return Ok(BackendState::NoWallet(client));
@@ -545,6 +529,19 @@ pub async fn connect(
             settings,
         ))
     } else if let Some(wallet) = wallets.into_iter().find(|w| w.id == connect_wallet_id) {
+        // Wallet is confirmed to belong to the OTP'd user, so it's safe to
+        // rewrite its settings entry with the authoritative user_id.
+        if let Err(e) = backfill_settings_for_wallet(
+            &network_dir,
+            &connect_wallet_id,
+            client.user_id(),
+            client.user_email(),
+        )
+        .await
+        {
+            tracing::warn!("Failed to update settings.json after OTP: {}", e);
+        }
+
         let (wallet_client, wallet) = client.connect_wallet(wallet);
         let coins = coins_to_cache(Arc::new(wallet_client.clone())).await?;
         let settings = wallet_client.get_wallet_settings().await?;
@@ -604,14 +601,17 @@ pub async fn connect_with_credentials(
 
     let client = BackendClient::connect(auth, backend_api_url, tokens, network).await?;
 
-    backfill_local_link(network_dir, &client, &auth_cfg).await?;
-
     if let Some(wallet) = client
         .list_wallets()
         .await?
         .into_iter()
         .find(|w| w.id == auth_cfg.wallet_id)
     {
+        // Only stamp settings/cache once we've confirmed the wallet belongs
+        // to the connected user. The cached-token by_email fallback above
+        // could otherwise have matched a row for a different `sub`.
+        backfill_local_link(network_dir, &client, &auth_cfg).await?;
+
         let (wallet_client, wallet) = client.connect_wallet(wallet);
         let coins = coins_to_cache(Arc::new(wallet_client.clone())).await?;
         let settings = wallet_client.get_wallet_settings().await?;
@@ -630,6 +630,12 @@ pub async fn connect_with_credentials(
 /// and the per-wallet settings carry the latest `user_id` (JWT `sub`) and email
 /// reported by the backend. Lazily migrates legacy entries that lack `user_id`
 /// and refreshes a stale email if it has been changed on Liana-Connect.
+///
+/// MUST be called only after the wallet has been verified to belong to the
+/// connected user (i.e. `list_wallets` returned a wallet whose id matches
+/// `auth_cfg.wallet_id`); otherwise a stale-by-email cache row could point us
+/// at a different `sub` and we would rewrite local state to that wrong
+/// identity.
 pub async fn backfill_local_link(
     network_dir: &NetworkDirectory,
     client: &BackendClient,

--- a/liana-gui/src/services/connect/login.rs
+++ b/liana-gui/src/services/connect/login.rs
@@ -564,27 +564,16 @@ pub async fn connect_with_credentials(
     network: Network,
     network_dir: &NetworkDirectory,
 ) -> Result<BackendState, Error> {
-    let cached = {
-        let by_uid = match &auth_cfg.user_id {
-            Some(uid) => cache::Account::from_cache_by_user_id(network_dir, uid),
-            None => Ok(None),
-        }
-        .map_err(|e| match e {
-            ConnectCacheError::NotFound => Error::CredentialsMissing,
-            _ => e.into(),
-        })?;
-        // Email lookup is the migration fallback: covers caches written before
-        // the user_id stamp landed, plus the picker-by-email flow.
-        match by_uid {
-            Some(a) => a,
-            None => cache::Account::from_cache_by_email(network_dir, &auth.email)
-                .map_err(|e| match e {
-                    ConnectCacheError::NotFound => Error::CredentialsMissing,
-                    _ => e.into(),
-                })?
-                .ok_or(Error::CredentialsMissing)?,
-        }
-    };
+    let cached = cache::Account::from_cache_by_uid_or_email(
+        network_dir,
+        auth_cfg.user_id.as_deref(),
+        &auth.email,
+    )
+    .map_err(|e| match e {
+        ConnectCacheError::NotFound => Error::CredentialsMissing,
+        _ => e.into(),
+    })?
+    .ok_or(Error::CredentialsMissing)?;
 
     let mut tokens = cached.tokens;
 


### PR DESCRIPTION
settings.json and connect.json were both keyed by email, so changing the email on Liana Connect broke the local link between a wallet and its cached tokens. Use the JWT `sub` claim as the stable key and treat email as a mutable display label.

- AuthConfig and Account gain an Option<String> user_id (serde default None so existing on-disk files still deserialize)
- stamp_account_identity + backfill_local_link run after every successful BackendClient::connect, lazily migrating legacy entries and picking up server-side email changes
- The OTP path (connect()) also patches settings.json so a forced re-auth after an email change does not leave settings stale
- filter_connect_cache takes a (user_ids, legacy_emails) pair so the delete flow preserves unmigrated cache rows