### PR TITLE
Use copy feedback buttons everywhere

### DIFF
--- a/liana-gui/src/app/view/coins.rs
+++ b/liana-gui/src/app/view/coins.rs
@@ -200,13 +200,9 @@ fn coin_list_view<'a>(
                                             Row::new()
                                                 .align_y(Alignment::Center)
                                                 .push(address_view(address.clone()))
-                                                .push(
-                                                    Button::new(icon::clipboard_icon())
-                                                        .on_press(Message::Clipboard(
-                                                            address.clone(),
-                                                        ))
-                                                        .style(theme::button::transparent_border),
-                                                ),
+                                                .push(button::btn_copy(Some(Message::Clipboard(
+                                                    address.clone(),
+                                                )))),
                                         )
                                         .spacing(5),
                                 )
@@ -240,13 +236,9 @@ fn coin_list_view<'a>(
                                                     p2_regular(format!("{}", coin.outpoint))
                                                         .style(theme::text::secondary),
                                                 )
-                                                .push(
-                                                    Button::new(icon::clipboard_icon())
-                                                        .on_press(Message::Clipboard(
-                                                            coin.outpoint.to_string(),
-                                                        ))
-                                                        .style(theme::button::transparent_border),
-                                                ),
+                                                .push(button::btn_copy(Some(Message::Clipboard(
+                                                    coin.outpoint.to_string(),
+                                                )))),
                                         )
                                         .spacing(5),
                                 )

--- a/liana-gui/src/app/view/home/payment_details.rs
+++ b/liana-gui/src/app/view/home/payment_details.rs
@@ -13,8 +13,8 @@ use liana_ui::{
         button, card, form,
         text::{legacy, Text},
     },
-    icon, theme,
-    widget::{Button, Column, ColumnExt, Element, SpaceExt},
+    theme,
+    widget::{Column, ColumnExt, Element, SpaceExt},
 };
 
 use crate::{
@@ -145,13 +145,9 @@ pub fn payment_details_view<'a>(
                                     .push(Container::new(
                                         legacy::text(format!("{}", tx.tx.compute_txid())).small(),
                                     ))
-                                    .push(
-                                        Button::new(icon::clipboard_icon())
-                                            .on_press(Message::Clipboard(
-                                                tx.tx.compute_txid().to_string(),
-                                            ))
-                                            .style(theme::button::transparent_border),
-                                    )
+                                    .push(button::btn_copy(Some(Message::Clipboard(
+                                        tx.tx.compute_txid().to_string(),
+                                    ))))
                                     .width(Length::Shrink),
                             ),
                     )

--- a/liana-gui/src/app/view/psbt.rs
+++ b/liana-gui/src/app/view/psbt.rs
@@ -221,14 +221,9 @@ pub fn broadcast_action<'a>(
                                         .spacing(5)
                                         .align_y(Alignment::Center)
                                         .push(text(txid.to_string()))
-                                        .push(
-                                            Button::new(
-                                                icon::clipboard_icon()
-                                                    .style(theme::text::secondary),
-                                            )
-                                            .on_press(Message::Clipboard(txid.to_string()))
-                                            .style(theme::button::transparent_border),
-                                        ),
+                                        .push(button::btn_copy(Some(Message::Clipboard(
+                                            txid.to_string(),
+                                        )))),
                                 )
                             },
                         ),
@@ -399,13 +394,9 @@ pub fn spend_overview_view<'a>(
                                             .style(theme::text::secondary),
                                     )
                                     .push(
-                                        Button::new(
-                                            icon::clipboard_icon().style(theme::text::secondary),
-                                        )
-                                        .on_press(Message::Clipboard(
+                                        button::btn_copy(Some(Message::Clipboard(
                                             tx.psbt.unsigned_tx.compute_txid().to_string(),
-                                        ))
-                                        .style(theme::button::transparent_border),
+                                        ))),
                                     )
                                     .align_y(Alignment::Center),
                             ),
