### PR TITLE
ci: isolate Python test dependencies

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,7 +55,10 @@ jobs:
 
       - name: Setup Python dependencies
         run: |
-          pip install --break-system-packages -r tests/requirements.txt
+          rm -rf .venv
+          python3 -m venv .venv
+          .venv/bin/pip install -r tests/requirements.txt
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Add local bin to PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -135,4 +138,4 @@ jobs:
           rm -rf ~/.cargo/registry/index
 
           # Run the functional tests
-          LIANAD_PATH=$PWD/target/release/lianad pytest tests/ -vvv -n 8
+          LIANAD_PATH=$PWD/target/release/lianad .venv/bin/pytest tests/ -vvv -n 8


### PR DESCRIPTION
integrations test were failing because weirds dependencies issues, this is solved by running it in venv & re-creating a new venv for each CI task.
The machine run a single runner & pip cache packages so it's near no-cost.