### PR TITLE
gui: leave new business path timelock empty

### DIFF
--- a/liana-business/business-installer/src/state/update.rs
+++ b/liana-business/business-installer/src/state/update.rs
@@ -659,7 +659,7 @@ impl State {
             path_index: None, // None indicates a new path
             selected_key_ids: Vec::new(),
             threshold: String::new(),
-            timelock_value: Some("1".to_string()),
+            timelock_value: Some(String::new()),
             timelock_unit: TimelockUnit::Days,
         });
     }


### PR DESCRIPTION
The business installer create-path modal now opens the recovery path timelock input empty instead of pre-filling 1 day. The empty field stays invalid, so the save button remains disabled until a timelock is entered.

Fixes #2140