@@ -784,11 +775,7 @@ fn input_view<'a>(
                         .spacing(5)
                         .push(p1_bold("Outpoint:").style(theme::text::secondary))
                         .push(p2_regular(outpoint.clone()).style(theme::text::secondary))
-                        .push(
-                            Button::new(icon::clipboard_icon().style(theme::text::secondary))
-                                .on_press(Message::Clipboard(outpoint.clone()))
-                                .style(theme::button::transparent_border),
-                        ),
+                        .push(button::btn_copy(Some(Message::Clipboard(outpoint.clone())))),
                 )
                 .push_maybe(coin.map(|c| {
                     let addr = c.address.to_string();
@@ -802,13 +789,7 @@ fn input_view<'a>(
                                 .spacing(5)
                                 .push(p1_bold("Address:").style(theme::text::secondary))
                                 .push(address_view(addr.clone()))
-                                .push(
-                                    Button::new(
-                                        icon::clipboard_icon().style(theme::text::secondary),
-                                    )
-                                    .on_press(Message::Clipboard(addr))
-                                    .style(theme::button::transparent_border),
-                                ),
+                                .push(button::btn_copy(Some(Message::Clipboard(addr)))),
                         )
                 }))
                 .push_maybe(coin.and_then(|c| {
@@ -891,13 +872,7 @@ fn payment_view<'a>(
                                 .spacing(5)
                                 .push(p1_bold("Address:").style(theme::text::secondary))
                                 .push(address_view(addr.clone()))
-                                .push(
-                                    Button::new(
-                                        icon::clipboard_icon().style(theme::text::secondary),
-                                    )
-                                    .on_press(Message::Clipboard(addr.clone()))
-                                    .style(theme::button::transparent_border),
-                                ),
+                                .push(button::btn_copy(Some(Message::Clipboard(addr.clone())))),
                         ),
                 )
                 .push_maybe(labels.get(&addr).map(|label| {
@@ -940,11 +915,7 @@ fn change_view(output: &TxOut, network: Network) -> Element<'_, Message> {
                         .spacing(5)
                         .push(p1_bold("Address:").style(theme::text::secondary))
                         .push(address_view(addr.clone()))
-                        .push(
-                            Button::new(icon::clipboard_icon().style(theme::text::secondary))
-                                .on_press(Message::Clipboard(addr))
-                                .style(theme::button::transparent_border),
-                        ),
+                        .push(button::btn_copy(Some(Message::Clipboard(addr)))),
                 ),
         )
         .into()
@@ -1075,10 +1046,7 @@ pub fn update_spend_view<'a>(
                 .push(
                     Row::new()
                         .push(text("PSBT:").bold().width(Length::Fill))
-                        .push(
-                            button::secondary(Some(icon::clipboard_icon()), "Copy")
-                                .on_press(Message::Clipboard(psbt)),
-                        )
+                        .push(button::btn_copy(Some(Message::Clipboard(psbt))))
                         .align_y(Alignment::Center),
                 )
                 .push(separation().width(Length::Fill))

--- a/liana-gui/src/app/view/psbt.rs
+++ b/liana-gui/src/app/view/psbt.rs
@@ -22,7 +22,7 @@ use liana_ui::{
         collapse::Collapse,
         form,
         modal::{legacy, modal_view, ModalWidth},
-        pill, scrollable, separation,
+        pill, scrollable,
         text::{self, *},
     },
     icon, theme,
@@ -1030,52 +1030,6 @@ pub fn sign_action_toasts<'a>(
     }
 
     vec
-}
-
-pub fn update_spend_view<'a>(
-    psbt: String,
-    updated: &form::Value<String>,
-    error: Option<&Error>,
-    processing: bool,
-) -> Element<'a, Message> {
-    Column::new()
-        .push(warn(error))
-        .push(card::simple(
-            Column::new()
-                .spacing(20)
-                .push(
-                    Row::new()
-                        .push(text("PSBT:").bold().width(Length::Fill))
-                        .push(button::btn_copy(Some(Message::Clipboard(psbt))))
-                        .align_y(Alignment::Center),
-                )
-                .push(separation().width(Length::Fill))
-                .push(
-                    Column::new()
-                        .spacing(10)
-                        .push(text("Insert updated PSBT:").bold())
-                        .push(
-                            form::Form::new_trimmed("PSBT", updated, move |msg| {
-                                Message::ImportSpend(ImportSpendMessage::PsbtEdited(msg))
-                            })
-                            .warning("Please enter the correct base64 encoded PSBT")
-                            .size(P1_SIZE)
-                            .padding(10),
-                        )
-                        .push(Row::new().push(Space::with_width(Length::Fill)).push(
-                            if updated.valid && !updated.value.is_empty() && !processing {
-                                button::secondary(None, "Update")
-                                    .on_press(Message::ImportSpend(ImportSpendMessage::Confirm))
-                            } else if processing {
-                                button::secondary(None, "Processing...")
-                            } else {
-                                button::secondary(None, "Update")
-                            },
-                        )),
-                ),
-        ))
-        .max_width(400)
-        .into()
 }
 
 pub fn update_spend_success_view<'a>() -> Element<'a, Message> {

--- a/liana-gui/src/app/view/settings/mod.rs
+++ b/liana-gui/src/app/view/settings/mod.rs
@@ -529,11 +529,9 @@ pub fn bitcoind<'a>(
                     .width(Length::FillPortion(3)),
                 )
                 .push(Space::with_width(10))
-                .push(
-                    Button::new(icon::clipboard_icon())
-                        .style(theme::button::transparent_border)
-                        .on_press(SettingsEditMessage::Clipboard(v.to_string())),
-                )
+                .push(button::btn_copy(Some(SettingsEditMessage::Clipboard(
+                    v.to_string(),
+                ))))
                 .align_y(Alignment::Center)
         });
     }
@@ -719,11 +717,9 @@ pub fn electrum<'a>(
                 .push(Container::new(text(k).bold().small()).width(Length::Fill))
                 .push(text(v.clone()).small())
                 .push(Space::with_width(10))
-                .push(
-                    Button::new(icon::clipboard_icon())
-                        .style(theme::button::transparent_border)
-                        .on_press(SettingsEditMessage::Clipboard(v.to_string())),
-                )
+                .push(button::btn_copy(Some(SettingsEditMessage::Clipboard(
+                    v.to_string(),
+                ))))
                 .align_y(Alignment::Center),
         );
     }
@@ -952,8 +948,7 @@ pub fn wallet_settings<'a>(
         BtnWidth::Auto,
         Some(backup_msg),
     );
-    let btn_copy = button::secondary(Some(icon::clipboard_icon()), "Copy")
-        .on_press(Message::Clipboard(descriptor.to_string()));
+    let btn_copy = button::btn_copy(Some(Message::Clipboard(descriptor.to_string())));
     let btn_register = button::secondary(Some(icon::chip_icon()), "Register on hardware device")
         .on_press(Message::Settings(SettingsMessage::RegisterWallet));
 

--- a/liana-gui/src/app/view/settings/mod.rs
+++ b/liana-gui/src/app/view/settings/mod.rs
@@ -939,7 +939,8 @@ pub fn wallet_settings<'a>(
     // ------------------------- Descriptor card -------------------------
     let title = text("Wallet descriptor:").bold();
     let descriptor_s =
-        scrollable::horizontal_thin(Column::new().push(text(descriptor.to_string()).small()));
+        scrollable::horizontal_thin(Column::new().push(text(descriptor.to_string()).small()))
+            .width(Length::Fill);
 
     let btn_backup = btn_secondary_with_tooltip(
         Some(icon::backup_icon()),
@@ -952,11 +953,15 @@ pub fn wallet_settings<'a>(
     let btn_register = button::secondary(Some(icon::chip_icon()), "Register on hardware device")
         .on_press(Message::Settings(SettingsMessage::RegisterWallet));
 
-    let btn_row = row![Space::fill_width(), btn_backup, btn_copy, btn_register]
+    let descriptor_row = row![descriptor_s, btn_copy]
+        .spacing(10)
+        .align_y(Alignment::Center)
+        .width(Length::Fill);
+    let btn_row = row![Space::fill_width(), btn_backup, btn_register]
         .spacing(10)
         .width(Length::Fill);
     let descriptor_card = card::simple(
-        column![title, descriptor_s, btn_row]
+        column![title, descriptor_row, btn_row]
             .spacing(10)
             .width(Length::Fill),
     )

--- a/liana-gui/src/app/view/transactions.rs
+++ b/liana-gui/src/app/view/transactions.rs
@@ -239,13 +239,9 @@ pub fn create_rbf_modal<'a>(
                                     .spacing(5)
                                     .align_y(Alignment::Center)
                                     .push(text(txid.to_string()))
-                                    .push(
-                                        Button::new(
-                                            icon::clipboard_icon().style(theme::text::secondary),
-                                        )
-                                        .on_press(Message::Clipboard(txid.to_string()))
-                                        .style(theme::button::transparent_border),
-                                    ),
+                                    .push(button::btn_copy(Some(Message::Clipboard(
+                                        txid.to_string(),
+                                    )))),
                             )
                         },
                     ),
@@ -411,9 +407,7 @@ pub fn tx_view<'a>(
                                     .align_y(Alignment::Center)
                                     .push(Container::new(text(txid.clone()).small()))
                                     .push(
-                                        Button::new(icon::clipboard_icon())
-                                            .on_press(Message::Clipboard(txid.clone()))
-                                            .style(theme::button::transparent_border),
+                                        button::btn_copy(Some(Message::Clipboard(txid.clone()))),
                                     )
                                     .width(Length::Shrink),
                             ),

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -732,10 +732,9 @@ pub fn backup_descriptor<'a>(
                                 .push(Space::with_width(Length::Fill))
                                 .push(backup_button)
                                 .push(Space::with_width(10))
-                                .push(
-                                    button::secondary(Some(icon::clipboard_icon()), "Copy")
-                                        .on_press(Message::Clipboard(descriptor.to_string())),
-                                ),
+                                .push(button::btn_copy(Some(Message::Clipboard(
+                                    descriptor.to_string(),
+                                )))),
                         )
                         .spacing(10),
                 )

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -724,17 +724,24 @@ pub fn backup_descriptor<'a>(
                 card::simple(
                     Column::new()
                         .push(text("The descriptor:").small().bold())
-                        .push(scrollable::horizontal_thin(
-                            Column::new().push(text(descriptor.to_string()).small()),
-                        ))
                         .push(
                             Row::new()
-                                .push(Space::with_width(Length::Fill))
-                                .push(backup_button)
-                                .push(Space::with_width(10))
+                                .align_y(Alignment::Center)
+                                .spacing(10)
+                                .push(
+                                    scrollable::horizontal_thin(
+                                        Column::new().push(text(descriptor.to_string()).small()),
+                                    )
+                                    .width(Length::Fill),
+                                )
                                 .push(button::btn_copy(Some(Message::Clipboard(
                                     descriptor.to_string(),
                                 )))),
+                        )
+                        .push(
+                            Row::new()
+                                .push(Space::with_width(Length::Fill))
+                                .push(backup_button),
                         )
                         .spacing(10),
                 )


### PR DESCRIPTION
Replace the remaining inline copy buttons with `btn_copy()` so they use the same temporary checkmark feedback added in #2180.

This covers the wallet views, PSBT views, transaction views, coin details, settings rows, and the installer descriptor copy button.