### PR TITLE
Installer v15

### DIFF
--- a/UI_GUIDELINES.md
+++ b/UI_GUIDELINES.md
@@ -68,13 +68,15 @@ Use these; do not build equivalents.
 - **tab**: `tab_header(items, active, on_select)`; `Dot`.
 - **widget traits** (`widget/mod.rs`): `RowExt` / `ColumnExt::push_maybe` (dynamic building only), `SpaceExt`.
 
-## Per-app layout
+## Installer Layout
 
-Each app owns its page scaffolding on top of the components above. Read the real helpers, do not restate them:
+Installer page scaffolding is shared by `liana-ui::component::installer`. Each installer keeps a thin local
+wrapper that enforces its own width policy and navigation message behavior:
 
-- **liana-gui**: sidebar, dashboard, and menu scaffolding in `liana-gui/src/app/view/mod.rs`.
-- **liana-business**: `layout()`, `layout_with_scrollable_list()`, `menu_entry()`, and the breadcrumb +
-  step-dot header in `liana-business/business-installer/src/views/mod.rs`.
+- **liana-gui installer**: `layout()` in `liana-gui/src/installer/view/mod.rs`, with an 800px content width.
+- **liana-business installer**: `layout()` and `layout_with_scrollable_list()` in
+  `liana-business/business-installer/src/views/mod.rs`, with the standard list-entry width.
+- **liana-gui app**: sidebar, dashboard, and menu scaffolding in `liana-gui/src/app/view/mod.rs`.
 
 ## liana-business specifics
 

--- a/UI_GUIDELINES.md
+++ b/UI_GUIDELINES.md
@@ -54,10 +54,11 @@ Use these; do not build equivalents.
   `fingerprint`, `coin_sequence`, feature-specific helpers. `pill`, `pill_with_icon`, `compact_pill`,
   `compact_metric`, and direct `PillWidth` + `theme::pill::*` composition are liana-ui internals. If a
   consumer needs a new pill, add a named helper in `component::pill` first, then use that helper.
-- **list**: `list_entry_row(tile, body, trailing, accent, width, msg)` and the `entry_*` constructors
-  (`entry_wallet/key/path/set_key/organization/register/device_list/action`, `account_entry`,
-  `entry_paste_xpub`); helpers `entry_chevron`, `breadcrumb_chevron`, `key_count`, `see_more`. Status enums
-  `Entry*`, `DeviceStatus`.
+- **list**: `list_entry_row(tile, body, trailing, accent, width, msg)`, `list_entry_row_static`,
+  `list_entry_chevron`, and the `entry_*` constructors
+  (`entry_wallet/key/path/set_key/organization/register/device_list/action/collapsible/action_accent/no_devices`,
+  `account_entry`, `account_select_entry`, `entry_paste_xpub`); helpers `right_chevron`,
+  `breadcrumb_chevron`, `key_count`, `see_more`. Status enums `Entry*`, `DeviceStatus`.
 - **modal**: `modal_view(title, back, close, width, content)` (and `modal_view_with_theme`); width
   `ModalWidth`.
 - **badge**: icon badges, `tile(Tile::..)`, `avatar(initials)`, `coin()`.

--- a/liana-business/business-installer/src/state/mod.rs
+++ b/liana-business/business-installer/src/state/mod.rs
@@ -171,7 +171,7 @@ impl State {
             View::Xpub => xpub_view(self),
             View::Keys => keys_view(self),
             View::Registration => registration_view(self),
-            View::Loading => loading_view(has_error),
+            View::Loading => loading_view(self.network, has_error),
         };
 
         // Wrap content with connection error banner if present

--- a/liana-business/business-installer/src/views/keys/mod.rs
+++ b/liana-business/business-installer/src/views/keys/mod.rs
@@ -120,7 +120,7 @@ fn keys_list(state: &State, editable: bool) -> Element<'static, Msg> {
         .map(|(key_id, key)| {
             let signer = key_signer(key);
             let trailing: Element<'static, Msg> = if editable {
-                icon::pencil_icon()
+                icon::edit_icon()
                     .size(16)
                     .style(theme::text::tertiary)
                     .into()

--- a/liana-business/business-installer/src/views/keys/mod.rs
+++ b/liana-business/business-installer/src/views/keys/mod.rs
@@ -251,6 +251,7 @@ pub fn keys_view(state: &State) -> Element<'_, Msg> {
 
     layout_with_scrollable_list(
         (5, INSTALLER_STEPS),
+        state.network,
         Some(current_user_email),
         is_ws_admin,
         &breadcrumb,

--- a/liana-business/business-installer/src/views/keys/modal.rs
+++ b/liana-business/business-installer/src/views/keys/modal.rs
@@ -298,7 +298,7 @@ fn footer<'a>(can_save: bool) -> Element<'a, Message> {
     row![
         Space::fill_width(),
         btn_cancel(Some(Message::KeyCancelModal)),
-        btn_save(can_save.then_some(Message::KeySave)),
+        btn_save(can_save.then_some(Message::KeySave), true),
     ]
     .spacing(HSpacing::ML)
     .align_y(Vertical::Center)

--- a/liana-business/business-installer/src/views/loading.rs
+++ b/liana-business/business-installer/src/views/loading.rs
@@ -4,12 +4,13 @@ use iced::{
     Alignment, Length,
 };
 use liana_ui::{component::text, theme, widget::*};
+use miniscript::bitcoin::Network;
 
 use super::layout;
 
 /// Loading view shown during wallet opening transition.
 /// When `has_error` is true, shows error msg with enabled Previous button.
-pub fn loading_view(has_error: bool) -> Element<'static, Msg> {
+pub fn loading_view(network: Network, has_error: bool) -> Element<'static, Msg> {
     let (status_text, status_detail, previous_msg): (&str, Option<[&str; 2]>, Option<Msg>) =
         if has_error {
             (
@@ -39,5 +40,5 @@ pub fn loading_view(has_error: bool) -> Element<'static, Msg> {
         .width(Length::Fill),
     );
 
-    layout((0, 0), None, &[], content, previous_msg)
+    layout((0, 0), network, None, &[], content, previous_msg)
 }

--- a/liana-business/business-installer/src/views/login/account_select.rs
+++ b/liana-business/business-installer/src/views/login/account_select.rs
@@ -43,6 +43,7 @@ pub fn account_select_view(state: &State) -> Element<'_, Msg> {
 
     layout_with_scrollable_list(
         (1, INSTALLER_STEPS),
+        state.network,
         None,
         false,
         &["Login".to_string()],

--- a/liana-business/business-installer/src/views/login/code.rs
+++ b/liana-business/business-installer/src/views/login/code.rs
@@ -62,6 +62,7 @@ pub fn login_code_view(state: &State) -> Element<'_, Msg> {
 
     layout(
         (2, INSTALLER_STEPS),
+        state.network,
         None,
         &["Login".to_string()],
         content,

--- a/liana-business/business-installer/src/views/login/email.rs
+++ b/liana-business/business-installer/src/views/login/email.rs
@@ -53,6 +53,7 @@ pub fn login_email_view(state: &State) -> Element<'_, Msg> {
         (!state.views.login.account_select.accounts.is_empty()).then_some(Msg::NavigateBack);
     layout(
         (1, INSTALLER_STEPS),
+        state.network,
         None,
         &["Login".to_string()],
         content,

--- a/liana-business/business-installer/src/views/mod.rs
+++ b/liana-business/business-installer/src/views/mod.rs
@@ -11,9 +11,10 @@ pub mod xpub;
 
 pub use keys::keys_view;
 use liana_connect::ws_business::{self, UserRole};
-use liana_ui::component::{button::btn_breadcrumb_previous, pill, text::capitalize_first};
+use liana_ui::component::{installer as installer_layout, text::capitalize_first};
 pub use loading::loading_view;
 pub use login::login_view;
+use miniscript::bitcoin::Network;
 pub use org_select::org_select_view;
 pub use paths::template_builder_view;
 pub use registration::registration_view;
@@ -25,20 +26,19 @@ use crate::{
     state::{message::Msg, State},
 };
 use iced::{
-    widget::{column, container, row, rule, Space},
+    widget::{column, container, row, Space},
     Alignment, Length,
 };
 use liana_ui::{
-    color,
     component::{
         button::{self, EntryWidth},
-        form, list, scrollable,
+        form, list,
         text::{self, short_email, truncate},
     },
-    icon,
-    spacing::{HSpacing, VSpacing},
+    spacing::VSpacing,
     theme,
     widget::*,
+    Variant,
 };
 use std::fmt::Display;
 use uuid::Uuid;
@@ -46,9 +46,6 @@ use uuid::Uuid;
 pub const INSTALLER_STEPS: usize = 7;
 pub const MENU_ENTRY_HEIGHT: u32 = 100;
 const CONTENT_WIDTH: f32 = button::STANDARD_ENTRY_WIDTH;
-const USERBAR_HEIGHT: u32 = 44;
-const MAX_SCROLL_HEIGHT: u32 = 500;
-const HEADER_HEIGHT: u32 = 88;
 
 fn format_last_edit_info_string_helper(
     last_edited: Option<u64>,
@@ -106,191 +103,38 @@ fn admin_name_from_email(mail: &str) -> Option<String> {
     Some(format!("({})", capitalize_first(n)))
 }
 
-const CONTENT_TOP_SPACING: u32 = 72;
 const SCREEN_INTRO_SUB_WIDTH: u32 = 620;
-
-fn breadcrumb_header<'a>(segments: &[String]) -> Element<'a, Msg> {
-    let mut row = row![].spacing(HSpacing::M).align_y(Alignment::Center);
-
-    for (i, segment) in segments.iter().enumerate() {
-        if i > 0 {
-            row = row.push(list::breadcrumb_chevron());
-        }
-        row = row.push(if i + 1 == segments.len() {
-            text::new::h3_semi(segment).style(theme::text::primary)
-        } else {
-            text::new::h3(segment).style(theme::text::muted)
-        });
-    }
-
-    row.wrap().into()
-}
-
-enum LayoutContent<'a> {
-    Scrollable(Element<'a, Msg>),
-    ScrollableList {
-        header: Option<Element<'a, Msg>>,
-        list: Element<'a, Msg>,
-        pinned: Option<Element<'a, Msg>>,
-        footer: Option<Element<'a, Msg>>,
-    },
-}
-
-fn thin_separator<'a>() -> Container<'a, Msg> {
-    Container::new(rule::horizontal(1).style(theme::rule::separator))
-}
-
-fn user_bar<'a>(is_ws_admin: bool, email: Option<&'a str>) -> Element<'a, Msg> {
-    let ws_admin_pill = is_ws_admin.then_some(pill::ws_admin());
-    let user = email.map(|e| {
-        row![
-            icon::person_icon().size(16).style(theme::text::tertiary),
-            text::new::caption(e).style(theme::text::accent)
-        ]
-        .spacing(HSpacing::ML)
-    });
-    let user_bar = row![Space::fill_width(), ws_admin_pill, user]
-        .spacing(HSpacing::ML)
-        .align_y(Alignment::Center);
-
-    Container::new(user_bar)
-        .height(USERBAR_HEIGHT)
-        .padding([0, 28])
-        .align_y(Alignment::Center)
-        .style(theme::container::top_bar)
-        .into()
-}
-
-fn step_dots<'a>((step, total): (usize, usize)) -> Element<'a, Msg> {
-    let mut dots = row![].spacing(HSpacing::XS).align_y(Alignment::Center);
-    for i in 0..total {
-        let filled = i < step;
-        let width = if i + 1 == step { 20.0 } else { 8.0 };
-        dots = dots.push(
-            Container::new(Space::new())
-                .width(width)
-                .height(8)
-                .style(if filled {
-                    theme::container::step_dot_filled
-                } else {
-                    theme::container::step_dot_track
-                }),
-        );
-    }
-    dots.push(Space::with_width(HSpacing::XS))
-        .push(
-            text::new::small_caption(format!("{step}/{total}"))
-                .style(move |_: &theme::Theme| theme::text::custom(color::BUSINESS_STEP_LABEL)),
-        )
-        .into()
-}
-
-fn header<'a>(
-    breadcrumb: &[String],
-    msg: Option<Msg>,
-    has_left_button: bool,
-    progress: (usize, usize),
-) -> Element<'a, Msg> {
-    let left_button = btn_breadcrumb_previous(msg);
-
-    let progress = if progress.1 > 0 {
-        step_dots(progress)
-    } else {
-        row![].into()
-    };
-    let left_width = 200;
-    let left = if has_left_button {
-        Container::new(left_button).center_x(left_width)
-    } else {
-        Container::new(Space::with_width(left_width))
-    };
-
-    row![
-        left,
-        Container::new(breadcrumb_header(breadcrumb)).width(Length::FillPortion(8)),
-        Container::new(progress).center_x(Length::FillPortion(2)),
-    ]
-    .align_y(Alignment::Center)
-    .height(HEADER_HEIGHT)
-    .into()
-}
 
 fn layout_inner<'a>(
     progress: (usize, usize),
+    network: Network,
     email: Option<&'a str>,
     is_ws_admin: bool,
     breadcrumb: &[String],
-    content: LayoutContent<'a>,
+    content: installer_layout::LayoutContent<'a, Msg>,
     previous_message: Option<Msg>,
 ) -> Element<'a, Msg> {
-    let user_bar = user_bar(is_ws_admin, email);
-
-    let has_left_button = previous_message.is_some() || email.is_some();
-
-    let msg = if let Some(msg) = previous_message {
-        Some(msg)
-    } else if email.is_some() {
-        Some(Msg::Disconnect)
-    } else {
-        None
-    };
-    let header = header(breadcrumb, msg, has_left_button, progress);
-
-    let top = column![user_bar, thin_separator(), header];
-
-    let content = match content {
-        LayoutContent::Scrollable(inner) => {
-            let content_body = Container::new(column![
-                Space::with_height(CONTENT_TOP_SPACING as f32),
-                inner,
-            ])
-            .width(CONTENT_WIDTH);
-
-            column![
-                top,
-                scrollable::vertical(content_body)
-                    .height(Length::Fill)
-                    .width(Length::Shrink),
-            ]
-        }
-        LayoutContent::ScrollableList {
-            header,
-            list,
-            pinned,
-            footer,
-        } => {
-            let header = Container::new(header).center_x(Length::Fill);
-            let list_body =
-                Container::new(scrollable::vertical(list)).max_height(MAX_SCROLL_HEIGHT);
-            let footer = footer.map(|f| {
-                column![
-                    thin_separator(),
-                    Space::with_height(VSpacing::S),
-                    f,
-                    Space::with_height(VSpacing::S),
-                ]
-            });
-
-            let body = column![header, list_body, pinned, Space::fill_height(), footer,]
-                .spacing(VSpacing::M)
-                .width(CONTENT_WIDTH);
-
-            column![top, body].width(Length::Fill)
-        }
-    }
-    .align_x(Alignment::Center)
-    .width(Length::Fill)
-    .height(Length::Fill);
-
-    Container::new(content)
-        .center_x(Length::Fill)
-        .height(Length::Fill)
-        .style(theme::container::background)
-        .into()
+    let previous_message = previous_message.or_else(|| email.map(|_| Msg::Disconnect));
+    installer_layout::layout_inner(
+        installer_layout::LayoutConfig {
+            variant: Variant::LianaBusiness,
+            network,
+            email,
+            is_ws_admin,
+            nav_bar: installer_layout::NavBar::Steps {
+                progress,
+                breadcrumb: breadcrumb.to_vec(),
+                previous_message,
+            },
+            content_width: CONTENT_WIDTH,
+        },
+        content,
+    )
 }
 
 pub fn layout<'a>(
     progress: (usize, usize),
+    network: Network,
     email: Option<&'a str>,
     breadcrumb: &[String],
     content: impl Into<Element<'a, Msg>>,
@@ -298,10 +142,11 @@ pub fn layout<'a>(
 ) -> Element<'a, Msg> {
     layout_inner(
         progress,
+        network,
         email,
         false,
         breadcrumb,
-        LayoutContent::Scrollable(content.into()),
+        installer_layout::LayoutContent::Scrollable(content.into()),
         previous_message,
     )
 }
@@ -312,6 +157,7 @@ pub fn layout<'a>(
 #[allow(clippy::too_many_arguments)]
 pub fn layout_with_scrollable_list<'a>(
     progress: (usize, usize),
+    network: Network,
     email: Option<&'a str>,
     is_ws_admin: bool,
     breadcrumb: &[String],
@@ -323,10 +169,11 @@ pub fn layout_with_scrollable_list<'a>(
 ) -> Element<'a, Msg> {
     layout_inner(
         progress,
+        network,
         email,
         is_ws_admin,
         breadcrumb,
-        LayoutContent::ScrollableList {
+        installer_layout::LayoutContent::ScrollableList {
             header: header_content,
             list: list_content.into(),
             pinned: pinned_content,
@@ -429,6 +276,7 @@ pub struct SelectSearch<'a> {
 /// Standard "pick one from a list" page used by org_select and wallet_select.
 pub struct SelectListView<'a> {
     pub progress: (usize, usize),
+    pub network: Network,
     pub email: &'a str,
     pub is_ws_admin: bool,
     pub breadcrumb: Vec<String>,
@@ -461,6 +309,7 @@ pub fn select_list_view(cfg: SelectListView<'_>) -> Element<'_, Msg> {
 
     layout_with_scrollable_list(
         cfg.progress,
+        cfg.network,
         Some(cfg.email),
         cfg.is_ws_admin,
         &cfg.breadcrumb,

--- a/liana-business/business-installer/src/views/mod.rs
+++ b/liana-business/business-installer/src/views/mod.rs
@@ -11,6 +11,7 @@ pub mod xpub;
 
 pub use keys::keys_view;
 use liana_connect::ws_business::{self, UserRole};
+pub use liana_ui::component::installer::{intro_description, intro_prompt, screen_intro};
 use liana_ui::component::{installer as installer_layout, text::capitalize_first};
 pub use loading::loading_view;
 pub use login::login_view;
@@ -40,7 +41,6 @@ use liana_ui::{
     widget::*,
     Variant,
 };
-use std::fmt::Display;
 use uuid::Uuid;
 
 pub const INSTALLER_STEPS: usize = 7;
@@ -102,8 +102,6 @@ fn admin_name_from_email(mail: &str) -> Option<String> {
         .unwrap_or(mail);
     Some(format!("({})", capitalize_first(n)))
 }
-
-const SCREEN_INTRO_SUB_WIDTH: u32 = 620;
 
 fn layout_inner<'a>(
     progress: (usize, usize),
@@ -181,33 +179,6 @@ pub fn layout_with_scrollable_list<'a>(
         },
         previous_message,
     )
-}
-
-pub fn screen_intro<'a, M: 'a>(
-    title: impl Display + 'a,
-    sub: Option<Element<'a, M>>,
-    extra_spacing: bool,
-) -> Element<'a, M> {
-    let spacing = if extra_spacing { 60 } else { 15 };
-    column![text::new::d3(title), sub]
-        .align_x(Alignment::Center)
-        .spacing(spacing)
-        .into()
-}
-
-pub fn intro_description<'a, M: 'a>(text: &'a str) -> Element<'a, M> {
-    Container::new(text::new::caption(text).style(theme::text::secondary))
-        .width(Length::Shrink)
-        .max_width(SCREEN_INTRO_SUB_WIDTH)
-        .align_x(Alignment::Center)
-        .into()
-}
-
-pub fn intro_prompt<'a, M: 'a>(prompt: &'a str, accent: Option<&'a str>) -> Element<'a, M> {
-    let accent = accent.map(|accent| text::new::h3_semi(accent).style(theme::text::accent));
-    Container::new(row![text::new::h3_semi(prompt), accent].wrap())
-        .center_x(Length::Fill)
-        .into()
 }
 
 // NOTE: content MUST have width and height to Length::Fill

--- a/liana-business/business-installer/src/views/org_select.rs
+++ b/liana-business/business-installer/src/views/org_select.rs
@@ -190,6 +190,7 @@ pub fn org_select_view(state: &State) -> Element<'_, Msg> {
 
     select_list_view(SelectListView {
         progress: (3, INSTALLER_STEPS),
+        network: state.network,
         email: current_user_email,
         is_ws_admin,
         breadcrumb: vec!["Organizations".to_string()],

--- a/liana-business/business-installer/src/views/org_select.rs
+++ b/liana-business/business-installer/src/views/org_select.rs
@@ -84,11 +84,10 @@ fn is_wallet_accessible(
 
 pub fn org_card<'a>(name: String, id: Uuid, subtitle: Option<String>) -> Element<'a, Msg> {
     let name = truncate(&name, 30);
-    let trailing = list::entry_chevron();
 
     let message = Some(Msg::OrgSelected(id));
 
-    list::entry_organization(name, subtitle, Some(trailing), message)
+    list::entry_organization(name, subtitle, message)
 }
 
 pub fn no_org_card() -> Container<'static, Msg> {

--- a/liana-business/business-installer/src/views/paths/mod.rs
+++ b/liana-business/business-installer/src/views/paths/mod.rs
@@ -153,6 +153,7 @@ pub fn template_builder_view(state: &State) -> Element<'_, Msg> {
 
     layout_with_scrollable_list(
         (5, INSTALLER_STEPS),
+        state.network,
         Some(current_user_email),
         is_ws_admin,
         &breadcrumb,

--- a/liana-business/business-installer/src/views/paths/modal.rs
+++ b/liana-business/business-installer/src/views/paths/modal.rs
@@ -254,7 +254,7 @@ pub fn edit_path_modal_view<'a>(
     let has_keys = !modal_state.selected_key_ids.is_empty();
     let can_save = has_keys && threshold_valid && (modal_state.is_primary || timelock_valid);
 
-    let save_button = btn_save(can_save.then_some(Msg::TemplateSavePath));
+    let save_button = btn_save(can_save.then_some(Msg::TemplateSavePath), true);
 
     let footer = row![
         Space::fill_width(),

--- a/liana-business/business-installer/src/views/registration/mod.rs
+++ b/liana-business/business-installer/src/views/registration/mod.rs
@@ -70,6 +70,7 @@ pub fn registration_view(state: &State) -> Element<'_, Msg> {
 
     layout_with_scrollable_list(
         (7, INSTALLER_STEPS),
+        state.network,
         Some(current_user_email),
         false,
         &breadcrumb,

--- a/liana-business/business-installer/src/views/registration/mod.rs
+++ b/liana-business/business-installer/src/views/registration/mod.rs
@@ -204,7 +204,7 @@ pub fn registration_key_entry(
     let trailing = if done {
         Some(pill::registered().into())
     } else if can_register {
-        Some(list::entry_chevron())
+        Some(list::right_chevron())
     } else {
         Some(text::new::caption("-").style(theme::text::tertiary).into())
     };

--- a/liana-business/business-installer/src/views/template_builder/mod.rs
+++ b/liana-business/business-installer/src/views/template_builder/mod.rs
@@ -142,6 +142,7 @@ pub fn template_builder_view(state: &State) -> Element<'_, Msg> {
 
     layout_with_scrollable_list(
         (5, INSTALLER_STEPS),
+        state.network,
         Some(current_user_email),
         is_ws_admin,
         &breadcrumb,

--- a/liana-business/business-installer/src/views/wallet_select.rs
+++ b/liana-business/business-installer/src/views/wallet_select.rs
@@ -2,18 +2,15 @@ use crate::{
     backend::Backend,
     state::{Msg, State},
 };
-use iced::{
-    widget::{column, row},
-    Alignment, Length,
-};
+use iced::{widget::column, Alignment, Length};
 use liana_connect::ws_business::{KeyIdentity, UserRole, Wallet, WalletStatus};
 use liana_ui::{
     component::{
-        list::{self, EntryStatus},
+        list::{self, EntryAccent},
         pill,
-        text::{self, truncate},
+        text::{self},
     },
-    spacing::{HSpacing, VSpacing},
+    spacing::VSpacing,
     theme,
     widget::*,
 };
@@ -58,7 +55,7 @@ fn derive_user_role(
 }
 
 /// Render a colored status badge for wallet status
-fn status_badge(wallet: &Wallet, user_email: &str) -> Element<'static, Msg> {
+fn status_pill(wallet: &Wallet, user_email: &str) -> Element<'static, Msg> {
     match wallet.effective_status(user_email) {
         WalletStatus::Registration => pill::register(),
         WalletStatus::Created | WalletStatus::Drafted => pill::draft(),
@@ -69,7 +66,7 @@ fn status_badge(wallet: &Wallet, user_email: &str) -> Element<'static, Msg> {
     .into()
 }
 
-fn role_badge(role: &UserRole) -> Option<Element<'static, Msg>> {
+fn role_pill(role: &UserRole) -> Option<Element<'static, Msg>> {
     match role {
         UserRole::WizardSardineAdmin => None,
         UserRole::WalletManager => Some(pill::role_manager().into()),
@@ -95,31 +92,27 @@ pub fn wallet_card<'a>(
     last_edit_info: Option<Element<'a, Msg>>,
     user_email: &str,
 ) -> Element<'a, Msg> {
-    let alias = truncate(&wallet.alias, 25);
-    let role = role_badge(role);
-    let trailing = row![status_badge(wallet, user_email), list::entry_chevron()]
-        .spacing(HSpacing::ML)
-        .align_y(Alignment::Center);
-
+    let role = role_pill(role);
+    let status = Some(status_pill(wallet, user_email));
     let message = Some(Msg::OrgWalletSelected(wallet.id));
 
     list::entry_wallet(
-        wallet_entry_status(wallet, user_email),
-        alias,
-        role,
+        Some(wallet_accent(wallet, user_email)),
+        &wallet.alias,
         last_edit_info,
-        Some(trailing.into()),
+        role,
+        status,
         message,
     )
 }
 
-fn wallet_entry_status(wallet: &Wallet, user_email: &str) -> EntryStatus {
+fn wallet_accent(wallet: &Wallet, user_email: &str) -> EntryAccent {
     match wallet.effective_status(user_email) {
         WalletStatus::Registration | WalletStatus::Locked | WalletStatus::Validated => {
-            EntryStatus::Warning
+            EntryAccent::Warning
         }
-        WalletStatus::Created | WalletStatus::Drafted => EntryStatus::Simple,
-        WalletStatus::Finalized => EntryStatus::Success,
+        WalletStatus::Created | WalletStatus::Drafted => EntryAccent::Simple,
+        WalletStatus::Finalized => EntryAccent::Success,
     }
 }
 

--- a/liana-business/business-installer/src/views/wallet_select.rs
+++ b/liana-business/business-installer/src/views/wallet_select.rs
@@ -241,6 +241,7 @@ pub fn wallet_select_view(state: &State) -> Element<'_, Msg> {
 
     select_list_view(SelectListView {
         progress: (4, INSTALLER_STEPS),
+        network: state.network,
         email: current_user_email,
         is_ws_admin,
         breadcrumb,

--- a/liana-business/business-installer/src/views/xpub/modal.rs
+++ b/liana-business/business-installer/src/views/xpub/modal.rs
@@ -424,7 +424,7 @@ fn other_options(modal_state: &XpubEntryModalState) -> Element<'_, Msg> {
             Tile::Import,
             "Import extended public key file",
             None::<String>,
-            Some(list::entry_chevron()),
+            Some(list::right_chevron()),
             button::EntryWidth::Standard,
             Some(Msg::XpubLoadFromFile),
         );
@@ -433,7 +433,7 @@ fn other_options(modal_state: &XpubEntryModalState) -> Element<'_, Msg> {
             Tile::Paste,
             "Paste an extended public key",
             None::<String>,
-            Some(list::entry_chevron()),
+            Some(list::right_chevron()),
             button::EntryWidth::Standard,
             Some(Msg::XpubSelectPaste),
         );

--- a/liana-business/business-installer/src/views/xpub/modal.rs
+++ b/liana-business/business-installer/src/views/xpub/modal.rs
@@ -466,7 +466,7 @@ fn select_footer_buttons(modal_state: &XpubEntryModalState) -> Element<'_, Msg> 
     let buttons = row![
         btn_cancel(Some(Msg::XpubCancelModal)),
         clear_button,
-        btn_save(can_save.then_some(Msg::XpubSave))
+        btn_save(can_save.then_some(Msg::XpubSave), true)
     ]
     .spacing(HSpacing::M);
 
@@ -482,7 +482,7 @@ fn details_footer_buttons(modal_state: &XpubEntryModalState) -> Element<'_, Msg>
     let can_save =
         modal_state.validate().is_ok() && modal_state.has_changes() && !modal_state.processing;
     let clear_button = btn_clear(modal_state.current_xpub.is_some().then_some(Msg::XpubClear));
-    let save_button = btn_save(can_save.then_some(Msg::XpubSave));
+    let save_button = btn_save(can_save.then_some(Msg::XpubSave), true);
 
     if let Some(retry_button) = retry_button {
         row![retry_button, Space::fill_width(), clear_button, save_button]

--- a/liana-business/business-installer/src/views/xpub/view.rs
+++ b/liana-business/business-installer/src/views/xpub/view.rs
@@ -225,6 +225,7 @@ pub fn xpub_view(state: &State) -> Element<'_, Msg> {
 
     layout_with_scrollable_list(
         (6, INSTALLER_STEPS),
+        state.network,
         Some(current_user_email),
         is_ws_admin,
         &breadcrumb,

--- a/liana-business/src/settings/views/mod.rs
+++ b/liana-business/src/settings/views/mod.rs
@@ -6,12 +6,14 @@ use iced::{
 };
 use liana_ui::{
     component::{
-        self, badge, button, card,
+        self, badge,
+        button::btn_register_on_device,
+        card,
         panels::setting::{header, settings_section, SectionKind},
         pick_list, scrollable, separation,
         text::*,
     },
-    icon, theme,
+    theme,
     widget::{ColumnExt, Element, SpaceExt},
 };
 
@@ -49,10 +51,7 @@ pub fn wallet_view(state: &BusinessSettingsUI) -> Element<'_, Msg> {
                 Row::new()
                     .spacing(10)
                     .push(Space::with_width(Length::Fill))
-                    .push(
-                        button::secondary(Some(icon::chip_icon()), "Register on device")
-                            .on_press(Msg::RegisterWallet),
-                    ),
+                    .push(btn_register_on_device(Msg::RegisterWallet)),
             )
             .spacing(10),
     )

--- a/liana-gui/src/app/menu.rs
+++ b/liana-gui/src/app/menu.rs
@@ -118,7 +118,7 @@ impl Menu {
         match self {
             Menu::Home => icon::home_icon(),
             Menu::Receive => icon::receive_icon(),
-            Menu::PSBTs => icon::edit_icon(),
+            Menu::PSBTs => icon::edit_icon_padding(),
             Menu::Transactions => icon::collection_icon(),
             Menu::Settings => icon::settings_icon(),
             Menu::Coins => icon::coins_icon(),

--- a/liana-gui/src/app/menu.rs
+++ b/liana-gui/src/app/menu.rs
@@ -118,7 +118,7 @@ impl Menu {
         match self {
             Menu::Home => icon::home_icon(),
             Menu::Receive => icon::receive_icon(),
-            Menu::PSBTs => icon::pencil_icon(),
+            Menu::PSBTs => icon::edit_icon(),
             Menu::Transactions => icon::collection_icon(),
             Menu::Settings => icon::settings_icon(),
             Menu::Coins => icon::coins_icon(),

--- a/liana-gui/src/app/view/export.rs
+++ b/liana-gui/src/app/view/export.rs
@@ -1,15 +1,16 @@
 use iced::{
-    alignment::{self, Horizontal},
-    widget::{progress_bar, Column, Container, Row, Space},
-    Length,
+    widget::{column, progress_bar, row, Space},
+    Alignment, Length,
 };
 use liana_ui::{
     component::{
-        button, card,
-        text::{h4_bold, text},
+        button::{btn_cancel, btn_ignore, btn_overwrite},
+        modal::{modal_view, ModalWidth},
+        text::new,
     },
-    icon,
-    widget::{ColumnExt, Element, RowExt, SpaceExt},
+    spacing::{HSpacing, VSpacing},
+    theme,
+    widget::{Element, SpaceExt},
 };
 
 use crate::export::ImportExportState;
@@ -22,20 +23,17 @@ pub fn export_modal<'a, Message: From<ImportExportMessage> + Clone + 'static>(
     title: &str,
     import_export_type: &ImportExportType,
 ) -> Element<'a, Message> {
-    let cancel = match state {
+    let cancel: Option<Element<'a, Message>> = match state {
         ImportExportState::Started | ImportExportState::Progress(_) => {
-            Some(button::secondary(None, "Cancel").on_press(ImportExportMessage::UserStop.into()))
+            Some(btn_cancel(Some(ImportExportMessage::UserStop.into())))
         }
         _ => None,
     }
-    .map(Container::new);
+    .map(Into::into);
 
-    let cross = match state {
+    let close = match state {
         ImportExportState::Ended | ImportExportState::TimedOut | ImportExportState::Aborted => {
-            Some(
-                button::transparent(Some(icon::cross_icon().size(30)), "")
-                    .on_press(ImportExportMessage::Close.into()),
-            )
+            Some(ImportExportMessage::Close.into())
         }
         _ => None,
     };
@@ -57,33 +55,23 @@ pub fn export_modal<'a, Message: From<ImportExportMessage> + Clone + 'static>(
             ImportExportState::Closed => "".into(),
         }
     };
+    let conflict_buttons = || -> Element<'a, Message> {
+        row![
+            Space::fill_width(),
+            btn_overwrite(Some(ImportExportMessage::Overwrite.into())),
+            btn_ignore(Some(ImportExportMessage::Ignore.into())),
+            Space::fill_width(),
+        ]
+        .spacing(HSpacing::M)
+        .into()
+    };
     let labels_btn = (
         "Labels conflict, what do you want to do?".to_string(),
-        Some(Container::new(
-            Row::new()
-                .push(
-                    button::secondary(None, "Overwrite")
-                        .on_press(ImportExportMessage::Overwrite.into()),
-                )
-                .push(Space::with_width(30))
-                .push(
-                    button::secondary(None, "Ignore").on_press(ImportExportMessage::Ignore.into()),
-                ),
-        )),
+        Some(conflict_buttons()),
     );
     let aliases_btn = (
         "Aliases conflict, what do you want to do?".to_string(),
-        Some(Container::new(
-            Row::new()
-                .push(
-                    button::secondary(None, "Overwrite")
-                        .on_press(ImportExportMessage::Overwrite.into()),
-                )
-                .push(Space::with_width(30))
-                .push(
-                    button::secondary(None, "Ignore").on_press(ImportExportMessage::Ignore.into()),
-                ),
-        )),
+        Some(conflict_buttons()),
     );
     let (msg, button) = match import_export_type {
         ImportExportType::ImportBackup {
@@ -98,11 +86,7 @@ pub fn export_modal<'a, Message: From<ImportExportMessage> + Clone + 'static>(
         },
         _ => (msg, cancel),
     };
-    let button = button.map(|b| {
-        Container::new(b)
-            .align_x(Horizontal::Center)
-            .width(Length::Fill)
-    });
+    let button = button.map(|b| row![Space::fill_width(), b, Space::fill_width()]);
 
     let mut p = match state {
         ImportExportState::Init => 0.0,
@@ -119,30 +103,17 @@ pub fn export_modal<'a, Message: From<ImportExportMessage> + Clone + 'static>(
     if p == 0.0 {
         p += 2.5;
     }
-    let progress_bar_row = Row::new()
-        .push(Space::with_width(30))
-        .push(progress_bar(0.0..=100.0, p))
-        .push(Space::with_width(30));
-    card::simple(
-        Column::new()
-            .spacing(10)
-            .push(
-                Row::new()
-                    .push(Space::with_width(20))
-                    .push(h4_bold(title))
-                    .push(Space::with_width(Length::Fill))
-                    .push_maybe(cross)
-                    .align_y(alignment::Vertical::Center),
-            )
-            .push(Space::with_height(Length::Fill))
-            .push(progress_bar_row)
-            .push(Space::with_height(Length::Fill))
-            .push(Row::new().push(text(msg)))
-            .push(Space::with_height(Length::Fill))
-            .push_maybe(button)
-            .push(Space::with_height(5)),
-    )
-    .width(Length::Fixed(500.0))
-    .height(Length::Fixed(300.0))
-    .into()
+    let mut progress = progress_bar(0.0..=100.0, p);
+    let mut msg = new::caption(msg);
+    if error.is_some() {
+        progress = progress.style(theme::progress_bar::error);
+        msg = msg.style(theme::text::warning)
+    }
+    let progress_bar_row = row![Space::with_width(30), progress, Space::with_width(30),];
+    let content = column![progress_bar_row, msg, button,]
+        .spacing(VSpacing::M)
+        .align_x(Alignment::Center)
+        .width(Length::Fill);
+
+    modal_view(Some(title), None, close, ModalWidth::M, content)
 }

--- a/liana-gui/src/app/view/home/payment_details.rs
+++ b/liana-gui/src/app/view/home/payment_details.rs
@@ -10,7 +10,8 @@ use liana::miniscript::bitcoin;
 use liana_ui::{
     component::{
         amount::amount_with_font,
-        button, card, form,
+        button::{self, btn_see_transaction_details},
+        card, form,
         text::{legacy, Text},
     },
     theme,
@@ -153,11 +154,9 @@ pub fn payment_details_view<'a>(
                     )
                     .spacing(5),
             ))
-            .push(
-                button::secondary(None, "See transaction details").on_press(Message::Menu(
-                    Menu::TransactionPreSelected(tx.tx.compute_txid()),
-                )),
-            )
+            .push(btn_see_transaction_details(Message::Menu(
+                Menu::TransactionPreSelected(tx.tx.compute_txid()),
+            )))
             .spacing(20),
     )
 }

--- a/liana-gui/src/app/view/label.rs
+++ b/liana-gui/src/app/view/label.rs
@@ -2,8 +2,11 @@ use iced::{advanced::text::Shaping, widget::row, Alignment};
 
 use liana_ui::{
     color,
-    component::{button, form, label::LABEL_LENGTH_WARNING},
-    icon,
+    component::{
+        button::{self, btn_add_label, btn_edit},
+        form,
+        label::LABEL_LENGTH_WARNING,
+    },
     widget::*,
 };
 
@@ -21,12 +24,10 @@ pub fn label_editable(
                     iced::widget::Text::new(label)
                         .size(size)
                         .shaping(Shaping::Advanced),
-                    button::secondary(Some(icon::pencil_icon()), "Edit").on_press(
-                        view::Message::Label(
-                            labelled,
-                            view::message::LabelMessage::Edited(label.to_string())
-                        )
-                    )
+                    btn_edit(Some(view::Message::Label(
+                        labelled,
+                        view::message::LabelMessage::Edited(label.to_string())
+                    )))
                 )
                 .spacing(5)
                 .align_y(Alignment::Center),
@@ -34,13 +35,11 @@ pub fn label_editable(
             .into();
         }
     }
-    Container::new(
-        button::secondary(Some(icon::pencil_icon()), "Add label").on_press(view::Message::Label(
-            labelled,
-            view::message::LabelMessage::Edited(String::default()),
-        )),
-    )
-    .into()
+    let add_label_msg = Some(view::Message::Label(
+        labelled,
+        view::message::LabelMessage::Edited(String::default()),
+    ));
+    btn_add_label(add_label_msg).into()
 }
 
 pub fn label_editing(

--- a/liana-gui/src/app/view/psbt.rs
+++ b/liana-gui/src/app/view/psbt.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use iced::{
-    widget::{tooltip, Space},
+    widget::{row, tooltip, Space},
     Alignment, Length,
 };
 
@@ -18,7 +18,8 @@ use liana_ui::{
     component::{
         address::address as address_view,
         amount::*,
-        button, card,
+        button::{self, btn_broadcast, btn_delete, btn_export, btn_import, btn_save, btn_sign},
+        card,
         collapse::Collapse,
         form,
         list::DeviceStatus,
@@ -54,6 +55,11 @@ pub fn psbt_view<'a>(
     currently_signing: bool,
     warning: Option<&'a Error>,
 ) -> Element<'a, Message> {
+    let delete_msg = if currently_signing {
+        None
+    } else {
+        Some(Message::Spend(SpendTxMessage::Delete))
+    };
     dashboard(
         &Menu::PSBTs,
         cache,
@@ -105,29 +111,14 @@ pub fn psbt_view<'a>(
                     )),
             )
             .push(if saved {
-                Row::new()
-                    .push(
-                        button::secondary(None, "Delete")
-                            .width(Length::Fixed(200.0))
-                            .on_press_maybe(if currently_signing {
-                                None
-                            } else {
-                                Some(Message::Spend(SpendTxMessage::Delete))
-                            }),
-                    )
-                    .width(Length::Fill)
+                row![btn_delete(delete_msg)].width(Length::Fill)
             } else {
                 Row::new()
                     .push(Space::with_width(Length::Fill))
-                    .push(
-                        button::secondary(None, "Save")
-                            .width(Length::Fixed(150.0))
-                            .on_press_maybe(if currently_signing {
-                                None
-                            } else {
-                                Some(Message::Spend(SpendTxMessage::Save))
-                            }),
-                    )
+                    .push(btn_save(
+                        (!currently_signing).then_some(Message::Spend(SpendTxMessage::Save)),
+                        false,
+                    ))
                     .width(Length::Fill)
             })
             .push(Space::with_height(10)),
@@ -230,12 +221,10 @@ pub fn broadcast_action<'a>(
                         ),
                     )
                 })
-                .push(
-                    Row::new().push(Column::new().width(Length::Fill)).push(
-                        button::primary(None, "Broadcast")
-                            .on_press(Message::Spend(SpendTxMessage::Confirm)),
-                    ),
-                ),
+                .push(row![
+                    Space::fill_width(),
+                    btn_broadcast(Some(Message::Spend(SpendTxMessage::Confirm)))
+                ]),
         )
         .width(Length::Fixed(if conflicting_txids.is_empty() {
             400.0
@@ -340,13 +329,13 @@ pub fn spend_overview_view<'a>(
     currently_signing: bool,
     saved: bool,
 ) -> Element<'a, Message> {
-    let export_button = button::secondary(Some(icon::backup_icon()), "Export").on_press_maybe(
-        if currently_signing || !saved {
-            None
-        } else {
-            Some(Message::ExportPsbt)
-        },
-    );
+    let enabled = saved && !currently_signing;
+    let export_msg = enabled.then_some(Message::ExportPsbt);
+    let export_button = btn_export(export_msg);
+
+    let import_msg = enabled.then_some(Message::ImportPsbt);
+    let import_button = btn_import(import_msg);
+
     Column::new()
         .spacing(20)
         .push(
@@ -373,17 +362,7 @@ pub fn spend_overview_view<'a>(
                                                     tooltip::Position::Top,
                                                 ))
                                             })
-                                            .push(
-                                                button::secondary(
-                                                    Some(icon::restore_icon()),
-                                                    "Import",
-                                                )
-                                                .on_press_maybe(if currently_signing || !saved {
-                                                    None
-                                                } else {
-                                                    Some(Message::ImportPsbt)
-                                                }),
-                                            ),
+                                            .push(import_button),
                                     )
                                     .align_y(Alignment::Center),
                             )
@@ -413,15 +392,11 @@ pub fn spend_overview_view<'a>(
                     .push(Space::with_width(Length::Fill))
                     .push_maybe(if tx.path_ready().is_none() {
                         Some(
-                            button::primary(None, "Sign")
-                                .on_press(Message::Spend(SpendTxMessage::Sign))
-                                .width(Length::Fixed(150.0)),
+                            btn_sign(Some(Message::Spend(SpendTxMessage::Sign))),
                         )
                     } else {
                         Some(
-                            button::primary(None, "Broadcast")
-                                .on_press(Message::Spend(SpendTxMessage::Broadcast))
-                                .width(Length::Fixed(150.0)),
+                            btn_broadcast(Some(Message::Spend(SpendTxMessage::Broadcast))),
                         )
                     })
                     .align_y(Alignment::Center)

--- a/liana-gui/src/app/view/psbt.rs
+++ b/liana-gui/src/app/view/psbt.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use iced::{
-    widget::{row, tooltip, Space},
+    widget::{column, row, tooltip, Space},
     Alignment, Length,
 };
 
@@ -955,16 +955,12 @@ pub fn sign_action<'a>(
         .spacing(10)
         .width(Length::Fill);
 
-    let width = ModalWidth::M;
+    let width = ModalWidth::L;
     let content = modal_view(Some(title), None, None, width, modal_content);
 
     let width = width as u32 + 50;
-    Column::new()
-        .push_maybe(warning.map(|w| warn(Some(w))))
-        .push(content)
-        .spacing(10)
-        .width(width)
-        .into()
+    let warning = warning.map(|w| warn(Some(w)));
+    column![warning, content].spacing(10).width(width).into()
 }
 
 pub fn sign_action_toasts<'a>(

--- a/liana-gui/src/app/view/psbts.rs
+++ b/liana-gui/src/app/view/psbts.rs
@@ -1,7 +1,13 @@
 use iced::{widget::Space, Alignment, Length};
 
 use liana_ui::{
-    component::{amount::*, badge, button, card, form, pill, text::*},
+    component::{
+        amount::*,
+        badge,
+        button::{btn_import, btn_new, btn_processing},
+        card, form, pill,
+        text::*,
+    },
     icon, theme,
     widget::*,
 };
@@ -34,12 +40,11 @@ pub fn import_psbt_view<'a>(
                 )
                 .push(Row::new().push(Space::with_width(Length::Fill)).push(
                     if imported.valid && !imported.value.is_empty() && !processing {
-                        button::secondary(None, "Import")
-                            .on_press(Message::ImportSpend(ImportSpendMessage::Confirm))
+                        btn_import(Some(Message::ImportSpend(ImportSpendMessage::Confirm)))
                     } else if processing {
-                        button::secondary(None, "Processing...")
+                        btn_processing()
                     } else {
-                        button::secondary(None, "Import")
+                        btn_import(None)
                     },
                 )),
         ))
@@ -67,14 +72,8 @@ pub fn psbts_view(spend_txs: &[SpendTx]) -> Element<'_, Message> {
                 .align_y(Alignment::Center)
                 .spacing(10)
                 .push(Container::new(panel_title(Menu::PSBTs.title())).width(Length::Fill))
-                .push(
-                    button::secondary(Some(icon::restore_icon()), "Import")
-                        .on_press(Message::ImportPsbt),
-                )
-                .push(
-                    button::secondary(Some(icon::plus_icon()), "New")
-                        .on_press(Message::Menu(Menu::CreateSpendTx)),
-                ),
+                .push(btn_import(Some(Message::ImportPsbt)))
+                .push(btn_new(Some(Message::Menu(Menu::CreateSpendTx)))),
         )
         .push(
             Column::new().spacing(10).push(

--- a/liana-gui/src/app/view/recovery.rs
+++ b/liana-gui/src/app/view/recovery.rs
@@ -74,11 +74,7 @@ pub fn recovery<'a>(
                 Some(
                     Row::new()
                         .push(Space::with_width(Length::Fill))
-                        .push(
-                            button::primary(None, "Next")
-                                .on_press_maybe(selected_path.map(|_| Message::Next))
-                                .width(Length::Fixed(200.0)),
-                        )
+                        .push(button::btn_next(selected_path.map(|_| Message::Next)))
                         .spacing(20)
                         .align_y(Alignment::Center),
                 )

--- a/liana-gui/src/app/view/settings/mod.rs
+++ b/liana-gui/src/app/view/settings/mod.rs
@@ -18,7 +18,7 @@ use liana::{
 use liana_ui::{
     component::{
         self, badge,
-        button::{self, btn_secondary_with_tooltip, BtnWidth},
+        button::{self, btn_backup_encrypt_descriptor, btn_register_on_device, btn_update},
         card, form,
         panels::setting::{
             export_section, header, settings_section, ImportExportKind, SectionKind,
@@ -932,26 +932,17 @@ pub fn wallet_settings<'a>(
         Some(SettingsMessage::EditWalletSettings.into()),
     );
 
-    let backup_label = "Back up encrypted descriptor";
-    let backup_tooltip = "An encrypted descriptor file (.bed) you can store anywhere. To decrypt it, you need one of your signing devices or xpubs.";
-    let backup_msg = Message::Settings(SettingsMessage::ExportEncryptedDescriptor);
-
     // ------------------------- Descriptor card -------------------------
     let title = text("Wallet descriptor:").bold();
     let descriptor_s =
         scrollable::horizontal_thin(Column::new().push(text(descriptor.to_string()).small()))
             .width(Length::Fill);
 
-    let btn_backup = btn_secondary_with_tooltip(
-        Some(icon::backup_icon()),
-        backup_label,
-        Some(backup_tooltip),
-        BtnWidth::Auto,
-        Some(backup_msg),
-    );
+    let backup_msg = Message::Settings(SettingsMessage::ExportEncryptedDescriptor);
+    let btn_backup = btn_backup_encrypt_descriptor(backup_msg);
+
     let btn_copy = button::btn_copy(Some(Message::Clipboard(descriptor.to_string())));
-    let btn_register = button::secondary(Some(icon::chip_icon()), "Register on hardware device")
-        .on_press(Message::Settings(SettingsMessage::RegisterWallet));
+    let btn_register = btn_register_on_device(Message::Settings(SettingsMessage::RegisterWallet));
 
     let descriptor_row = row![descriptor_s, btn_copy]
         .spacing(10)
@@ -1016,6 +1007,8 @@ pub fn wallet_settings<'a>(
         col_content.push(key_alias_entry(fg, name));
     }
 
+    let update_msg =
+        (!processing && wallet_alias.valid).then_some(Message::Settings(SettingsMessage::Save));
     let last_row = Row::new()
         .align_y(Alignment::Center)
         .push(Space::with_width(Length::Fill))
@@ -1029,11 +1022,7 @@ pub fn wallet_settings<'a>(
         } else {
             None
         })
-        .push(if !processing && wallet_alias.valid {
-            button::secondary(None, "Update").on_press(Message::Settings(SettingsMessage::Save))
-        } else {
-            button::secondary(None, "Updating")
-        });
+        .push(btn_update(update_msg));
 
     col_content.push(last_row.into());
 

--- a/liana-gui/src/app/view/settings/mod.rs
+++ b/liana-gui/src/app/view/settings/mod.rs
@@ -18,7 +18,9 @@ use liana::{
 use liana_ui::{
     component::{
         self, badge,
-        button::{self, btn_backup_encrypt_descriptor, btn_register_on_device, btn_update},
+        button::{
+            self, btn_backup_encrypt_descriptor, btn_icon_edit, btn_register_on_device, btn_update,
+        },
         card, form,
         panels::setting::{
             export_section, header, settings_section, ImportExportKind, SectionKind,
@@ -553,13 +555,9 @@ pub fn bitcoind<'a>(
                             .align_y(Alignment::Center)
                             .width(Length::Fill),
                     )
-                    .push(if can_edit {
-                        Button::new(icon::pencil_icon())
-                            .style(theme::button::transparent_border)
-                            .on_press(SettingsEditMessage::Select)
-                    } else {
-                        Button::new(icon::pencil_icon()).style(theme::button::transparent_border)
-                    })
+                    .push(btn_icon_edit(
+                        can_edit.then_some(SettingsEditMessage::Select),
+                    ))
                     .align_y(Alignment::Center),
             )
             .push(separation().width(Length::Fill))
@@ -741,13 +739,9 @@ pub fn electrum<'a>(
                             .align_y(Alignment::Center)
                             .width(Length::Fill),
                     )
-                    .push(if can_edit {
-                        Button::new(icon::pencil_icon())
-                            .style(theme::button::transparent_border)
-                            .on_press(SettingsEditMessage::Select)
-                    } else {
-                        Button::new(icon::pencil_icon()).style(theme::button::transparent_border)
-                    })
+                    .push(btn_icon_edit(
+                        can_edit.then_some(SettingsEditMessage::Select),
+                    ))
                     .align_y(Alignment::Center),
             )
             .push(separation().width(Length::Fill))

--- a/liana-gui/src/app/view/spend/mod.rs
+++ b/liana-gui/src/app/view/spend/mod.rs
@@ -85,8 +85,8 @@ pub fn spend_view<'a>(
         row![delete].width(Length::Fill)
     } else {
         let previous = button::btn_previous((!currently_signing).then_some(Message::Previous));
-        let save =
-            button::btn_save((!currently_signing).then_some(Message::Spend(SpendTxMessage::Save)));
+        let save_msg = (!currently_signing).then_some(Message::Spend(SpendTxMessage::Save));
+        let save = button::btn_save(save_msg, false);
         row![previous, Space::fill_width(), save].width(Length::Fill)
     };
 

--- a/liana-gui/src/installer/decrypt.rs
+++ b/liana-gui/src/installer/decrypt.rs
@@ -591,6 +591,9 @@ fn valid_content(state: &DecryptModal) -> Container<'static, installer::Message>
     );
 
     let mut col = Column::new().spacing(5).push(description);
+    if devices.is_empty() {
+        col = col.push(modal::modal_no_devices_placeholder());
+    }
     for d in devices {
         col = col.push(d);
     }

--- a/liana-gui/src/installer/decrypt.rs
+++ b/liana-gui/src/installer/decrypt.rs
@@ -668,7 +668,7 @@ pub fn mnemonic_input_button<'a>(
     modal::acked_input_button(
         collapsed,
         ack,
-        || icon::pencil_icon().color(color::WHITE),
+        || icon::edit_icon().color(color::WHITE),
         "UNSAFE: Enter mnemonic of one of the keys",
         " This option is not secure. I understand that entering a mnemonic on a computer may result in theft of my funds.",
         "code code code code code code code code code code code brave",

--- a/liana-gui/src/installer/message.rs
+++ b/liana-gui/src/installer/message.rs
@@ -191,6 +191,7 @@ pub enum DefineDescriptor {
     AddSafetyNetPath,
     ThresholdSequenceModal(ThresholdSequenceModal),
     Reset,
+    ShowImportDescriptor(bool),
     AliasEdited(Fingerprint, String /* alias*/),
     Compiled(Result<Box<LianaDescriptor>, String>),
 }

--- a/liana-gui/src/installer/message.rs
+++ b/liana-gui/src/installer/message.rs
@@ -117,6 +117,8 @@ pub enum SelectBackend {
 
 #[derive(Debug, Clone)]
 pub enum ImportRemoteWallet {
+    ToggleOptions(bool),
+    ToggleOption(ImportWalletOption),
     RemoteWallets(Result<Vec<liana_connect::wallets::api::Wallet>, Error>),
     ImportDescriptor(String),
     ConfirmDescriptor,
@@ -127,6 +129,12 @@ pub enum ImportRemoteWallet {
     InvitationAccepted(Result<liana_connect::wallets::api::Wallet, Error>),
     ImportDescriptorFromFile,
     ImportExport(ImportExportMessage),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImportWalletOption {
+    Invitation,
+    PasteDescriptor,
 }
 
 #[derive(Debug, Clone)]

--- a/liana-gui/src/installer/message.rs
+++ b/liana-gui/src/installer/message.rs
@@ -104,6 +104,8 @@ pub enum SelectBackend {
     // view messages
     RequestOTP,
     EditEmail,
+    ConnectWithAnotherEmail,
+    BackToConnectAccounts,
     EmailEdited(String),
     OTPEdited(String),
     ContinueWithLocalWallet(bool),

--- a/liana-gui/src/installer/message.rs
+++ b/liana-gui/src/installer/message.rs
@@ -65,6 +65,7 @@ pub enum Message {
     KeyRedeemed(ProviderKey, Result<(), liana_connect::keys::Error>),
     AllKeysRedeemed,
     BackupDescriptor,
+    ShowBackupDescriptorHelp(bool),
     ExportEncryptedDescriptor(Result<Box<LianaDescriptor>, encrypted_backup::Error>),
     ExportXpub(String),
     ImportExport(ImportExportMessage),

--- a/liana-gui/src/installer/mod.rs
+++ b/liana-gui/src/installer/mod.rs
@@ -14,10 +14,7 @@ use liana::{
     descriptors::{LianaDescriptor, LianaPolicy},
     miniscript::bitcoin::{self, Network},
 };
-use liana_ui::{
-    component::network_banner,
-    widget::{Column, Element},
-};
+use liana_ui::widget::Element;
 use lianad::config::{BitcoinBackend, BitcoindConfig, BitcoindRpcAuth, Config};
 use std::{collections::HashMap, fmt::Debug, ops::Deref};
 use tokio::runtime::Handle;
@@ -403,8 +400,7 @@ impl LianaInstaller {
     }
 
     pub fn view(&self) -> Element<'_, Message> {
-        let content = self
-            .steps
+        self.steps
             .get(self.current)
             .expect("There is always a step")
             .view(
@@ -412,13 +408,7 @@ impl LianaInstaller {
                 self.progress(),
                 self.network,
                 self.context.remote_backend.user_email(),
-            );
-
-        if self.network != Network::Bitcoin {
-            Column::with_children(vec![network_banner(self.network).into(), content]).into()
-        } else {
-            content
-        }
+            )
     }
 }
 

--- a/liana-gui/src/installer/mod.rs
+++ b/liana-gui/src/installer/mod.rs
@@ -410,6 +410,7 @@ impl LianaInstaller {
             .view(
                 &self.hws,
                 self.progress(),
+                self.network,
                 self.context.remote_backend.user_email(),
             );
 

--- a/liana-gui/src/installer/step/backend.rs
+++ b/liana-gui/src/installer/step/backend.rs
@@ -83,9 +83,10 @@ impl Step for ChooseBackend {
         &'a self,
         _hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         _email: Option<&'a str>,
     ) -> Element<'a, Message> {
-        view::choose_backend(progress)
+        view::choose_backend(progress, network)
     }
 }
 
@@ -383,10 +384,12 @@ impl Step for RemoteBackendLogin {
         &'a self,
         _hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         _email: Option<&'a str>,
     ) -> Element<'a, Message> {
         view::login(
             progress,
+            network,
             match &self.step {
                 ConnectionStep::EnterEmail { email } => view::connection_step_enter_email(
                     email,
@@ -753,10 +756,12 @@ impl Step for ImportRemoteWallet {
         &'a self,
         _hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         email: Option<&'a str>,
     ) -> Element<'a, Message> {
         let content = view::import_wallet_or_descriptor(
             progress,
+            network,
             email,
             &self.invitation_token,
             self.invitation

--- a/liana-gui/src/installer/step/backend.rs
+++ b/liana-gui/src/installer/step/backend.rs
@@ -468,6 +468,8 @@ pub struct ImportRemoteWallet {
     network: Network,
     invitation_token: form::Value<String>,
     invitation: Option<api::WalletInvitation>,
+    options_expanded: bool,
+    active_option: Option<message::ImportWalletOption>,
     imported_descriptor: form::Value<String>,
     descriptor: Option<LianaDescriptor>,
     error: Option<String>,
@@ -485,6 +487,8 @@ impl ImportRemoteWallet {
             network,
             invitation_token: form::Value::default(),
             invitation: None,
+            options_expanded: false,
+            active_option: None,
             imported_descriptor: form::Value::default(),
             descriptor: None,
             error: None,
@@ -529,6 +533,12 @@ impl Step for ImportRemoteWallet {
     // Verification of the values is happening when the user click on Next button.
     fn update(&mut self, hws: &mut HardwareWallets, message: Message) -> Task<Message> {
         match message {
+            Message::ImportRemoteWallet(message::ImportRemoteWallet::ToggleOptions(expanded)) => {
+                self.options_expanded = expanded;
+            }
+            Message::ImportRemoteWallet(message::ImportRemoteWallet::ToggleOption(option)) => {
+                self.active_option = (self.active_option != Some(option)).then_some(option);
+            }
             Message::ImportRemoteWallet(message::ImportRemoteWallet::ImportDescriptorFromFile) => {
                 let modal = ExportModal::new(None, ImportExportType::FromBackup);
                 let launch = modal.launch(false);
@@ -769,6 +779,8 @@ impl Step for ImportRemoteWallet {
                 .map(|invit| invit.wallet_name.as_str()),
             &self.imported_descriptor,
             self.error.as_ref(),
+            self.options_expanded,
+            self.active_option,
             self.wallets
                 .iter()
                 .map(|w| (&w.name, w.metadata.wallet_alias.as_ref()))

--- a/liana-gui/src/installer/step/backend.rs
+++ b/liana-gui/src/installer/step/backend.rs
@@ -92,6 +92,9 @@ impl Step for ChooseBackend {
 
 #[allow(clippy::large_enum_variant)]
 pub enum ConnectionStep {
+    SelectAccount {
+        selected_email: Option<String>,
+    },
     EnterEmail {
         email: form::Value<String>,
     },
@@ -146,6 +149,66 @@ impl Step for RemoteBackendLogin {
     }
     fn update(&mut self, _hws: &mut HardwareWallets, message: Message) -> Task<Message> {
         match &mut self.step {
+            ConnectionStep::SelectAccount { selected_email } => match message {
+                Message::SelectBackend(message::SelectBackend::ExistingConnectAccounts(
+                    accounts,
+                )) => {
+                    self.connect_accounts = accounts;
+                    if self.connect_accounts.is_empty() {
+                        self.step = ConnectionStep::EnterEmail {
+                            email: form::Value::default(),
+                        };
+                    }
+                }
+                Message::SelectBackend(message::SelectBackend::ConnectWithAnotherEmail) => {
+                    if !self.processing {
+                        self.step = ConnectionStep::EnterEmail {
+                            email: form::Value::default(),
+                        };
+                    }
+                }
+                Message::SelectBackend(message::SelectBackend::SelectConnectAccount(email)) => {
+                    *selected_email = Some(email.clone());
+                    self.processing = true;
+                    self.connection_error = None;
+                    self.auth_error = None;
+                    return Task::perform(
+                        connect_with_existing_account(
+                            email,
+                            self.network,
+                            self.network_dir.clone(),
+                        ),
+                        |msg| Message::SelectBackend(message::SelectBackend::Connected(msg)),
+                    );
+                }
+                Message::SelectBackend(message::SelectBackend::Connected(res)) => {
+                    self.processing = false;
+                    match res {
+                        Ok(remote_backend) => {
+                            self.step = ConnectionStep::Connected {
+                                email: remote_backend
+                                    .user_email()
+                                    .expect("Gui connected to Liana backend")
+                                    .to_string(),
+                                remote_backend,
+                            };
+                            return Task::perform(async move {}, |_| Message::Next);
+                        }
+                        Err(e) => {
+                            if let Error::Auth(AuthError { http_status, .. }) = e {
+                                if http_status == Some(403) {
+                                    self.auth_error = Some("Token has expired or is invalid")
+                                } else {
+                                    self.connection_error = Some(e);
+                                }
+                            } else {
+                                self.connection_error = Some(e);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            },
             ConnectionStep::EnterEmail { email } => match message {
                 Message::SelectBackend(message::SelectBackend::EmailEdited(value)) => {
                     email.valid = value.is_empty()
@@ -159,17 +222,19 @@ impl Step for RemoteBackendLogin {
                 Message::SelectBackend(message::SelectBackend::ExistingConnectAccounts(
                     accounts,
                 )) => {
+                    if !accounts.is_empty() && email.value.is_empty() {
+                        self.step = ConnectionStep::SelectAccount {
+                            selected_email: None,
+                        };
+                    }
                     self.connect_accounts = accounts;
                 }
-                Message::SelectBackend(message::SelectBackend::SelectConnectAccount(email)) => {
-                    return Task::perform(
-                        connect_with_existing_account(
-                            email,
-                            self.network,
-                            self.network_dir.clone(),
-                        ),
-                        |msg| Message::SelectBackend(message::SelectBackend::Connected(msg)),
-                    )
+                Message::SelectBackend(message::SelectBackend::BackToConnectAccounts) => {
+                    if !self.processing && !self.connect_accounts.is_empty() {
+                        self.step = ConnectionStep::SelectAccount {
+                            selected_email: None,
+                        };
+                    }
                 }
                 Message::SelectBackend(message::SelectBackend::RequestOTP) => {
                     if email.value.is_empty() {
@@ -260,13 +325,22 @@ impl Step for RemoteBackendLogin {
                 backend_api_url,
             } => match message {
                 Message::SelectBackend(message::SelectBackend::EditEmail) => {
-                    self.step = ConnectionStep::EnterEmail {
-                        email: form::Value {
-                            value: email.clone(),
-                            warning: None,
-                            valid: true,
-                        },
-                    };
+                    if !self.processing {
+                        self.step = ConnectionStep::EnterEmail {
+                            email: form::Value {
+                                value: email.clone(),
+                                warning: None,
+                                valid: true,
+                            },
+                        };
+                    }
+                }
+                Message::SelectBackend(message::SelectBackend::BackToConnectAccounts) => {
+                    if !self.processing && !self.connect_accounts.is_empty() {
+                        self.step = ConnectionStep::SelectAccount {
+                            selected_email: None,
+                        };
+                    }
                 }
                 Message::SelectBackend(message::SelectBackend::RequestOTP) => {
                     *otp = form::Value::default();
@@ -331,13 +405,23 @@ impl Step for RemoteBackendLogin {
                 }
                 _ => {}
             },
-            ConnectionStep::Connected { .. } => {
-                if let Message::SelectBackend(message::SelectBackend::EditEmail) = message {
-                    self.step = ConnectionStep::EnterEmail {
-                        email: form::Value::default(),
+            ConnectionStep::Connected { .. } => match message {
+                Message::SelectBackend(message::SelectBackend::EditEmail) => {
+                    if !self.processing {
+                        self.step = ConnectionStep::EnterEmail {
+                            email: form::Value::default(),
+                        }
                     }
                 }
-            }
+                Message::SelectBackend(message::SelectBackend::BackToConnectAccounts) => {
+                    if !self.processing && !self.connect_accounts.is_empty() {
+                        self.step = ConnectionStep::SelectAccount {
+                            selected_email: None,
+                        };
+                    }
+                }
+                _ => {}
+            },
         }
 
         Task::none()
@@ -387,32 +471,47 @@ impl Step for RemoteBackendLogin {
         network: Network,
         _email: Option<&'a str>,
     ) -> Element<'a, Message> {
-        view::login(
-            progress,
-            network,
-            match &self.step {
-                ConnectionStep::EnterEmail { email } => view::connection_step_enter_email(
-                    email,
-                    self.processing,
-                    self.connection_error.as_ref(),
+        match &self.step {
+            ConnectionStep::SelectAccount { selected_email } => {
+                view::connection_step_select_account(
+                    progress,
+                    network,
                     &self.connect_accounts,
-                    self.auth_error,
-                ),
-                ConnectionStep::EnterOtp { email, otp, .. } => view::connection_step_enter_otp(
-                    email,
-                    otp,
                     self.processing,
+                    selected_email.as_deref(),
                     self.connection_error.as_ref(),
                     self.auth_error,
-                ),
-                ConnectionStep::Connected { email, .. } => view::connection_step_connected(
-                    email,
-                    self.processing,
-                    self.connection_error.as_ref(),
-                    self.auth_error,
-                ),
-            },
-        )
+                )
+            }
+            ConnectionStep::EnterEmail { email } => view::connection_step_enter_email(
+                progress,
+                network,
+                email,
+                self.processing,
+                self.connection_error.as_ref(),
+                self.auth_error,
+                !self.connect_accounts.is_empty(),
+            ),
+            ConnectionStep::EnterOtp { email, otp, .. } => view::connection_step_enter_otp(
+                progress,
+                network,
+                email,
+                otp,
+                self.processing,
+                self.connection_error.as_ref(),
+                self.auth_error,
+                !self.connect_accounts.is_empty(),
+            ),
+            ConnectionStep::Connected { email, .. } => view::connection_step_connected(
+                progress,
+                network,
+                email,
+                self.processing,
+                self.connection_error.as_ref(),
+                self.auth_error,
+                !self.connect_accounts.is_empty(),
+            ),
+        }
     }
 }
 

--- a/liana-gui/src/installer/step/descriptor/editor/key.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/key.rs
@@ -10,7 +10,7 @@ use iced::{
     alignment::{Horizontal, Vertical},
     clipboard,
     widget::{column, container, row, Column, Row, Space},
-    Length, Subscription, Task,
+    Alignment, Length, Subscription, Task,
 };
 use liana::miniscript::{
     bitcoin::{
@@ -1004,16 +1004,13 @@ impl SelectKeySource {
     ) -> Element<'_, Message> {
         let mut col = column![p1_bold("Detected hardware")]
             .spacing(5)
+            .align_x(Alignment::Center)
             .width(modal::BTN_W);
         for hw in hws {
             col = col.push(self.widget_signing_device(hw));
         }
         if hws.is_empty() {
-            col = col.push(row![
-                Space::with_width(Length::Fill),
-                p1_regular("- No other sources detected -"),
-                Space::with_width(Length::Fill)
-            ])
+            col = col.push(modal_no_devices_placeholder());
         }
         col.into()
     }

--- a/liana-gui/src/installer/step/descriptor/editor/mod.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/mod.rs
@@ -601,12 +601,14 @@ impl Step for DefineDescriptor {
         &'a self,
         hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         _email: Option<&'a str>,
     ) -> Element<'a, Message> {
         let content = match self.descriptor_template {
             DescriptorTemplate::SimpleInheritance => {
                 view::editor::template::inheritance::inheritance_template(
                     progress,
+                    network,
                     self.use_taproot,
                     &self.paths[0],
                     &self.paths[1],
@@ -617,6 +619,7 @@ impl Step for DefineDescriptor {
             DescriptorTemplate::MultisigSecurity => {
                 view::editor::template::multisig_security_wallet::multisig_security_template(
                     progress,
+                    network,
                     self.use_taproot,
                     &self.paths[0],
                     &self.paths[1],
@@ -626,6 +629,7 @@ impl Step for DefineDescriptor {
             }
             DescriptorTemplate::Custom => view::editor::template::custom::custom_template(
                 progress,
+                network,
                 self.use_taproot,
                 &self.paths[0],
                 &mut self.paths[1..]

--- a/liana-gui/src/installer/step/descriptor/editor/template.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/template.rs
@@ -1,4 +1,5 @@
 use iced::Task;
+use liana::miniscript::bitcoin::Network;
 
 use liana_ui::widget::Element;
 
@@ -40,10 +41,11 @@ impl Step for ChooseDescriptorTemplate {
     fn view<'a>(
         &'a self,
         _hws: &'a HardwareWallets,
-        progress: (usize, usize),
+        _progress: (usize, usize),
+        network: Network,
         _email: Option<&'a str>,
     ) -> Element<'a, Message> {
-        view::editor::template::choose_descriptor_template(progress)
+        view::editor::template::choose_descriptor_template(network)
     }
 }
 
@@ -67,17 +69,22 @@ impl Step for DescriptorTemplateDescription {
         &'a self,
         _hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         _email: Option<&'a str>,
     ) -> Element<'a, Message> {
         match self.template {
             DescriptorTemplate::SimpleInheritance => {
-                view::editor::template::inheritance::inheritance_template_description(progress)
+                view::editor::template::inheritance::inheritance_template_description(
+                    progress, network,
+                )
             }
             DescriptorTemplate::MultisigSecurity => {
-                view::editor::template::multisig_security_wallet::multisig_security_template_description(progress)
+                view::editor::template::multisig_security_wallet::multisig_security_template_description(
+                    progress, network,
+                )
             }
             DescriptorTemplate::Custom => {
-                view::editor::template::custom::custom_template_description(progress)
+                view::editor::template::custom::custom_template_description(progress, network)
             }
         }
     }

--- a/liana-gui/src/installer/step/descriptor/mod.rs
+++ b/liana-gui/src/installer/step/descriptor/mod.rs
@@ -37,6 +37,7 @@ pub struct ImportDescriptor {
     imported_descriptor: form::Value<String>,
     imported_backup: Option<Backup>,
     imported_aliases: Option<HashMap<Fingerprint, KeySetting>>,
+    paste_descriptor_expanded: bool,
 }
 
 impl ImportDescriptor {
@@ -49,6 +50,7 @@ impl ImportDescriptor {
             modal: ImportDescriptorModal::None,
             imported_backup: None,
             imported_aliases: None,
+            paste_descriptor_expanded: false,
         }
     }
 
@@ -101,6 +103,12 @@ impl Step for ImportDescriptor {
                 }
                 self.imported_descriptor.value = desc;
                 self.check_descriptor(self.network);
+                None
+            }
+            Message::DefineDescriptor(message::DefineDescriptor::ShowImportDescriptor(
+                expanded,
+            )) => {
+                self.paste_descriptor_expanded = expanded;
                 None
             }
             Message::ImportBackup => {
@@ -237,6 +245,7 @@ impl Step for ImportDescriptor {
             self.imported_backup.is_some(),
             self.wrong_network,
             self.error.as_ref(),
+            self.paste_descriptor_expanded,
         );
         self.modal.view(content)
     }

--- a/liana-gui/src/installer/step/descriptor/mod.rs
+++ b/liana-gui/src/installer/step/descriptor/mod.rs
@@ -420,6 +420,7 @@ pub struct BackupDescriptor {
     modal: Option<ExportModal>,
     error: Option<Error>,
     context: Option<Context>,
+    help_open: bool,
 }
 
 impl Step for BackupDescriptor {
@@ -479,6 +480,9 @@ impl Step for BackupDescriptor {
             Message::UserActionDone(done) => {
                 self.done = done;
             }
+            Message::ShowBackupDescriptorHelp(open) => {
+                self.help_open = open;
+            }
             _ => {}
         }
         Task::none()
@@ -508,6 +512,7 @@ impl Step for BackupDescriptor {
             &self.keys,
             self.error.as_ref(),
             self.done,
+            self.help_open,
         );
         if let Some(modal) = &self.modal {
             modal.view(content)

--- a/liana-gui/src/installer/step/descriptor/mod.rs
+++ b/liana-gui/src/installer/step/descriptor/mod.rs
@@ -226,10 +226,12 @@ impl Step for ImportDescriptor {
         &'a self,
         _hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         email: Option<&'a str>,
     ) -> Element<'a, Message> {
         let content = view::import_descriptor(
             progress,
+            network,
             email,
             &self.imported_descriptor,
             self.imported_backup.is_some(),
@@ -374,12 +376,14 @@ impl Step for RegisterDescriptor {
         &'a self,
         hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         email: Option<&'a str>,
     ) -> Element<'a, Message> {
         let desc = self.descriptor.as_ref().unwrap();
 
         view::register_descriptor(
             progress,
+            network,
             email,
             desc,
             &hws.list,
@@ -503,10 +507,12 @@ impl Step for BackupDescriptor {
         &'a self,
         _hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         email: Option<&'a str>,
     ) -> Element<'a, Message> {
         let content = view::backup_descriptor(
             progress,
+            network,
             email,
             self.descriptor.as_ref().expect("Must be a descriptor"),
             &self.keys,

--- a/liana-gui/src/installer/step/mnemonic.rs
+++ b/liana-gui/src/installer/step/mnemonic.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use iced::Task;
-use liana::{bip39, signer::HotSigner};
+use liana::{bip39, miniscript::bitcoin::Network, signer::HotSigner};
 
 use liana_ui::widget::Element;
 
@@ -55,9 +55,10 @@ impl Step for BackupMnemonic {
         &'a self,
         _hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         email: Option<&'a str>,
     ) -> Element<'a, Message> {
-        view::backup_mnemonic(progress, email, &self.words, self.done)
+        view::backup_mnemonic(progress, network, email, &self.words, self.done)
     }
 }
 
@@ -172,10 +173,12 @@ impl Step for RecoverMnemonic {
         &'a self,
         _hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         email: Option<&'a str>,
     ) -> Element<'a, Message> {
         view::recover_mnemonic(
             progress,
+            network,
             email,
             &self.words,
             self.current,

--- a/liana-gui/src/installer/step/mnemonic.rs
+++ b/liana-gui/src/installer/step/mnemonic.rs
@@ -97,7 +97,7 @@ impl Step for RecoverMnemonic {
         match message {
             Message::MnemonicWord(index, value) => {
                 if let Some((word, valid)) = self.words.get_mut(index) {
-                    if value.len() >= 3 {
+                    if value.len() > 1 {
                         let suggestions = self.language.words_by_prefix(&value);
                         if suggestions.contains(&value.as_ref()) {
                             *valid = true;

--- a/liana-gui/src/installer/step/mod.rs
+++ b/liana-gui/src/installer/step/mod.rs
@@ -51,6 +51,7 @@ pub trait Step {
         &'a self,
         _hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         email: Option<&'a str>,
     ) -> Element<'a, Message>;
 
@@ -189,10 +190,12 @@ impl Step for Final {
         &'a self,
         _hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         email: Option<&'a str>,
     ) -> Element<'a, Message> {
         view::install(
             progress,
+            network,
             email,
             self.generating,
             self.wallet_settings.is_some(),

--- a/liana-gui/src/installer/step/node/bitcoind.rs
+++ b/liana-gui/src/installer/step/node/bitcoind.rs
@@ -332,9 +332,10 @@ impl Step for SelectBitcoindTypeStep {
         &self,
         _hws: &HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         _email: Option<&str>,
     ) -> Element<'_, Message> {
-        view::select_bitcoind_type(progress)
+        view::select_bitcoind_type(progress, network)
     }
 }
 
@@ -780,10 +781,12 @@ impl Step for InternalBitcoindStep {
         &self,
         _hws: &HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         _email: Option<&str>,
     ) -> Element<'_, Message> {
         view::start_internal_bitcoind(
             progress,
+            network,
             self.exe_path.as_ref(),
             self.started.as_ref(),
             self.error.as_ref(),

--- a/liana-gui/src/installer/step/node/mod.rs
+++ b/liana-gui/src/installer/step/node/mod.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 
 use iced::Task;
+use liana::miniscript::bitcoin::Network;
 use liana_ui::widget::Element;
 
 #[derive(Clone)]
@@ -229,11 +230,13 @@ impl Step for DefineNode {
         &self,
         _hws: &HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         _email: Option<&str>,
     ) -> Element<'_, Message> {
         // TODO: Make input fields read-only while waiting for a ping result.
         view::define_bitcoin_node(
             progress,
+            network,
             self.nodes.iter().map(|node| node.definition.node_type()),
             self.selected_node_type,
             self.selected().definition.view(),

--- a/liana-gui/src/installer/step/share_xpubs.rs
+++ b/liana-gui/src/installer/step/share_xpubs.rs
@@ -205,9 +205,11 @@ impl Step for ShareXpubs {
         &'a self,
         hws: &'a HardwareWallets,
         _progress: (usize, usize),
+        network: Network,
         email: Option<&'a str>,
     ) -> Element<'a, Message> {
         let content = view::share_xpubs(
+            network,
             email,
             hws.list
                 .iter()

--- a/liana-gui/src/installer/step/wallet_alias.rs
+++ b/liana-gui/src/installer/step/wallet_alias.rs
@@ -57,9 +57,10 @@ impl Step for WalletAlias {
         &'a self,
         _hws: &'a HardwareWallets,
         progress: (usize, usize),
+        network: Network,
         email: Option<&'a str>,
     ) -> Element<'a, Message> {
-        view::wallet_alias(progress, email, &self.wallet_alias)
+        view::wallet_alias(progress, network, email, &self.wallet_alias)
     }
 
     fn apply(&mut self, ctx: &mut Context) -> bool {

--- a/liana-gui/src/installer/view/editor/mod.rs
+++ b/liana-gui/src/installer/view/editor/mod.rs
@@ -2,9 +2,10 @@
 
 pub mod template;
 
-use iced::widget::{container, slider, Button, Space};
+use iced::widget::{container, slider, Space};
 use iced::{alignment, Alignment, Length};
 
+use liana_ui::component::button::{btn_edit, btn_remove, btn_set};
 use liana_ui::component::text::{p1_bold, p2_regular, H3_SIZE};
 use std::borrow::Cow;
 use std::fmt::Display;
@@ -171,6 +172,8 @@ pub fn defined_key<'a>(
     warning: Option<&'static str>,
     fixed: bool,
 ) -> Element<'a, message::DefineKey> {
+    let delete_button = (!fixed).then_some(btn_remove(Some(message::DefineKey::Delete)));
+    let edit_button = btn_edit(Some(message::DefineKey::EditAlias));
     card::simple(
         Row::new()
             .spacing(10)
@@ -194,20 +197,8 @@ pub fn defined_key<'a>(
             } else {
                 None
             })
-            .push(
-                button::secondary(Some(icon::pencil_icon()), "Edit")
-                    .on_press(message::DefineKey::EditAlias),
-            )
-            .push_maybe(if fixed {
-                None
-            } else {
-                Some(
-                    Button::new(icon::trash_icon())
-                        .style(theme::button::secondary)
-                        .padding(5)
-                        .on_press(message::DefineKey::Delete),
-                )
-            }),
+            .push(edit_button)
+            .push_maybe(delete_button),
     )
     .into()
 }
@@ -218,6 +209,8 @@ pub fn undefined_key<'a>(
     active: bool,
     fixed: bool,
 ) -> Element<'a, message::DefineKey> {
+    let delete_button = (!fixed).then_some(btn_remove(Some(message::DefineKey::Delete)));
+    let set_button = active.then_some(btn_set(Some(message::DefineKey::Edit)));
     card::simple(
         Row::new()
             .spacing(10)
@@ -230,24 +223,8 @@ pub fn undefined_key<'a>(
                     .spacing(5)
                     .push(p1_bold(title)),
             )
-            .push_maybe(if active {
-                Some(
-                    button::primary(Some(icon::pencil_icon()), "Set")
-                        .on_press(message::DefineKey::Edit),
-                )
-            } else {
-                None
-            })
-            .push_maybe(if fixed {
-                None
-            } else {
-                Some(
-                    Button::new(icon::trash_icon())
-                        .style(theme::button::secondary)
-                        .padding(5)
-                        .on_press(message::DefineKey::Delete),
-                )
-            }),
+            .push_maybe(set_button)
+            .push_maybe(delete_button),
     )
     .into()
 }

--- a/liana-gui/src/installer/view/editor/template/custom.rs
+++ b/liana-gui/src/installer/view/editor/template/custom.rs
@@ -3,12 +3,13 @@ use iced::{
     widget::{row, Container, Space},
     Alignment, Length,
 };
+use liana::miniscript::bitcoin::Network;
 
 use liana_ui::{
     color,
     component::{
         button::{btn_add_recovery_option, btn_add_safety_net, btn_next},
-        text::{h3, p1_regular},
+        text::new,
     },
     image, theme,
     widget::*,
@@ -23,23 +24,26 @@ use crate::installer::{
     },
 };
 
-pub fn custom_template_description(progress: (usize, usize)) -> Element<'static, Message> {
+pub fn custom_template_description(
+    progress: (usize, usize),
+    network: Network,
+) -> Element<'static, Message> {
     let row_next = row![Space::fill_width(), btn_next(Some(Message::Next))];
     layout(
         progress,
+        network,
         None,
         "Introduction",
         Column::new()
             .align_x(Alignment::Start)
-            .push(h3("Build your own"))
-            .max_width(800.0)
+            .push(new::b1_bold("Build your own"))
             .push(Container::new(
-                p1_regular("For this setup you will need to define your primary and recovery spending policies. For security reasons, we suggest you use a separate Hardware Wallet for each key belonging to them.")
+                new::caption("For this setup you will need to define your primary and recovery spending policies. For security reasons, we suggest you use a separate Hardware Wallet for each key belonging to them.")
                 .style(theme::text::secondary)
                 .align_x(alignment::Horizontal::Left)
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
             .push(Container::new(
-                p1_regular("The keys belonging to your primary policy can always spend. Those belonging to the recovery policies will be able to spend only after a defined time of wallet inactivity, allowing for secure recovery and advanced spending policies.")
+                new::caption("The keys belonging to your primary policy can always spend. Those belonging to the recovery policies will be able to spend only after a defined time of wallet inactivity, allowing for secure recovery and advanced spending policies.")
                 .style(theme::text::secondary)
                 .align_x(alignment::Horizontal::Left)
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
@@ -47,7 +51,6 @@ pub fn custom_template_description(progress: (usize, usize)) -> Element<'static,
             .push(row_next)
             .push(Space::with_height(50.0))
             .spacing(20),
-        true,
         Some(Message::Previous),
     )
 }
@@ -55,6 +58,7 @@ pub fn custom_template_description(progress: (usize, usize)) -> Element<'static,
 #[allow(clippy::too_many_arguments)]
 pub fn custom_template<'a>(
     progress: (usize, usize),
+    network: Network,
     use_taproot: bool,
     primary_path: &'a Path,
     recovery_paths: &mut dyn Iterator<Item = (usize, &'a Path)>,
@@ -224,11 +228,11 @@ pub fn custom_template<'a>(
 
     layout(
         progress,
+        network,
         None,
         "Set keys",
         Column::new()
             .align_x(Alignment::Start)
-            .max_width(super::MAX_WIDTH)
             .push(advanced_settings)
             .push(primary)
             .push(recovery_paths)
@@ -238,7 +242,6 @@ pub fn custom_template<'a>(
             .push(last_btn_row)
             .push(Space::with_height(super::BOTTOM_PADDING))
             .spacing(20),
-        true,
         Some(Message::Previous),
     )
 }

--- a/liana-gui/src/installer/view/editor/template/custom.rs
+++ b/liana-gui/src/installer/view/editor/template/custom.rs
@@ -24,6 +24,7 @@ use crate::installer::{
 };
 
 pub fn custom_template_description(progress: (usize, usize)) -> Element<'static, Message> {
+    let row_next = row![Space::fill_width(), btn_next(Some(Message::Next))];
     layout(
         progress,
         None,
@@ -43,7 +44,7 @@ pub fn custom_template_description(progress: (usize, usize)) -> Element<'static,
                 .align_x(alignment::Horizontal::Left)
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
             .push(image::custom_template_description().width(Length::Fill))
-            .push(row![Space::fill_width(), btn_next(Some(Message::Next))])
+            .push(row_next)
             .push(Space::with_height(50.0))
             .spacing(20),
         true,

--- a/liana-gui/src/installer/view/editor/template/custom.rs
+++ b/liana-gui/src/installer/view/editor/template/custom.rs
@@ -1,16 +1,16 @@
 use iced::{
     alignment,
-    widget::{tooltip, Container, Space},
+    widget::{row, Container, Space},
     Alignment, Length,
 };
 
 use liana_ui::{
     color,
     component::{
-        button::{self, BtnWidth},
-        text::{h3, p1_regular, text},
+        button::{btn_add_recovery_option, btn_add_safety_net, btn_next},
+        text::{h3, p1_regular},
     },
-    icon, image, theme,
+    image, theme,
     widget::*,
 };
 
@@ -22,8 +22,6 @@ use crate::installer::{
         layout,
     },
 };
-
-const SAFETY_NET_DESCRIPTION: &str = "This adds a final recovery option containing keys from professional key agents.\n\nUse this option if you have been provided one or more Safety Net tokens.";
 
 pub fn custom_template_description(progress: (usize, usize)) -> Element<'static, Message> {
     layout(
@@ -45,7 +43,7 @@ pub fn custom_template_description(progress: (usize, usize)) -> Element<'static,
                 .align_x(alignment::Horizontal::Left)
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
             .push(image::custom_template_description().width(Length::Fill))
-            .push(Row::new().push(Space::with_width(Length::Fill)).push(button::primary(None, "Next").width(Length::Fixed(200.0)).on_press(Message::Next)))
+            .push(row![Space::fill_width(), btn_next(Some(Message::Next))])
             .push(Space::with_height(50.0))
             .spacing(20),
         true,
@@ -159,27 +157,20 @@ pub fn custom_template<'a>(
         },
     );
 
+    let add_recov_option = Some(Message::DefineDescriptor(
+        message::DefineDescriptor::AddRecoveryPath,
+    ));
+
+    let safety_net =
+        safety_net_path
+            .is_none()
+            .then_some(btn_add_safety_net(Some(Message::DefineDescriptor(
+                message::DefineDescriptor::AddSafetyNetPath,
+            ))));
+
     let btn_row = Row::new()
-        .push(
-            button::secondary(Some(icon::plus_icon()), "Add recovery option")
-                .width(BtnWidth::XXL)
-                .on_press(Message::DefineDescriptor(
-                    message::DefineDescriptor::AddRecoveryPath,
-                )),
-        )
-        .push_maybe(
-            safety_net_path.is_none().then_some(tooltip::Tooltip::new(
-                button::secondary(Some(icon::plus_icon()), "Add Safety Net")
-                    .width(210)
-                    .on_press(Message::DefineDescriptor(
-                        message::DefineDescriptor::AddSafetyNetPath,
-                    )),
-                Container::new(text(SAFETY_NET_DESCRIPTION))
-                    .style(theme::card::simple)
-                    .padding(10),
-                tooltip::Position::Bottom,
-            )),
-        )
+        .push(btn_add_recovery_option(add_recov_option))
+        .push_maybe(safety_net)
         .spacing(10);
 
     let safety_net = safety_net_path.map(|(sn_index, sn_path)| {

--- a/liana-gui/src/installer/view/editor/template/inheritance.rs
+++ b/liana-gui/src/installer/view/editor/template/inheritance.rs
@@ -1,9 +1,13 @@
-use iced::{alignment, widget::Space, Alignment, Length};
+use iced::{
+    alignment,
+    widget::{row, Space},
+    Alignment, Length,
+};
 
 use liana_ui::{
     color,
     component::{
-        button,
+        button::btn_next,
         text::{h3, p1_regular, Text, H3_SIZE},
     },
     icon, image, theme,
@@ -55,7 +59,7 @@ After a period of inactivity (but not before that) your Inheritance Key will bec
                 .align_x(alignment::Horizontal::Left)
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
             .push(image::inheritance_template_description().width(Length::Fill))
-            .push(Row::new().push(Space::with_width(Length::Fill)).push(button::primary(None, "Next").width(Length::Fixed(200.0)).on_press(Message::Next)))
+            .push(row![Space::fill_width(), btn_next(Some(Message::Next))])
             .push(Space::with_height(50.0))
             .spacing(20),
         true,

--- a/liana-gui/src/installer/view/editor/template/inheritance.rs
+++ b/liana-gui/src/installer/view/editor/template/inheritance.rs
@@ -24,6 +24,7 @@ use crate::installer::{
 };
 
 pub fn inheritance_template_description(progress: (usize, usize)) -> Element<'static, Message> {
+    let row_next = row![Space::fill_width(), btn_next(Some(Message::Next))];
     layout(
         progress,
         None,
@@ -59,7 +60,7 @@ After a period of inactivity (but not before that) your Inheritance Key will bec
                 .align_x(alignment::Horizontal::Left)
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
             .push(image::inheritance_template_description().width(Length::Fill))
-            .push(row![Space::fill_width(), btn_next(Some(Message::Next))])
+            .push(row_next)
             .push(Space::with_height(50.0))
             .spacing(20),
         true,

--- a/liana-gui/src/installer/view/editor/template/inheritance.rs
+++ b/liana-gui/src/installer/view/editor/template/inheritance.rs
@@ -3,12 +3,13 @@ use iced::{
     widget::{row, Space},
     Alignment, Length,
 };
+use liana::miniscript::bitcoin::Network;
 
 use liana_ui::{
     color,
     component::{
         button::btn_next,
-        text::{h3, p1_regular, Text, H3_SIZE},
+        text::{new, H3_SIZE},
     },
     icon, image, theme,
     widget::*,
@@ -23,18 +24,21 @@ use crate::installer::{
     },
 };
 
-pub fn inheritance_template_description(progress: (usize, usize)) -> Element<'static, Message> {
+pub fn inheritance_template_description(
+    progress: (usize, usize),
+    network: Network,
+) -> Element<'static, Message> {
     let row_next = row![Space::fill_width(), btn_next(Some(Message::Next))];
     layout(
         progress,
+        network,
         None,
         "Introduction",
         Column::new()
             .align_x(Alignment::Start)
-            .push(h3("Simple inheritance wallet"))
-            .max_width(800.0)
+            .push(new::b1_bold("Simple inheritance wallet"))
             .push(Container::new(
-                p1_regular("For this setup you will need 2 Keys: Your Primary Key (for yourself) and an Inheritance Key (for your heir). For security reasons, we suggest you use a separate Hardware Wallet for each key.")
+                new::caption("For this setup you will need 2 Keys: Your Primary Key (for yourself) and an Inheritance Key (for your heir). For security reasons, we suggest you use a separate Hardware Wallet for each key.")
                 .style(theme::text::secondary)
                 .align_x(alignment::Horizontal::Left)
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
@@ -45,16 +49,16 @@ pub fn inheritance_template_description(progress: (usize, usize)) -> Element<'st
                     .align_y(Alignment::Center)
                     .spacing(10)
                     .push(icon::round_key_icon().size(H3_SIZE).color(color::GREEN))
-                    .push(p1_regular("Primary key").bold())
+                    .push(new::b5_bold("Primary key"))
                 ).push(
                     Row::new()
                         .align_y(Alignment::Center)
                         .spacing(10)
                         .push(icon::round_key_icon().size(H3_SIZE).color(color::WHITE))
-                        .push(p1_regular("Inheritance key").bold())
+                        .push(new::b5_bold("Inheritance key"))
             ))
             .push(Container::new(
-                p1_regular("You will always be able to spend using your Primary Key.
+                new::caption("You will always be able to spend using your Primary Key.
 After a period of inactivity (but not before that) your Inheritance Key will become able to recover your funds.")
                 .style(theme::text::secondary)
                 .align_x(alignment::Horizontal::Left)
@@ -63,13 +67,13 @@ After a period of inactivity (but not before that) your Inheritance Key will bec
             .push(row_next)
             .push(Space::with_height(50.0))
             .spacing(20),
-        true,
         Some(Message::Previous),
     )
 }
 
 pub fn inheritance_template<'a>(
     progress: (usize, usize),
+    network: Network,
     use_taproot: bool,
     primary_path: &'a Path,
     recovery_path: &'a Path,
@@ -140,11 +144,11 @@ pub fn inheritance_template<'a>(
 
     layout(
         progress,
+        network,
         None,
         "Set keys",
         Column::new()
             .align_x(Alignment::Start)
-            .max_width(super::MAX_WIDTH)
             .push(advanced_settings)
             .push(primary)
             .push(recovery)
@@ -152,7 +156,6 @@ pub fn inheritance_template<'a>(
             .push(footer)
             .push(Space::with_height(super::BOTTOM_PADDING))
             .spacing(20),
-        true,
         Some(Message::Previous),
     )
 }

--- a/liana-gui/src/installer/view/editor/template/mod.rs
+++ b/liana-gui/src/installer/view/editor/template/mod.rs
@@ -10,7 +10,7 @@ use iced::{
 use liana_ui::{
     component::{
         button::{self, btn_clear_all, btn_customize, btn_next},
-        collapse,
+        collapse, list,
         text::{new, p1_bold},
     },
     icon, theme,
@@ -111,10 +111,12 @@ fn template_option(
     .align_x(Alignment::Start)
     .width(Length::Fill);
 
-    button::list_entry(
+    list::list_entry_chevron(
+        None,
         content,
         None,
-        button::EntryWidth::Fill,
+        None,
+        button::EntryWidth::Standard,
         Some(Message::SelectDescriptorTemplate(template)),
     )
 }

--- a/liana-gui/src/installer/view/editor/template/mod.rs
+++ b/liana-gui/src/installer/view/editor/template/mod.rs
@@ -6,6 +6,7 @@ use iced::{
     widget::{column, row, Space},
     Alignment, Length,
 };
+use liana::miniscript::bitcoin::Network;
 
 use liana_ui::{
     component::{
@@ -22,9 +23,6 @@ use crate::installer::{
     message::{self, Message},
     view::{editor::define_descriptor_advanced_settings, layout},
 };
-
-/// Max width of the editor templates' main content column.
-pub const MAX_WIDTH: f32 = 1000.0;
 
 /// Bottom padding below the footer of the editor templates.
 pub const BOTTOM_PADDING: f32 = 100.0;
@@ -68,7 +66,7 @@ pub fn template_footer<'a>(valid: bool, processing: bool, customize: bool) -> Ro
         .push(next)
 }
 
-pub fn choose_descriptor_template(progress: (usize, usize)) -> Element<'static, Message> {
+pub fn choose_descriptor_template(network: Network) -> Element<'static, Message> {
     let simple_inheritance = template_option(
         "Simple inheritance",
         "Two keys required, one for yourself to spend and another for your heir.",
@@ -85,16 +83,16 @@ pub fn choose_descriptor_template(progress: (usize, usize)) -> Element<'static, 
         context::DescriptorTemplate::Custom,
     );
     let content = column![simple_inheritance, expanding_multisig, custom,]
-        .max_width(800.0)
-        .align_x(Alignment::Start)
+        .align_x(Alignment::Center)
+        .width(Length::Fill)
         .spacing(20);
 
     layout(
-        progress,
+        (0, 0),
+        network,
         None,
         "Choose wallet type",
         content,
-        true,
         Some(Message::Previous),
     )
 }

--- a/liana-gui/src/installer/view/editor/template/mod.rs
+++ b/liana-gui/src/installer/view/editor/template/mod.rs
@@ -3,15 +3,15 @@ pub mod inheritance;
 pub mod multisig_security_wallet;
 
 use iced::{
-    widget::{row, Space},
+    widget::{column, row, Space},
     Alignment, Length,
 };
 
 use liana_ui::{
     component::{
-        button::{btn_clear_all, btn_customize, btn_next},
+        button::{self, btn_clear_all, btn_customize, btn_next},
         collapse,
-        text::{h3, p1_bold, p2_regular},
+        text::{new, p1_bold},
     },
     icon, theme,
     widget::*,
@@ -69,63 +69,52 @@ pub fn template_footer<'a>(valid: bool, processing: bool, customize: bool) -> Ro
 }
 
 pub fn choose_descriptor_template(progress: (usize, usize)) -> Element<'static, Message> {
+    let simple_inheritance = template_option(
+        "Simple inheritance",
+        "Two keys required, one for yourself to spend and another for your heir.",
+        context::DescriptorTemplate::SimpleInheritance,
+    );
+    let expanding_multisig = template_option(
+        "Expanding multisig",
+        "Two keys required to spend, with an extra key as a backup.",
+        context::DescriptorTemplate::MultisigSecurity,
+    );
+    let custom = template_option(
+        "Build your own",
+        "Create a custom setup that fits all your needs.",
+        context::DescriptorTemplate::Custom,
+    );
+    let content = column![simple_inheritance, expanding_multisig, custom,]
+        .max_width(800.0)
+        .align_x(Alignment::Start)
+        .spacing(20);
+
     layout(
         progress,
         None,
         "Choose wallet type",
-        Column::new()
-            .max_width(800.0)
-            .align_x(Alignment::Start)
-            .push(
-                Button::new(
-                    Column::new()
-                        .align_x(Alignment::Start)
-                        .push(h3("Simple inheritance"))
-                        .push(p2_regular("Two keys required, one for yourself to spend and another for your heir.").style(theme::text::secondary))
-                        .width(Length::Fill)
-                )
-                .padding(15)
-                .on_press(
-                        Message::SelectDescriptorTemplate(
-                            context::DescriptorTemplate::SimpleInheritance,
-                        )
-                ).style(theme::button::secondary)
-                .width(Length::Fill),
-            )
-            .push(
-                Button::new(
-                    Column::new()
-                        .align_x(Alignment::Start)
-                        .push(h3("Expanding multisig"))
-                        .push(p2_regular("Two keys required to spend, with an extra key as a backup.").style(theme::text::secondary))
-                        .width(Length::Fill)
-                )
-                .padding(15)
-                .on_press(
-                        Message::SelectDescriptorTemplate(
-                            context::DescriptorTemplate::MultisigSecurity,
-                        )
-                ).style(theme::button::secondary)
-                .width(Length::Fill),
-            )
-            .push(
-                Button::new(
-                    Column::new()
-                        .align_x(Alignment::Start)
-                        .push(h3("Build your own"))
-                        .push(p2_regular("Create a custom setup that fits all your needs.").style(theme::text::secondary))
-                        .width(Length::Fill)
-                )
-                .padding(15)
-                .on_press(
-                        Message::SelectDescriptorTemplate(
-                            context::DescriptorTemplate::Custom,
-                        )
-                ).style(theme::button::secondary)
-                .width(Length::Fill),
-            )
-            .spacing(20),
+        content,
         true,
         Some(Message::Previous),
+    )
+}
+
+fn template_option(
+    title: &'static str,
+    description: &'static str,
+    template: context::DescriptorTemplate,
+) -> Element<'static, Message> {
+    let content = column![
+        new::b1_bold(title),
+        new::caption(description).style(theme::text::secondary),
+    ]
+    .align_x(Alignment::Start)
+    .width(Length::Fill);
+
+    button::list_entry(
+        content,
+        None,
+        button::EntryWidth::Fill,
+        Some(Message::SelectDescriptorTemplate(template)),
     )
 }

--- a/liana-gui/src/installer/view/editor/template/mod.rs
+++ b/liana-gui/src/installer/view/editor/template/mod.rs
@@ -9,7 +9,7 @@ use iced::{
 
 use liana_ui::{
     component::{
-        button::{self, btn_clear_all, btn_customize},
+        button::{btn_clear_all, btn_customize, btn_next},
         collapse,
         text::{h3, p1_bold, p2_regular},
     },
@@ -60,19 +60,12 @@ pub fn template_footer<'a>(valid: bool, processing: bool, customize: bool) -> Ro
     ))));
 
     let msg = (!processing & valid).then_some(Message::Next);
-    let msg_label = if processing {
-        "Processing..."
-    } else {
-        "Continue"
-    };
-    let contin = button::primary(None, msg_label)
-        .width(210)
-        .on_press_maybe(msg);
+    let next = btn_next(msg);
 
     row![clear_all, Space::with_width(40)]
         .push_maybe(customize)
         .push(Space::fill_width())
-        .push(contin)
+        .push(next)
 }
 
 pub fn choose_descriptor_template(progress: (usize, usize)) -> Element<'static, Message> {

--- a/liana-gui/src/installer/view/editor/template/multisig_security_wallet.rs
+++ b/liana-gui/src/installer/view/editor/template/multisig_security_wallet.rs
@@ -3,12 +3,13 @@ use iced::{
     widget::{row, Space},
     Alignment, Length,
 };
+use liana::miniscript::bitcoin::Network;
 
 use liana_ui::{
     color,
     component::{
         button::btn_next,
-        text::{h3, p1_regular, Text, H3_SIZE},
+        text::{new, H3_SIZE},
     },
     icon, image, theme,
     widget::*,
@@ -25,18 +26,19 @@ use crate::installer::{
 
 pub fn multisig_security_template_description(
     progress: (usize, usize),
+    network: Network,
 ) -> Element<'static, Message> {
     let row_next = row![Space::fill_width(), btn_next(Some(Message::Next))];
     layout(
         progress,
+        network,
         None,
         "Introduction",
         Column::new()
             .align_x(Alignment::Start)
-            .push(h3("Expanding multisig wallet"))
-            .max_width(800.0)
+            .push(new::b1_bold("Expanding multisig wallet"))
             .push(Container::new(
-                p1_regular("For this setup you will need 3 keys: two Primary Keys and a Recovery Key. For security reasons, we suggest you use a separate Hardware Wallet for each key.")
+                new::caption("For this setup you will need 3 keys: two Primary Keys and a Recovery Key. For security reasons, we suggest you use a separate Hardware Wallet for each key.")
                 .style(theme::text::secondary)
                 .align_x(alignment::Horizontal::Left)
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
@@ -47,22 +49,22 @@ pub fn multisig_security_template_description(
                     .align_y(Alignment::Center)
                     .spacing(10)
                     .push(icon::round_key_icon().size(H3_SIZE).style(theme::text::success))
-                    .push(p1_regular("Primary key #1").bold())
+                    .push(new::b5_bold("Primary key #1"))
                 ).push(
                     Row::new()
                     .align_y(Alignment::Center)
                     .spacing(10)
                     .push(icon::round_key_icon().size(H3_SIZE).style(theme::text::success))
-                    .push(p1_regular("Primary key #2").bold())
+                    .push(new::b5_bold("Primary key #2"))
                 ).push(
                     Row::new()
                         .align_y(Alignment::Center)
                         .spacing(10)
                         .push(icon::round_key_icon().size(H3_SIZE).style(theme::text::success))
-                        .push(p1_regular("Recovery key").bold())
+                        .push(new::b5_bold("Recovery key"))
             ))
             .push(Container::new(
-                p1_regular("The Primary Keys will compose a 2-of-2 multisig which will always be able to spend. In case one of your keys becomes unavailable, after a period of inactivity you will be able to recover your funds using the Recovery Key together with one of your Primary Keys (2-of-3 multisig):")
+                new::caption("The Primary Keys will compose a 2-of-2 multisig which will always be able to spend. In case one of your keys becomes unavailable, after a period of inactivity you will be able to recover your funds using the Recovery Key together with one of your Primary Keys (2-of-3 multisig):")
                 .style(theme::text::secondary)
                 .align_x(alignment::Horizontal::Left)
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
@@ -70,13 +72,13 @@ pub fn multisig_security_template_description(
             .push(row_next)
             .push(Space::with_height(50.0))
             .spacing(20),
-        true,
         Some(Message::Previous),
     )
 }
 
 pub fn multisig_security_template<'a>(
     progress: (usize, usize),
+    network: Network,
     use_taproot: bool,
     primary_path: &'a Path,
     recovery_path: &'a Path,
@@ -204,11 +206,11 @@ pub fn multisig_security_template<'a>(
 
     layout(
         progress,
+        network,
         None,
         "Set keys",
         Column::new()
             .align_x(Alignment::Start)
-            .max_width(super::MAX_WIDTH)
             .push(advanced_settings)
             .push(primary)
             .push(recovery)
@@ -216,7 +218,6 @@ pub fn multisig_security_template<'a>(
             .push(footer)
             .push(Space::with_height(super::BOTTOM_PADDING))
             .spacing(20),
-        true,
         Some(Message::Previous),
     )
 }

--- a/liana-gui/src/installer/view/editor/template/multisig_security_wallet.rs
+++ b/liana-gui/src/installer/view/editor/template/multisig_security_wallet.rs
@@ -1,9 +1,13 @@
-use iced::{alignment, widget::Space, Alignment, Length};
+use iced::{
+    alignment,
+    widget::{row, Space},
+    Alignment, Length,
+};
 
 use liana_ui::{
     color,
     component::{
-        button,
+        button::btn_next,
         text::{h3, p1_regular, Text, H3_SIZE},
     },
     icon, image, theme,
@@ -62,7 +66,7 @@ pub fn multisig_security_template_description(
                 .align_x(alignment::Horizontal::Left)
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
             .push(image::multisig_security_template_description().width(Length::Fill))
-            .push(Row::new().push(Space::with_width(Length::Fill)).push(button::primary(None, "Next").width(Length::Fixed(200.0)).on_press(Message::Next)))
+            .push(row![Space::fill_width(), btn_next(Some(Message::Next))])
             .push(Space::with_height(50.0))
             .spacing(20),
         true,

--- a/liana-gui/src/installer/view/editor/template/multisig_security_wallet.rs
+++ b/liana-gui/src/installer/view/editor/template/multisig_security_wallet.rs
@@ -26,6 +26,7 @@ use crate::installer::{
 pub fn multisig_security_template_description(
     progress: (usize, usize),
 ) -> Element<'static, Message> {
+    let row_next = row![Space::fill_width(), btn_next(Some(Message::Next))];
     layout(
         progress,
         None,
@@ -66,7 +67,7 @@ pub fn multisig_security_template_description(
                 .align_x(alignment::Horizontal::Left)
             ).align_x(alignment::Horizontal::Left).width(Length::Fill))
             .push(image::multisig_security_template_description().width(Length::Fill))
-            .push(row![Space::fill_width(), btn_next(Some(Message::Next))])
+            .push(row_next)
             .push(Space::with_height(50.0))
             .spacing(20),
         true,

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -1449,38 +1449,32 @@ pub fn backup_mnemonic<'a>(
     words: &'a [&'static str; 12],
     done: bool,
 ) -> Element<'a, Message> {
-    let msg_next = done.then_some(Message::Next);
+    let words = words
+        .iter()
+        .enumerate()
+        .fold(column![].spacing(5), |words, (i, word)| {
+            let number = Container::new(new::caption(format!("#{}", i + 1))).width(50);
+            words.push(row![number, new::b5_bold(*word)].align_y(Alignment::End))
+        });
+    let backed_up = checkbox(done)
+        .label("I have backed up my mnemonic")
+        .on_toggle(Message::UserActionDone);
+    let button_next = row![Space::fill_width(), btn_next(done.then_some(Message::Next))];
+    let content = column![
+        new::caption(prompt::MNEMONIC_HELP),
+        words,
+        backed_up,
+        button_next,
+        Space::with_height(20),
+    ]
+    .spacing(50);
+
     layout(
         progress,
         network,
         email,
         "Back Up your mnemonic",
-        Column::new()
-            .push(text(prompt::MNEMONIC_HELP))
-            .push(
-                words
-                    .iter()
-                    .enumerate()
-                    .fold(Column::new().spacing(5), |acc, (i, w)| {
-                        acc.push(
-                            Row::new()
-                                .align_y(Alignment::End)
-                                .push(
-                                    Container::new(text(format!("#{}", i + 1)).small())
-                                        .width(Length::Fixed(50.0)),
-                                )
-                                .push(text(*w).bold()),
-                        )
-                    }),
-            )
-            .push(
-                checkbox(done)
-                    .label("I have backed up my mnemonic")
-                    .on_toggle(Message::UserActionDone),
-            )
-            .push(btn_next(msg_next))
-            .push(Space::with_height(20.0))
-            .spacing(50),
+        content,
         Some(Message::Previous),
     )
 }

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -1,38 +1,41 @@
 pub mod editor;
 
 use async_hwi::utils::extract_keys_and_template;
-use iced::widget::{checkbox, radio, tooltip, Button, Space, TextInput};
-use iced::widget::{column, row};
 use iced::{
     alignment,
-    widget::{progress_bar, tooltip as iced_tooltip},
+    widget::{checkbox, column, progress_bar, radio, row, tooltip, Button, Space, TextInput},
     Alignment, Length,
 };
 
-use liana::miniscript::bitcoin::bip32::ChildNumber;
-use liana_ui::component::button::{
-    btn_backup_descriptor, btn_check_connection, btn_next, btn_select,
+use std::{
+    collections::{HashMap, HashSet},
+    net::{Ipv4Addr, Ipv6Addr},
+    path::PathBuf,
+    str::FromStr,
 };
-use liana_ui::component::text::{self, p2_regular};
-use std::collections::HashMap;
-use std::net::{Ipv4Addr, Ipv6Addr};
-use std::path::PathBuf;
-use std::{collections::HashSet, str::FromStr};
 
 use liana::{
     descriptors::{LianaDescriptor, LianaPolicy},
-    miniscript::bitcoin::{self, bip32::Fingerprint},
+    miniscript::bitcoin::{
+        self,
+        bip32::{ChildNumber, Fingerprint},
+        Network,
+    },
 };
+
 use liana_ui::{
     component::{
-        button::{self},
-        card, collapse, form,
+        button::{
+            self, btn_backup_descriptor, btn_check_connection, btn_next, btn_select, EntryWidth,
+        },
+        card, collapse, form, installer as installer_layout,
         list::DeviceStatus,
         modal, scrollable, separation,
-        text::{h2, h3, h4_bold, new, p1_bold, p1_regular, text, Text},
+        text::{self, h2, h3, h4_bold, new, p1_bold, p1_regular, text, Text as _},
     },
     icon, theme,
     widget::*,
+    Variant,
 };
 
 use crate::node::electrum::validate_domain_checkbox;
@@ -54,8 +57,10 @@ use crate::{
     },
 };
 
+#[allow(clippy::too_many_arguments)]
 pub fn import_wallet_or_descriptor<'a>(
     progress: (usize, usize),
+    network: Network,
     email: Option<&'a str>,
     invitation: &'a form::Value<String>,
     invitation_wallet: Option<&'a str>,
@@ -208,6 +213,7 @@ pub fn import_wallet_or_descriptor<'a>(
 
     layout(
         progress,
+        network,
         email,
         "Add wallet",
         Column::new()
@@ -217,13 +223,13 @@ pub fn import_wallet_or_descriptor<'a>(
             .push(card::simple(col_invitation_token).padding(0))
             .push(card::simple(col_descriptor).padding(0))
             .push(Space::with_height(10)),
-        true,
         Some(Message::Previous),
     )
 }
 
 pub fn import_descriptor<'a>(
     progress: (usize, usize),
+    network: Network,
     email: Option<&'a str>,
     imported_descriptor: &form::Value<String>,
     imported_backup: bool,
@@ -286,6 +292,7 @@ pub fn import_descriptor<'a>(
 
     layout(
         progress,
+        network,
         email,
         "Import the wallet",
         Column::new()
@@ -308,7 +315,6 @@ pub fn import_descriptor<'a>(
             .push(btn_next(valid.then_some(Message::Next)))
             .push_maybe(error.map(|e| card::error("Invalid descriptor", e.to_string())))
             .spacing(50),
-        true,
         Some(Message::Previous),
     )
 }
@@ -480,6 +486,7 @@ pub fn hardware_wallet_xpubs<'a>(
 }
 
 pub fn share_xpubs<'a>(
+    network: Network,
     email: Option<&'a str>,
     hws: Vec<Element<'a, Message>>,
     signer: Element<'a, Message>,
@@ -500,6 +507,7 @@ pub fn share_xpubs<'a>(
         .push(Space::with_width(Length::Fill));
     layout(
         (0, 0),
+        network,
         email,
         "Share your public keys (Xpubs)",
         column![
@@ -515,7 +523,6 @@ pub fn share_xpubs<'a>(
         ]
         .spacing(10)
         .width(Length::Fill),
-        true,
         Some(Message::Previous),
     )
 }
@@ -544,6 +551,7 @@ pub fn descriptor_view(descriptor_str: String) -> Element<'static, Message> {
 #[allow(clippy::too_many_arguments)]
 pub fn register_descriptor<'a>(
     progress: (usize, usize),
+    network: Network,
     email: Option<&'a str>,
     descriptor: &'a LianaDescriptor,
     hws: &'a [HardwareWallet],
@@ -562,21 +570,22 @@ pub fn register_descriptor<'a>(
             descriptor_view(descriptor_str)
         };
 
-    let warning = (!created_desc)
-        .then_some(text("This step is only necessary if you are using a signing device.").bold());
+    let warning = (!created_desc).then_some(new::b5_bold(
+        "This step is only necessary if you are using a signing device.",
+    ));
     let error_card = error.map(|e| card::error("Failed to register descriptor", e.to_string()));
 
     let devices_title = Container::new(if created_desc {
-        text("Select hardware wallet to register descriptor on:").bold()
+        new::b5_bold("Select hardware wallet to register descriptor on:")
     } else {
-        text("If necessary, please select the signing device to register descriptor on:").bold()
+        new::b5_bold("If necessary, please select the signing device to register descriptor on:")
     })
     .width(Length::Fill);
     let devices: Element<'a, Message> = if hws.is_empty() {
         modal::modal_no_devices_placeholder()
     } else {
         Column::with_children(hws.iter().enumerate().map(|(i, hw)| {
-            crate::view::hw::device_list_entry(
+            let entry = crate::view::hw::device_list_entry(
                 hw,
                 crate::view::hw::HwRowMode::Registration {
                     chosen: Some(i) == chosen_hw,
@@ -589,14 +598,17 @@ pub fn register_descriptor<'a>(
                     device_must_support_taproot: false,
                 },
                 move || Message::Select(i),
-            )
+            );
+            Container::new(entry).width(EntryWidth::Standard).into()
         }))
         .spacing(10)
         .into()
     };
     let signing_devices = column![devices_title, devices]
+        .align_x(Alignment::Center)
         .spacing(10)
-        .width(Length::Fill);
+        .width(EntryWidth::Standard);
+    let signing_devices = Container::new(signing_devices).center_x(Length::Fill);
 
     let registered_checkbox = created_desc.then_some(
         checkbox(done)
@@ -605,33 +617,38 @@ pub fn register_descriptor<'a>(
     );
 
     let next = (!created_desc || (done && !processing)).then_some(Message::Next);
-    let next_button = btn_next(next);
+    let next_button = row![Space::fill_width(), btn_next(next)];
 
-    let content = Column::new()
-        .push_maybe(warning)
-        .push(displayed_descriptor)
-        .push(text(prompt::REGISTER_DESCRIPTOR_HELP))
-        .push_maybe(error_card)
-        .push(signing_devices)
-        .push_maybe(registered_checkbox)
-        .push(next_button)
-        .push(Space::with_height(5))
-        .spacing(50);
+    let help = new::caption(prompt::REGISTER_DESCRIPTOR_HELP);
+
+    let content = column![
+        warning,
+        displayed_descriptor,
+        help,
+        error_card,
+        signing_devices,
+        registered_checkbox,
+        next_button,
+        Space::with_height(5),
+    ]
+    .spacing(20);
 
     let previous = (!processing).then_some(Message::Previous);
 
     layout(
         progress,
+        network,
         email,
         "Register descriptor",
         content,
-        true,
         previous,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn backup_descriptor<'a>(
     progress: (usize, usize),
+    network: Network,
     email: Option<&'a str>,
     descriptor: &'a LianaDescriptor,
     keys: &'a HashMap<Fingerprint, settings::KeySetting>,
@@ -694,15 +711,14 @@ pub fn backup_descriptor<'a>(
         row_next,
         Space::with_height(20),
     ]
-    .max_width(800)
     .spacing(50);
 
     layout(
         progress,
+        network,
         email,
         "Back Up your wallet configuration (Descriptor)",
         content,
-        true,
         Some(Message::Previous),
     )
 }
@@ -716,123 +732,128 @@ fn display_policy(
     let mut primary_keys: Vec<Fingerprint> = primary_keys.into_keys().collect();
     primary_keys.sort();
     let recovery_paths = policy.recovery_paths();
-    let mut col = Column::new().push(
-        Row::new()
-            .spacing(5)
-            .push(
-                text(format!(
-                    "{} signature{}",
-                    primary_threshold,
-                    if primary_threshold > 1 { "s" } else { "" }
-                ))
-                .bold(),
-            )
-            .push(if primary_keys.len() > 1 {
-                text(format!("out of {} by", primary_keys.len()))
-            } else {
-                text("by")
-            })
-            .push(
-                primary_keys
-                    .iter()
-                    .enumerate()
-                    .fold(Row::new().spacing(5), |row, (i, k)| {
-                        let content = if let Some(key) = keys.get(k) {
-                            Container::new(
-                                iced_tooltip::Tooltip::new(
-                                    text(key.name.clone()).bold(),
-                                    text(k.to_string()),
-                                    iced_tooltip::Position::Bottom,
-                                )
-                                .style(theme::card::simple),
-                            )
-                        } else {
-                            Container::new(text(format!("[{k}]")).bold())
-                        };
-                        if primary_keys.len() == 1 || i == primary_keys.len() - 1 {
-                            row.push(content)
-                        } else if i <= primary_keys.len() - 2 {
-                            row.push(content).push(text("and"))
-                        } else {
-                            row.push(content).push(text(","))
-                        }
-                    }),
-            )
-            .push(text("can always spend this wallet's funds (Primary path)")),
-    );
+
+    let primary_signature = new::b5_bold(format!(
+        "{} signature{}",
+        primary_threshold,
+        if primary_threshold > 1 { "s" } else { "" }
+    ));
+    let primary_key_count = if primary_keys.len() > 1 {
+        new::caption(format!("out of {} by", primary_keys.len()))
+    } else {
+        new::caption("by")
+    };
+    let primary_key_list =
+        primary_keys
+            .iter()
+            .enumerate()
+            .fold(Row::new().spacing(5), |row, (i, k)| {
+                let content = if let Some(key) = keys.get(k) {
+                    Container::new(
+                        tooltip::Tooltip::new(
+                            new::b5_bold(key.name.clone()),
+                            new::caption(k.to_string()),
+                            tooltip::Position::Bottom,
+                        )
+                        .style(theme::card::simple),
+                    )
+                } else {
+                    Container::new(new::b5_bold(format!("[{k}]")))
+                };
+                if primary_keys.len() == 1 || i == primary_keys.len() - 1 {
+                    row.push(content)
+                } else if i <= primary_keys.len() - 2 {
+                    row.push(content).push(new::caption("and"))
+                } else {
+                    row.push(content).push(new::caption(","))
+                }
+            });
+    let primary_row = row![
+        primary_signature,
+        primary_key_count,
+        primary_key_list,
+        new::caption("can always spend this wallet's funds (Primary path)"),
+    ]
+    .spacing(5);
+
+    let mut col = column![primary_row];
     for (i, (sequence, recovery_path)) in recovery_paths.iter().enumerate() {
         let (threshold, recovery_keys) = recovery_path.thresh_origins();
         // The iteration over an HashMap keys can have a different order at each refresh
         let mut recovery_keys: Vec<Fingerprint> = recovery_keys.into_keys().collect();
         recovery_keys.sort();
-        col = col.push(
-            Row::new()
-                .spacing(5)
-                .push(
-                    text(format!(
-                        "{} signature{}",
-                        threshold,
-                        if threshold > 1 { "s" } else { "" }
-                    ))
-                    .bold(),
-                )
-                .push(if recovery_keys.len() > 1 {
-                    text(format!("out of {} by", recovery_keys.len()))
-                } else {
-                    text("by")
-                })
-                .push(recovery_keys.iter().enumerate().fold(
-                    Row::new().spacing(5),
-                    |row, (i, k)| {
-                        let content = if let Some(key) = keys.get(k) {
-                            Container::new(
-                                iced_tooltip::Tooltip::new(
-                                    text(key.name.clone()).bold(),
-                                    text(k.to_string()),
-                                    iced_tooltip::Position::Bottom,
-                                )
-                                .style(theme::card::simple),
+
+        let recovery_signature = new::b5_bold(format!(
+            "{} signature{}",
+            threshold,
+            if threshold > 1 { "s" } else { "" }
+        ));
+        let recovery_key_count = if recovery_keys.len() > 1 {
+            new::caption(format!("out of {} by", recovery_keys.len()))
+        } else {
+            new::caption("by")
+        };
+        let recovery_key_list =
+            recovery_keys
+                .iter()
+                .enumerate()
+                .fold(Row::new().spacing(5), |row, (i, k)| {
+                    let content = if let Some(key) = keys.get(k) {
+                        Container::new(
+                            tooltip::Tooltip::new(
+                                new::b5_bold(key.name.clone()),
+                                new::caption(k.to_string()),
+                                tooltip::Position::Bottom,
                             )
-                        } else {
-                            Container::new(text(format!("[{k}]")).bold())
-                        };
-                        if recovery_keys.len() == 1 || i == recovery_keys.len() - 1 {
-                            row.push(content)
-                        } else if i <= recovery_keys.len() - 2 {
-                            row.push(content).push(text("and"))
-                        } else {
-                            row.push(content).push(text(","))
-                        }
-                    },
-                ))
-                .push(text("can spend coins inactive for"))
-                .push(
-                    text(format!(
-                        "{} blocks (~{})",
-                        sequence,
-                        expire_message_units(*sequence as u32).join(",")
-                    ))
-                    .bold(),
-                )
-                .push(text(
-                    // If max timelock and all keys are from provider, then it's a safety net path.
-                    if *sequence == u16::MAX
-                        && recovery_keys
-                            .iter()
-                            .all(|fg| keys.get(fg).is_some_and(|k| k.provider_key.is_some()))
-                    {
-                        "(Safety Net path)".to_string()
+                            .style(theme::card::simple),
+                        )
                     } else {
-                        format!("(Recovery path #{})", i + 1)
-                    },
-                )),
+                        Container::new(new::b5_bold(format!("[{k}]")))
+                    };
+                    if recovery_keys.len() == 1 || i == recovery_keys.len() - 1 {
+                        row.push(content)
+                    } else if i <= recovery_keys.len() - 2 {
+                        row.push(content).push(new::caption("and"))
+                    } else {
+                        row.push(content).push(new::caption(","))
+                    }
+                });
+        let recovery_duration = new::b5_bold(format!(
+            "{} blocks (~{})",
+            sequence,
+            expire_message_units(*sequence as u32).join(",")
+        ));
+        let recovery_kind = new::caption(
+            // If max timelock and all keys are from provider, then it's a safety net path.
+            if *sequence == u16::MAX
+                && recovery_keys
+                    .iter()
+                    .all(|fg| keys.get(fg).is_some_and(|k| k.provider_key.is_some()))
+            {
+                "(Safety Net path)".to_string()
+            } else {
+                format!("(Recovery path #{})", i + 1)
+            },
         );
+        let recovery_row = row![
+            recovery_signature,
+            recovery_key_count,
+            recovery_key_list,
+            new::caption("can spend coins inactive for"),
+            recovery_duration,
+            recovery_kind,
+        ]
+        .spacing(5);
+
+        col = col.push(recovery_row);
     }
-    Column::new()
-        .spacing(10)
-        .push(text("The wallet policy:").bold())
-        .push(scrollable::horizontal_thin(col))
-        .into()
+
+    column![
+        new::b5_bold("The wallet policy:"),
+        scrollable::horizontal_thin(col)
+    ]
+    .spacing(10)
+    .into()
 }
 
 /// returns y,m,d
@@ -875,8 +896,10 @@ fn expire_message_units(sequence: u32) -> Vec<String> {
 
 const RADIO_TITLE_WIDTH: u32 = 160;
 
+#[allow(clippy::too_many_arguments)]
 pub fn define_bitcoin_node<'a>(
     progress: (usize, usize),
+    network: Network,
     available_node_types: impl Iterator<Item = NodeType>,
     selected_node_type: NodeType,
     node_view: Element<'a, Message>,
@@ -932,16 +955,14 @@ pub fn define_bitcoin_node<'a>(
     let button_next = btn_next(msg_next);
     let actions = row![Space::fill_width(), button_check_connection, button_next].spacing(10);
 
-    let content = column![node_type, node_view, actions]
-        .max_width(800)
-        .spacing(50);
+    let content = column![node_type, node_view, actions].spacing(50);
 
     layout(
         progress,
+        network,
         None,
         "Set up connection to the Bitcoin node",
         content,
-        true,
         Some(Message::Previous),
     )
 }
@@ -1027,7 +1048,7 @@ pub fn define_bitcoind<'a>(
     };
     let auth = column![auth_type, auth_fields].spacing(10);
 
-    column![address, auth].max_width(800).spacing(50).into()
+    column![address, auth].spacing(50).into()
 }
 
 pub fn define_electrum<'a>(
@@ -1060,10 +1081,13 @@ pub fn define_electrum<'a>(
     ]
     .spacing(10);
 
-    column![address].max_width(800).spacing(50).into()
+    column![address].spacing(50).into()
 }
 
-pub fn select_bitcoind_type<'a>(progress: (usize, usize)) -> Element<'a, Message> {
+pub fn select_bitcoind_type<'a>(
+    progress: (usize, usize),
+    network: Network,
+) -> Element<'a, Message> {
     let existing_node_title = Container::new(text::new::b5_bold("I already have a node"))
         .padding(20)
         .width(Length::FillPortion(1));
@@ -1104,20 +1128,21 @@ pub fn select_bitcoind_type<'a>(progress: (usize, usize)) -> Element<'a, Message
     .center_x(Length::FillPortion(1));
     let actions = row![existing_node_action, managed_node_action].spacing(20);
 
-    let content = column![titles, descriptions, actions].max_width(800);
+    let content = column![titles, descriptions, actions];
 
     layout(
         progress,
+        network,
         None,
         "Bitcoin node management",
         content,
-        true,
         Some(Message::Previous),
     )
 }
 
 pub fn start_internal_bitcoind<'a>(
     progress: (usize, usize),
+    network: Network,
     exe_path: Option<&PathBuf>,
     started: Option<&Result<(), StartInternalBitcoindError>>,
     error: Option<&'a String>,
@@ -1132,6 +1157,7 @@ pub fn start_internal_bitcoind<'a>(
     };
     layout(
         progress,
+        network,
         None,
         "Start Bitcoin full node",
         Column::new()
@@ -1234,7 +1260,6 @@ pub fn start_internal_bitcoind<'a>(
             .spacing(50)
             .push(btn_next(msg_next))
             .push_maybe(error.map(|e| card::invalid(new::caption(e)))),
-        true,
         Some(message::Message::InternalBitcoind(
             message::InternalBitcoindMsg::Previous,
         )),
@@ -1243,6 +1268,7 @@ pub fn start_internal_bitcoind<'a>(
 
 pub fn install<'a>(
     progress: (usize, usize),
+    network: Network,
     email: Option<&'a str>,
     generating: bool,
     installed: bool,
@@ -1255,6 +1281,7 @@ pub fn install<'a>(
     };
     layout(
         progress,
+        network,
         email,
         "Finalize installation",
         Column::new()
@@ -1274,7 +1301,6 @@ pub fn install<'a>(
             })
             .spacing(10)
             .width(Length::Fill),
-        true,
         prev_msg,
     )
 }
@@ -1405,6 +1431,7 @@ pub fn defined_sequence<'a>(
 
 pub fn backup_mnemonic<'a>(
     progress: (usize, usize),
+    network: Network,
     email: Option<&'a str>,
     words: &'a [&'static str; 12],
     done: bool,
@@ -1412,6 +1439,7 @@ pub fn backup_mnemonic<'a>(
     let msg_next = done.then_some(Message::Next);
     layout(
         progress,
+        network,
         email,
         "Back Up your mnemonic",
         Column::new()
@@ -1440,13 +1468,14 @@ pub fn backup_mnemonic<'a>(
             .push(btn_next(msg_next))
             .push(Space::with_height(20.0))
             .spacing(50),
-        true,
         Some(Message::Previous),
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn recover_mnemonic<'a>(
     progress: (usize, usize),
+    network: Network,
     email: Option<&'a str>,
     words: &'a [(String, bool); 12],
     current: usize,
@@ -1460,6 +1489,7 @@ pub fn recover_mnemonic<'a>(
 
     layout(
         progress,
+        network,
         email,
         "Import Mnemonic",
         Column::new()
@@ -1546,14 +1576,14 @@ pub fn recover_mnemonic<'a>(
                     .push(button_next)
             })
             .spacing(50),
-        true,
         Some(Message::Previous),
     )
 }
 
-pub fn choose_backend(progress: (usize, usize)) -> Element<'static, Message> {
+pub fn choose_backend(progress: (usize, usize), network: Network) -> Element<'static, Message> {
     layout(
         progress,
+        network,
         None,
         "Choose backend",
         Column::new()
@@ -1616,27 +1646,29 @@ pub fn choose_backend(progress: (usize, usize)) -> Element<'static, Message> {
                 tooltip::Position::Bottom,
             ))
             .spacing(20),
-        true,
         Some(Message::Previous),
     )
 }
 
-pub fn login(progress: (usize, usize), connection_step: Element<Message>) -> Element<Message> {
+pub fn login(
+    progress: (usize, usize),
+    network: Network,
+    connection_step: Element<Message>,
+) -> Element<Message> {
     layout(
         progress,
+        network,
         None,
         "Login",
         Container::new(
             Column::new()
                 .spacing(50)
-                .max_width(700)
                 .align_x(Alignment::Center)
                 .width(Length::FillPortion(1))
                 .push(h2("Liana Connect"))
                 .push(connection_step),
         )
         .center_x(Length::Fill),
-        true,
         Some(Message::Previous),
     )
 }
@@ -1772,98 +1804,50 @@ pub const LOCAL_WALLET_DESC: &str = "Use your already existing Bitcoin node or a
 
 pub fn wallet_alias<'a>(
     progress: (usize, usize),
+    network: Network,
     email: Option<&'a str>,
     wallet_alias: &form::Value<String>,
 ) -> Element<'a, Message> {
     let msg_next = wallet_alias.valid.then_some(Message::Next);
+    let label = new::b5_bold("Wallet alias:");
+    let form = form::Form::new("Wallet alias", wallet_alias, Message::WalletAliasEdited)
+        .warning("Wallet alias is too long.");
+    let note = new::caption("You will be able to change it later in Settings > Wallet");
+    let form_section = column![label, form, note].spacing(20);
+    let next = row![Space::fill_width(), btn_next(msg_next)];
+    let content = column![form_section, next].spacing(50);
+
     layout(
         progress,
+        network,
         email,
         "Give your wallet an alias",
-        Column::new()
-            .push(
-                Column::new()
-                    .spacing(20)
-                    .push(p1_bold("Wallet alias:"))
-                    .push(
-                        form::Form::new("Wallet alias", wallet_alias, Message::WalletAliasEdited)
-                            .warning("Wallet alias is too long.")
-                            .size(text::P1_SIZE)
-                            .padding(10),
-                    )
-                    .push(p2_regular(
-                        "You will be able to change it later in Settings > Wallet",
-                    )),
-            )
-            .push(btn_next(msg_next))
-            .spacing(50),
-        true,
+        content,
         Some(Message::Previous),
     )
 }
 
 fn layout<'a>(
     progress: (usize, usize),
+    network: Network,
     email: Option<&'a str>,
     title: &'static str,
     content: impl Into<Element<'a, Message>>,
-    padding_left: bool,
     previous_message: Option<Message>,
 ) -> Element<'a, Message> {
-    let mut prev_button = button::transparent(Some(icon::previous_icon()), "Previous");
-    if let Some(msg) = previous_message {
-        prev_button = prev_button.on_press(msg);
-    }
-    Container::new(scrollable::vertical(
-        Column::new()
-            .width(Length::Fill)
-            .push(
-                Row::new()
-                    .push(Space::with_width(Length::Fill))
-                    .push_maybe(email.map(|e| {
-                        Container::new(p1_regular(e).style(theme::text::success)).padding(20)
-                    })),
-            )
-            .push(Space::with_height(Length::Fixed(100.0)))
-            .push(
-                Row::new()
-                    .align_y(Alignment::Center)
-                    .push(Container::new(prev_button).center_x(Length::FillPortion(2)))
-                    .push(Container::new(h3(title)).width(Length::FillPortion(8)))
-                    .push_maybe(if progress.1 > 0 {
-                        Some(
-                            Container::new(text(format!("{} | {}", progress.0, progress.1)))
-                                .center_x(Length::FillPortion(2)),
-                        )
-                    } else {
-                        None
-                    }),
-            )
-            .push(
-                Row::new()
-                    .push(Space::with_width(Length::FillPortion(2)))
-                    .push(
-                        Container::new(
-                            Column::new()
-                                .push(Space::with_height(Length::Fixed(100.0)))
-                                .push(content),
-                        )
-                        .width(Length::FillPortion(if padding_left {
-                            8
-                        } else {
-                            10
-                        })),
-                    )
-                    .push_maybe(if padding_left {
-                        Some(Space::with_width(Length::FillPortion(2)))
-                    } else {
-                        None
-                    }),
-            ),
-    ))
-    .center_x(Length::Fill)
-    .height(Length::Fill)
-    .width(Length::Fill)
-    .style(theme::container::background)
-    .into()
+    installer_layout::layout(
+        installer_layout::LayoutConfig {
+            variant: Variant::Liana,
+            network,
+            email,
+            is_ws_admin: false,
+            nav_bar: installer_layout::NavBar::StepTitle {
+                progress,
+                title,
+                previous_message,
+            },
+            content_width: 800.0,
+        },
+        content,
+    )
 }

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -11,7 +11,7 @@ use iced::{
 
 use liana::miniscript::bitcoin::bip32::ChildNumber;
 use liana_ui::component::button::{
-    btn_backup_descriptor, btn_next, btn_secondary, btn_select, BtnWidth,
+    btn_backup_descriptor, btn_check_connection, btn_next, btn_select,
 };
 use liana_ui::component::text::{self, p2_regular};
 use std::collections::HashMap;
@@ -29,7 +29,7 @@ use liana_ui::{
         card, collapse, form,
         list::DeviceStatus,
         modal, scrollable, separation,
-        text::{h2, h3, h4_bold, p1_bold, p1_regular, text, Text},
+        text::{h2, h3, h4_bold, new, p1_bold, p1_regular, text, Text},
     },
     icon, theme,
     widget::*,
@@ -492,7 +492,9 @@ pub fn share_xpubs<'a>(
             tooltip::Position::Bottom,
         ));
     let title = Row::new()
-        .push(text("Import an extended public key by selecting a signing device:").bold())
+        .push(new::b5_bold(
+            "Import an extended public key by selecting a signing device:",
+        ))
         .push(Space::with_width(10))
         .push(info)
         .push(Space::with_width(Length::Fill));
@@ -507,7 +509,7 @@ pub fn share_xpubs<'a>(
             } else {
                 Column::with_children(hws).spacing(10).into()
             },
-            Container::new(text("Or create a new random key:").bold()).width(Length::Fill),
+            Container::new(new::b5_bold("Or create a new random key:")).width(Length::Fill),
             signer,
             Space::with_height(10),
         ]
@@ -519,8 +521,8 @@ pub fn share_xpubs<'a>(
 }
 
 pub fn policy_entry_card(title: String, content: String) -> Container<'static, Message> {
-    let title = text(title).small().bold();
-    let scroll = scrollable::horizontal_thin(column![text(content).small()]);
+    let title = new::b5_bold(title);
+    let scroll = scrollable::horizontal_thin(column![new::caption(content)]);
     card::simple(column![title, scroll].spacing(10)).width(Length::Fill)
 }
 
@@ -871,6 +873,8 @@ fn expire_message_units(sequence: u32) -> Vec<String> {
     }
 }
 
+const RADIO_TITLE_WIDTH: u32 = 160;
+
 pub fn define_bitcoin_node<'a>(
     progress: (usize, usize),
     available_node_types: impl Iterator<Item = NodeType>,
@@ -880,10 +884,8 @@ pub fn define_bitcoin_node<'a>(
     can_try_ping: bool,
     waiting_for_ping_result: bool,
 ) -> Element<'a, Message> {
-    let msg_next = is_running.and_then(|r| r.is_ok().then_some(Message::Next));
-    let button_next = btn_next(msg_next);
     let node_type = available_node_types.fold(
-        row![text::new::b5_bold("Node type:")].spacing(10),
+        row![text::new::b5_bold("Node type:").width(RADIO_TITLE_WIDTH)].spacing(10),
         |row, node_type| {
             row.push(radio(
                 match node_type {
@@ -901,10 +903,10 @@ pub fn define_bitcoin_node<'a>(
         },
     );
 
-    let connection_status = if waiting_for_ping_result {
-        Container::new(row![text::new::caption("Checking connection...")].spacing(10))
+    let connection_status: Element<'a, Message> = if waiting_for_ping_result {
+        text::new::caption("Checking connection...").into()
     } else if let Some(res) = is_running {
-        let status = if res.is_ok() {
+        if res.is_ok() {
             row![
                 icon::circle_check_icon().style(theme::text::success),
                 text::new::caption("Connection checked").style(theme::text::success),
@@ -914,23 +916,25 @@ pub fn define_bitcoin_node<'a>(
                 icon::circle_cross_icon().style(theme::text::error),
                 text::new::caption("Connection failed").style(theme::text::error),
             ]
-        };
-        Container::new(status.align_y(Alignment::Center).spacing(10))
+        }
+        .align_y(Alignment::Center)
+        .into()
     } else {
-        Container::new(Space::with_height(21))
+        Container::new(Space::with_height(21)).into()
     };
+    let node_view = column![node_view, connection_status].spacing(5);
 
-    let check_connection =
+    let msg_next = is_running.and_then(|r| r.is_ok().then_some(Message::Next));
+
+    let msg_check_connection =
         (can_try_ping && !waiting_for_ping_result).then_some(Message::DefineNode(DefineNode::Ping));
-    let button_check_connection = Container::new(btn_secondary(
-        None,
-        "Check connection",
-        BtnWidth::XL,
-        check_connection,
-    ));
-    let actions = row![button_check_connection, button_next].spacing(10);
+    let button_check_connection = btn_check_connection(msg_check_connection, msg_next.is_none());
+    let button_next = btn_next(msg_next);
+    let actions = row![Space::fill_width(), button_check_connection, button_next].spacing(10);
 
-    let content = column![node_type, node_view, connection_status, actions].spacing(50);
+    let content = column![node_type, node_view, actions]
+        .max_width(800)
+        .spacing(50);
 
     layout(
         progress,
@@ -965,7 +969,7 @@ pub fn define_bitcoind<'a>(
     };
     let address_input = form::Form::new_trimmed("Address", address, address_msg)
         .warning("Please enter correct address")
-        .component_label(text::new::b5_bold("Address:"))
+        .label("Address:")
         .padding(10);
     let loopback_warning = (!is_loopback && address.valid).then_some(
         text::new::caption(
@@ -978,7 +982,7 @@ pub fn define_bitcoind<'a>(
     let auth_type = [RpcAuthType::CookieFile, RpcAuthType::UserPass]
         .iter()
         .fold(
-            row![text::new::b5_bold("RPC authentication:")].spacing(10),
+            row![text::new::b5_bold("RPC authentication:").width(RADIO_TITLE_WIDTH)].spacing(10),
             |row, auth_type| {
                 row.push(radio(
                     format!("{auth_type}"),
@@ -1003,7 +1007,6 @@ pub fn define_bitcoind<'a>(
                     ))
                 })
                 .warning("Please enter correct path")
-                .padding(10),
             ]
         }
         RpcAuthType::UserPass => row![
@@ -1012,21 +1015,19 @@ pub fn define_bitcoind<'a>(
                     DefineBitcoind::ConfigFieldEdited(ConfigField::User, msg),
                 ))
             })
-            .warning("Please enter correct user")
-            .padding(10),
+            .warning("Please enter correct user"),
             form::Form::new_trimmed("Password", &rpc_auth_vals.password, |msg| {
                 Message::DefineNode(DefineNode::DefineBitcoind(
                     DefineBitcoind::ConfigFieldEdited(ConfigField::Password, msg),
                 ))
             })
             .warning("Please enter correct password")
-            .padding(10),
         ]
         .spacing(10),
     };
     let auth = column![auth_type, auth_fields].spacing(10);
 
-    column![address, auth].spacing(50).into()
+    column![address, auth].max_width(800).spacing(50).into()
 }
 
 pub fn define_electrum<'a>(
@@ -1050,7 +1051,7 @@ pub fn define_electrum<'a>(
             "Please enter correct address (including port), \
         optionally prefixed with tcp:// or ssl://",
         )
-        .component_label(text::new::b5_bold("Address:"))
+        .label("Address")
         .padding(10);
     let address = column![
         address_input,
@@ -1059,7 +1060,7 @@ pub fn define_electrum<'a>(
     ]
     .spacing(10);
 
-    column![address].spacing(50).into()
+    column![address].max_width(800).spacing(50).into()
 }
 
 pub fn select_bitcoind_type<'a>(progress: (usize, usize)) -> Element<'a, Message> {
@@ -1124,6 +1125,11 @@ pub fn start_internal_bitcoind<'a>(
     install_state: Option<&InstallState>,
 ) -> Element<'a, Message> {
     let version = crate::node::bitcoind::VERSION;
+    let msg_next = if let Some(Ok(_)) = started {
+        Some(Message::Next)
+    } else {
+        None
+    };
     layout(
         progress,
         None,
@@ -1135,18 +1141,21 @@ pub fn start_internal_bitcoind<'a>(
                         .spacing(10)
                         .align_y(Alignment::Center)
                         .push(icon::circle_check_icon().style(theme::text::success))
-                        .push(text("Download complete").style(theme::text::success)),
+                        .push(new::caption("Download complete").style(theme::text::success)),
                     DownloadState::Downloading { progress } => Row::new()
                         .spacing(10)
                         .align_y(Alignment::Center)
-                        .push(text(format!(
+                        .push(new::caption(format!(
                             "Downloading Bitcoin Core {version}... {progress:.2}%"
                         ))),
                     DownloadState::Errored(e) => Row::new()
                         .spacing(10)
                         .align_y(Alignment::Center)
                         .push(icon::circle_cross_icon().style(theme::text::error))
-                        .push(text(format!("Download failed: '{e}'.")).style(theme::text::error)),
+                        .push(
+                            new::caption(format!("Download failed: '{e}'."))
+                                .style(theme::text::error),
+                        ),
                     _ => Row::new().spacing(10).align_y(Alignment::Center),
                 }
             }))
@@ -1160,13 +1169,14 @@ pub fn start_internal_bitcoind<'a>(
                         .spacing(10)
                         .align_y(Alignment::Center)
                         .push(icon::circle_check_icon().style(theme::text::success))
-                        .push(text("Installation complete").style(theme::text::success)),
+                        .push(new::caption("Installation complete").style(theme::text::success)),
                     InstallState::Errored(e) => Row::new()
                         .spacing(10)
                         .align_y(Alignment::Center)
                         .push(icon::circle_cross_icon().style(theme::text::error))
                         .push(
-                            text(format!("Installation failed: '{e}'.")).style(theme::text::error),
+                            new::caption(format!("Installation failed: '{e}'."))
+                                .style(theme::text::error),
                         ),
                 }
             } else if exe_path.is_some() {
@@ -1175,7 +1185,7 @@ pub fn start_internal_bitcoind<'a>(
                     .align_y(Alignment::Center)
                     .push(icon::circle_check_icon().style(theme::text::success))
                     .push(
-                        text("Liana-managed bitcoind already installed")
+                        new::caption("Liana-managed bitcoind already installed")
                             .style(theme::text::success),
                     )
             } else if let Some(DownloadState::Downloading { progress }) = download_state {
@@ -1194,7 +1204,7 @@ pub fn start_internal_bitcoind<'a>(
                                 .spacing(10)
                                 .align_y(Alignment::Center)
                                 .push(icon::circle_check_icon().style(theme::text::success))
-                                .push(text("Started").style(theme::text::success)),
+                                .push(new::caption("Started").style(theme::text::success)),
                         )
                     } else {
                         Container::new(
@@ -1203,7 +1213,7 @@ pub fn start_internal_bitcoind<'a>(
                                 .align_y(Alignment::Center)
                                 .push(icon::circle_cross_icon().style(theme::text::error))
                                 .push(
-                                    text(res.as_ref().err().unwrap().to_string())
+                                    new::caption(res.as_ref().err().unwrap().to_string())
                                         .style(theme::text::error),
                                 ),
                         )
@@ -1216,24 +1226,14 @@ pub fn start_internal_bitcoind<'a>(
                         Row::new()
                             .spacing(10)
                             .align_y(Alignment::Center)
-                            .push(text("Starting...")),
+                            .push(new::caption("Starting...")),
                     )),
                     _ => Some(Container::new(Space::with_height(Length::Fixed(25.0)))),
                 }
             })
             .spacing(50)
-            .push(
-                Row::new().push(
-                    button::secondary(None, "Next")
-                        .width(Length::Fixed(200.0))
-                        .on_press_maybe(if let Some(Ok(_)) = started {
-                            Some(Message::Next)
-                        } else {
-                            None
-                        }),
-                ),
-            )
-            .push_maybe(error.map(|e| card::invalid(text(e)))),
+            .push(btn_next(msg_next))
+            .push_maybe(error.map(|e| card::invalid(new::caption(e)))),
         true,
         Some(message::Message::InternalBitcoind(
             message::InternalBitcoindMsg::Previous,
@@ -1258,16 +1258,16 @@ pub fn install<'a>(
         email,
         "Finalize installation",
         Column::new()
-            .push_maybe(warning.map(|e| card::invalid(text(e))))
+            .push_maybe(warning.map(|e| card::invalid(new::caption(e))))
             .push(if generating {
-                Container::new(text("Installing..."))
+                Container::new(new::caption("Installing..."))
             } else if installed {
                 Container::new(
                     Row::new()
                         .spacing(10)
                         .align_y(Alignment::Center)
                         .push(icon::circle_check_icon().style(theme::text::success))
-                        .push(text("Installed").style(theme::text::success)),
+                        .push(new::caption("Installed").style(theme::text::success)),
                 )
             } else {
                 Container::new(Space::with_height(Length::Fixed(25.0)))
@@ -1295,7 +1295,7 @@ pub fn defined_threshold<'a>(
                         row.push(icon::round_key_icon())
                     }
                 }))
-                .push(text(format!(
+                .push(new::caption(format!(
                     "{} out of {} key{}",
                     threshold.0,
                     threshold.1,
@@ -1318,7 +1318,7 @@ pub fn defined_threshold<'a>(
                         row.push(icon::round_key_icon())
                     }
                 }))
-                .push(text(format!(
+                .push(new::caption(format!(
                     "{} out of {} key{}",
                     threshold.0,
                     threshold.1,
@@ -1338,7 +1338,7 @@ pub fn defined_sequence<'a>(
         .padding(5)
         .spacing(5)
         .align_y(Alignment::Center)
-        .push(text(
+        .push(new::caption(
             format_sequence_duration(sequence.as_u16(), true)
                 .iter()
                 .filter_map(|(n, unit)| {
@@ -1361,7 +1361,7 @@ pub fn defined_sequence<'a>(
                             .align_y(Alignment::Center)
                             .spacing(5)
                             .push(
-                                text::p1_regular("Available after inactivity of ~")
+                                new::caption("Available after inactivity of ~")
                                     .style(theme::text::secondary),
                             )
                             .push(
@@ -1376,7 +1376,7 @@ pub fn defined_sequence<'a>(
                 ),
                 PathSequence::Primary => Row::new()
                     .push(
-                        p1_regular("Able to move the funds at any time.")
+                        new::caption("Able to move the funds at any time.")
                             .style(theme::text::secondary),
                     )
                     .padding(5),
@@ -1386,7 +1386,7 @@ pub fn defined_sequence<'a>(
                             .align_y(Alignment::Center)
                             .spacing(5)
                             .push(
-                                text::p1_regular("Available after inactivity of ~")
+                                new::caption("Available after inactivity of ~")
                                     .style(theme::text::secondary),
                             )
                             .push(duration_row),
@@ -1396,7 +1396,7 @@ pub fn defined_sequence<'a>(
                     .align_y(alignment::Vertical::Center),
                 ),
             })
-            .push_maybe(warning.map(|w| text(w.message()).small().style(theme::text::error)))
+            .push_maybe(warning.map(|w| new::small_caption(w.message()).style(theme::text::error)))
             .spacing(15),
     )
     .padding(5)

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -1,8 +1,8 @@
 pub mod editor;
 
 use async_hwi::utils::extract_keys_and_template;
-use iced::widget::column;
 use iced::widget::{checkbox, radio, tooltip, Button, Space, TextInput};
+use iced::widget::{column, row};
 use iced::{
     alignment,
     widget::{progress_bar, tooltip as iced_tooltip},
@@ -84,6 +84,11 @@ pub fn import_wallet_or_descriptor<'a>(
         card::simple(col_wallets).into()
     };
 
+    let msg_next = (!invitation.value.is_empty()).then_some(Message::ImportRemoteWallet(
+        message::ImportRemoteWallet::FetchInvitation,
+    ));
+    let row_next = row![Space::fill_width(), btn_next(msg_next)];
+
     let col_invitation_token = collapse::Collapse::new(
         Column::new()
             .spacing(5)
@@ -145,19 +150,7 @@ pub fn import_wallet_or_descriptor<'a>(
                                 )
                                 .spacing(10),
                         )
-                        .push(
-                            Row::new().push(Space::with_width(Length::Fill)).push(
-                                button::secondary(None, "Next")
-                                    .width(Length::Fixed(200.0))
-                                    .on_press_maybe(if !invitation.value.is_empty() {
-                                        Some(Message::ImportRemoteWallet(
-                                            message::ImportRemoteWallet::FetchInvitation,
-                                        ))
-                                    } else {
-                                        None
-                                    }),
-                            ),
-                        )
+                        .push(row_next)
                         .spacing(20),
                 )
                 .padding(15),
@@ -165,6 +158,11 @@ pub fn import_wallet_or_descriptor<'a>(
         },
     )
     .padding(15);
+
+    let msg_next = (!imported_descriptor.value.is_empty() && imported_descriptor.valid).then_some(
+        Message::ImportRemoteWallet(message::ImportRemoteWallet::ConfirmDescriptor),
+    );
+    let row_next = row![Space::fill_width(), btn_next(msg_next)];
 
     let col_descriptor = collapse::Collapse::new(
         Column::new()
@@ -199,23 +197,7 @@ pub fn import_wallet_or_descriptor<'a>(
                         ))
                         .spacing(10),
                 )
-                .push(
-                    Row::new().push(Space::with_width(Length::Fill)).push(
-                        button::secondary(None, "Next")
-                            .width(Length::Fixed(200.0))
-                            .on_press_maybe(
-                                if imported_descriptor.value.is_empty()
-                                    || !imported_descriptor.valid
-                                {
-                                    None
-                                } else {
-                                    Some(Message::ImportRemoteWallet(
-                                        message::ImportRemoteWallet::ConfirmDescriptor,
-                                    ))
-                                },
-                            ),
-                    ),
-                )
+                .push(row_next)
                 .spacing(20),
         )
         .padding(15),
@@ -321,15 +303,7 @@ pub fn import_descriptor<'a>(
                 Settings > Node.",
                     )),
             )
-            .push(
-                if imported_descriptor.value.is_empty() || !imported_descriptor.valid {
-                    button::secondary(None, "Next").width(Length::Fixed(200.0))
-                } else {
-                    button::secondary(None, "Next")
-                        .width(Length::Fixed(200.0))
-                        .on_press(Message::Next)
-                },
-            )
+            .push(btn_next(valid.then_some(Message::Next)))
             .push_maybe(error.map(|e| card::error("Invalid descriptor", e.to_string())))
             .spacing(50),
         true,
@@ -732,13 +706,7 @@ pub fn backup_descriptor<'a>(
                     .label("I have backed up my descriptor")
                     .on_toggle(Message::UserActionDone),
             )
-            .push(if done {
-                button::primary(None, "Next")
-                    .on_press(Message::Next)
-                    .width(Length::Fixed(200.0))
-            } else {
-                button::secondary(None, "Next").width(Length::Fixed(200.0))
-            })
+            .push(btn_next(done.then_some(Message::Next)))
             .push(Space::with_height(20.0))
             .spacing(50),
         true,
@@ -925,6 +893,9 @@ pub fn define_bitcoin_node<'a>(
     can_try_ping: bool,
     waiting_for_ping_result: bool,
 ) -> Element<'a, Message> {
+    let msg_next = is_running.and_then(|r| r.is_ok().then_some(Message::Next));
+    let button_next = btn_next(msg_next);
+
     let col = Column::new()
         .push(
             available_node_types.fold(
@@ -993,13 +964,7 @@ pub fn define_bitcoin_node<'a>(
                         })
                         .width(BtnWidth::XL),
                 ))
-                .push(if is_running.map(|res| res.is_ok()).unwrap_or(false) {
-                    button::secondary(None, "Next")
-                        .on_press(Message::Next)
-                        .width(Length::Fixed(200.0))
-                } else {
-                    button::secondary(None, "Next").width(Length::Fixed(200.0))
-                }),
+                .push(button_next),
         )
         .spacing(50);
 
@@ -1604,6 +1569,10 @@ pub fn recover_mnemonic<'a>(
     recover: bool,
     error: Option<&'a String>,
 ) -> Element<'a, Message> {
+    let msg_next =
+        (!words.iter().any(|(_, valid)| !valid) && error.is_none()).then_some(Message::Next);
+    let button_next = btn_next(msg_next);
+
     layout(
         progress,
         email,
@@ -1689,15 +1658,7 @@ pub fn recover_mnemonic<'a>(
                             .on_press(Message::ImportMnemonic(false))
                             .width(Length::Fixed(200.0)),
                     )
-                    .push(
-                        if words.iter().any(|(_, valid)| !valid) || error.is_some() {
-                            button::secondary(None, "Next").width(Length::Fixed(200.0))
-                        } else {
-                            button::secondary(None, "Next")
-                                .on_press(Message::Next)
-                                .width(Length::Fixed(200.0))
-                        },
-                    )
+                    .push(button_next)
             })
             .spacing(50),
         true,

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -23,7 +23,8 @@ use liana::{
 };
 use liana_ui::{
     component::{
-        button, card, collapse, form,
+        button::{self},
+        card, collapse, form,
         list::DeviceStatus,
         modal, scrollable, separation,
         text::{h2, h3, h4_bold, p1_bold, p1_regular, text, Text},
@@ -1450,7 +1451,7 @@ pub fn defined_threshold<'a>(
                     threshold.1,
                     if threshold.1 > 1 { "s" } else { "" },
                 )))
-                .push(icon::pencil_icon()),
+                .push(icon::edit_icon()),
         )
         .padding(10)
         .on_press(message::DefinePath::EditThreshold)
@@ -1514,7 +1515,7 @@ pub fn defined_sequence<'a>(
                                     .style(theme::text::secondary),
                             )
                             .push(
-                                Button::new(duration_row.push(icon::pencil_icon()))
+                                Button::new(duration_row.push(icon::edit_icon()))
                                     .style(theme::button::secondary)
                                     .on_press(message::DefinePath::EditSequence),
                             ),

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -24,12 +24,13 @@ use std::{
 
 use liana_ui::{
     component::{
+        badge::Tile,
         button::{
             self, btn_accept, btn_backend_options_help, btn_backup_descriptor,
             btn_check_connection, btn_next, btn_select, EntryWidth,
         },
-        card, collapse, form, installer as installer_layout,
-        list::DeviceStatus,
+        card, form, installer as installer_layout,
+        list::{self, DeviceStatus, EntryAccent},
         modal, scrollable, separation,
         text::{self, h2, new, p1_regular, text, Text as _},
     },
@@ -66,145 +67,163 @@ pub fn import_wallet_or_descriptor<'a>(
     invitation_wallet: Option<&'a str>,
     imported_descriptor: &'a form::Value<String>,
     error: Option<&'a String>,
+    options_expanded: bool,
+    active_option: Option<message::ImportWalletOption>,
     wallets: Vec<(&'a String, Option<&'a String>)>,
 ) -> Element<'a, Message> {
-    let no_wallets = wallets.is_empty();
-    let wallets: Element<'a, Message> = if no_wallets {
-        new::h3_semi("You have no current wallets").into()
-    } else {
-        card::simple(wallets.into_iter().enumerate().fold(
-            column![new::h3_semi("Load a previously used wallet")].spacing(20),
-            |wallets, (i, (name, alias))| {
-                let content = column![
-                    alias.map(new::b5_bold),
-                    new::caption(name).style(theme::text::secondary),
-                ]
-                .width(Length::Fill);
-                wallets.push(
-                    Button::new(content)
-                        .style(theme::button::secondary)
-                        .padding(10)
-                        .on_press(Message::Select(i)),
-                )
-            },
-        ))
-        .into()
-    };
+    // Error banner
+    let error = error.map(|e| card::error("Something wrong happened", e.to_string()));
 
+    // Wallet list
+    let title = row![
+        new::h3_semi("Load a previously used wallet"),
+        Space::fill_width()
+    ];
+    let no_wallets = wallets.is_empty();
+    let wallet_accent = Some(match network {
+        Network::Bitcoin => EntryAccent::Bitcoin,
+        _ => EntryAccent::Testnet,
+    });
+    let wallets: Element<'a, Message> = if no_wallets {
+        Container::new(new::caption("You have no current wallets"))
+            .center_x(Length::Fill)
+            .into()
+    } else {
+        wallets
+            .into_iter()
+            .enumerate()
+            .fold(column![].spacing(20), |wallets, (i, (name, alias))| {
+                let title = alias.map_or(name.as_str(), |alias| alias.as_str());
+                let subtitle =
+                    alias.map(|_| new::caption(name).style(theme::text::secondary).into());
+                wallets.push(list::entry_wallet(
+                    wallet_accent,
+                    title,
+                    subtitle,
+                    None,
+                    None,
+                    Some(Message::Select(i)),
+                ))
+            })
+            .into()
+    };
+    let previous_wallets = column![title, wallets].spacing(20);
+
+    // Invitation entry
     let fetch_invitation = (!invitation.value.is_empty()).then_some(Message::ImportRemoteWallet(
         message::ImportRemoteWallet::FetchInvitation,
     ));
-    let invitation_form = column![
-        new::b5_bold("Paste invitation:"),
-        form::Form::new_trimmed("Invitation", invitation, |msg| {
-            Message::ImportRemoteWallet(message::ImportRemoteWallet::ImportInvitationToken(msg))
-        })
-        .warning("Invitation token is invalid or expired"),
+    let invitation_token_msg =
+        |msg| Message::ImportRemoteWallet(message::ImportRemoteWallet::ImportInvitationToken(msg));
+    let invitation_form = row![
+        form::Form::new_trimmed("Invitation token", invitation, invitation_token_msg)
+            .warning("Invitation token is invalid or expired"),
+        btn_next(fetch_invitation),
     ]
+    .align_y(Alignment::Start)
     .spacing(10);
-    let invitation_content: Element<'a, Message> = if let Some(wallet) = invitation_wallet {
-        let wallet_label = row![
+    let button_accept = btn_accept(Some(Message::ImportRemoteWallet(
+        message::ImportRemoteWallet::AcceptInvitation,
+    )));
+    let accept_invitation = |wallet: &'a str| {
+        row![
             Space::with_width(15),
             new::caption("Accept invitation for wallet:"),
             new::b5_bold(wallet),
-        ]
-        .spacing(5);
-        let accept = row![
             Space::fill_width(),
-            btn_accept(Some(Message::ImportRemoteWallet(
-                message::ImportRemoteWallet::AcceptInvitation,
-            ))),
-            Space::fill_width(),
-        ];
-        column![
-            Space::with_height(0),
-            wallet_label,
-            accept,
-            Space::with_width(5),
+            button_accept
         ]
-        .spacing(20)
-        .into()
-    } else {
-        Container::new(
-            column![
-                Space::with_height(0),
-                invitation_form,
-                row![Space::fill_width(), btn_next(fetch_invitation)],
-            ]
-            .spacing(20),
-        )
-        .padding(15)
+        .align_y(Alignment::Center)
+        .spacing(5)
         .into()
     };
+    let invitation_content: Element<'a, Message> = if let Some(wallet) = invitation_wallet {
+        accept_invitation(wallet)
+    } else {
+        invitation_form.into()
+    };
+    let invitation = list::entry_collapsible(list::CollapsibleEntry {
+        accent: wallet_accent,
+        tile: Tile::Import,
+        title: "Load a shared wallet",
+        collapsed_subtitle: Some("If you received an invitation to join a shared wallet"),
+        expanded_subtitle: Some("Type the invitation token you received by email"),
+        content: invitation_content,
+        expanded: active_option == Some(message::ImportWalletOption::Invitation),
+        on_toggle: Message::ImportRemoteWallet(message::ImportRemoteWallet::ToggleOption(
+            message::ImportWalletOption::Invitation,
+        )),
+    });
 
-    let invitation = collapse::Collapse::new(
-        column![
-            new::h3_semi("Load a shared wallet").style(theme::text::primary),
-            new::caption("If you received an invitation to join a shared wallet")
-                .style(theme::text::secondary),
-        ]
-        .spacing(5),
-        column![
-            new::h3_semi("Load a shared wallet").style(theme::text::primary),
-            new::caption("Type the invitation token you received by email")
-                .style(theme::text::secondary),
-        ]
-        .spacing(5),
-        invitation_content,
-    )
-    .padding(15);
+    // Import a descriptor entry
+    let import_descriptor = list::entry_action_accent(
+        wallet_accent,
+        Tile::Import,
+        "Import a descriptor",
+        None::<String>,
+        None,
+        button::EntryWidth::Standard,
+        Some(Message::ImportRemoteWallet(
+            message::ImportRemoteWallet::ImportDescriptorFromFile,
+        )),
+    );
 
+    // Paste a descriptor entry
     let confirm_descriptor = (!imported_descriptor.value.is_empty() && imported_descriptor.valid)
         .then_some(Message::ImportRemoteWallet(
             message::ImportRemoteWallet::ConfirmDescriptor,
         ));
-    let descriptor_form = column![
-        new::b5_bold("Descriptor:"),
+    let descriptor_form = row![
         form::Form::new_trimmed("Descriptor", imported_descriptor, |msg| {
             Message::ImportRemoteWallet(message::ImportRemoteWallet::ImportDescriptor(msg))
         })
         .warning("Either descriptor is invalid or incompatible with network"),
-        new::b5_bold("or"),
-        button::primary(None, "Import descriptor").on_press(Message::ImportRemoteWallet(
-            message::ImportRemoteWallet::ImportDescriptorFromFile,
-        )),
+        btn_next(confirm_descriptor),
     ]
+    .align_y(Alignment::Start)
     .spacing(10);
-    let descriptor_content = Container::new(
-        column![
-            Space::with_height(0),
-            descriptor_form,
-            row![Space::fill_width(), btn_next(confirm_descriptor)],
-        ]
-        .spacing(20),
-    )
-    .padding(15);
+    let descriptor_content = column![Space::with_height(0), descriptor_form,].spacing(10);
+    let paste_descriptor = list::entry_collapsible(list::CollapsibleEntry {
+        accent: wallet_accent,
+        tile: Tile::Paste,
+        title: "Paste a descriptor",
+        collapsed_subtitle: Some("Creates a new wallet from the pasted descriptor"),
+        expanded_subtitle: Some("Creates a new wallet from the pasted descriptor"),
+        content: descriptor_content.into(),
+        expanded: active_option == Some(message::ImportWalletOption::PasteDescriptor),
+        on_toggle: Message::ImportRemoteWallet(message::ImportRemoteWallet::ToggleOption(
+            message::ImportWalletOption::PasteDescriptor,
+        )),
+    });
 
-    let descriptor = collapse::Collapse::new(
-        column![
-            new::h3_semi("Load a wallet from descriptor").style(theme::text::primary),
-            new::caption("Creates a new wallet from the descriptor").style(theme::text::secondary),
-        ]
-        .spacing(5),
-        column![
-            new::h3_semi("Load a wallet from descriptor").style(theme::text::primary),
-            new::caption("Creates a new wallet from the descriptor").style(theme::text::secondary),
-        ]
-        .spacing(5),
-        descriptor_content,
-    )
-    .padding(15);
+    // Other options block
+    let other_options_header = row![
+        modal::optional_section(
+            options_expanded,
+            "Other options".to_string(),
+            || Message::ImportRemoteWallet(message::ImportRemoteWallet::ToggleOptions(true)),
+            || Message::ImportRemoteWallet(message::ImportRemoteWallet::ToggleOptions(false)),
+        ),
+        Space::fill_width(),
+    ];
+    let other_options_content: Option<Element<'a, Message>> = options_expanded.then_some(
+        column![invitation, import_descriptor, paste_descriptor,]
+            .spacing(20)
+            .into(),
+    );
+    let other_options = column![other_options_header, other_options_content].spacing(20);
 
-    let error = error.map(|e| card::error("Something wrong happened", e.to_string()));
-    let other_options = column![
-        card::simple(invitation).padding(0),
-        card::simple(descriptor).padding(0)
+    let content = column![
+        error,
+        previous_wallets,
+        other_options,
+        Space::with_height(10),
     ]
+    .width(EntryWidth::Standard)
+    .align_x(Alignment::Center)
     .spacing(20);
-    let content = column![error, wallets, other_options, Space::with_height(10),]
-        .width(Length::Fill)
-        .align_x(Alignment::Center)
-        .spacing(50);
+
+    let content = Container::new(content).center_x(Length::Fill);
 
     layout(
         progress,

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -7,13 +7,6 @@ use iced::{
     Alignment, Length,
 };
 
-use std::{
-    collections::{HashMap, HashSet},
-    net::{Ipv4Addr, Ipv6Addr},
-    path::PathBuf,
-    str::FromStr,
-};
-
 use liana::{
     descriptors::{LianaDescriptor, LianaPolicy},
     miniscript::bitcoin::{
@@ -22,17 +15,23 @@ use liana::{
         Network,
     },
 };
+use std::{
+    collections::{HashMap, HashSet},
+    net::{Ipv4Addr, Ipv6Addr},
+    path::PathBuf,
+    str::FromStr,
+};
 
 use liana_ui::{
     component::{
         button::{
-            self, btn_backend_options_help, btn_backup_descriptor, btn_check_connection, btn_next,
-            btn_select, EntryWidth,
+            self, btn_accept, btn_backend_options_help, btn_backup_descriptor,
+            btn_check_connection, btn_next, btn_select, EntryWidth,
         },
         card, collapse, form, installer as installer_layout,
         list::DeviceStatus,
         modal, scrollable, separation,
-        text::{self, h2, h4_bold, new, p1_bold, p1_regular, text, Text as _},
+        text::{self, h2, new, p1_regular, text, Text as _},
     },
     icon, theme,
     widget::*,
@@ -69,161 +68,150 @@ pub fn import_wallet_or_descriptor<'a>(
     error: Option<&'a String>,
     wallets: Vec<(&'a String, Option<&'a String>)>,
 ) -> Element<'a, Message> {
-    let mut col_wallets = Column::new()
-        .spacing(20)
-        .push(h4_bold("Load a previously used wallet"));
     let no_wallets = wallets.is_empty();
-    for (i, (name, alias)) in wallets.into_iter().enumerate() {
-        col_wallets = col_wallets.push(
-            Button::new(
-                Column::new()
-                    .push_maybe(alias.map(p1_bold))
-                    .push(p1_regular(name))
-                    .width(Length::Fill),
-            )
-            .style(theme::button::secondary)
-            .padding(10)
-            .on_press(Message::Select(i)),
-        );
-    }
-    let card_wallets: Element<'a, Message> = if no_wallets {
-        h4_bold("You have no current wallets").into()
+    let wallets: Element<'a, Message> = if no_wallets {
+        new::h3_semi("You have no current wallets").into()
     } else {
-        card::simple(col_wallets).into()
+        card::simple(wallets.into_iter().enumerate().fold(
+            column![new::h3_semi("Load a previously used wallet")].spacing(20),
+            |wallets, (i, (name, alias))| {
+                let content = column![
+                    alias.map(new::b5_bold),
+                    new::caption(name).style(theme::text::secondary),
+                ]
+                .width(Length::Fill);
+                wallets.push(
+                    Button::new(content)
+                        .style(theme::button::secondary)
+                        .padding(10)
+                        .on_press(Message::Select(i)),
+                )
+            },
+        ))
+        .into()
     };
 
-    let msg_next = (!invitation.value.is_empty()).then_some(Message::ImportRemoteWallet(
+    let fetch_invitation = (!invitation.value.is_empty()).then_some(Message::ImportRemoteWallet(
         message::ImportRemoteWallet::FetchInvitation,
     ));
-    let row_next = row![Space::fill_width(), btn_next(msg_next)];
-
-    let col_invitation_token = collapse::Collapse::new(
-        Column::new()
-            .spacing(5)
-            .push(h4_bold("Load a shared wallet").style(theme::text::primary))
-            .push(
-                text("If you received an invitation to join a shared wallet")
-                    .style(theme::text::secondary),
-            ),
-        Column::new()
-            .spacing(5)
-            .push(h4_bold("Load a shared wallet").style(theme::text::primary))
-            .push(
-                text("Type the invitation token you received by email")
-                    .style(theme::text::secondary),
-            ),
-        if let Some(wallet) = invitation_wallet {
-            Element::<'a, Message>::from(
-                Column::new()
-                    .push(Space::with_height(0))
-                    .push(
-                        Row::new()
-                            .spacing(5)
-                            .push(Space::with_width(15))
-                            .push(text("Accept invitation for wallet:"))
-                            .push(text(wallet).bold()),
-                    )
-                    .push(
-                        Row::new()
-                            .push(Space::with_width(Length::Fill))
-                            .push(
-                                button::secondary(None, "Accept")
-                                    .width(Length::Fixed(200.0))
-                                    .on_press(Message::ImportRemoteWallet(
-                                        message::ImportRemoteWallet::AcceptInvitation,
-                                    )),
-                            )
-                            .push(Space::with_width(Length::Fill)),
-                    )
-                    .push(Space::with_width(5))
-                    .spacing(20),
-            )
-        } else {
-            Element::<'a, Message>::from(
-                Container::new(
-                    Column::new()
-                        .push(Space::with_height(0))
-                        .push(
-                            Column::new()
-                                .push(text("Paste invitation:").bold())
-                                .push(
-                                    form::Form::new_trimmed("Invitation", invitation, |msg| {
-                                        Message::ImportRemoteWallet(
-                                            message::ImportRemoteWallet::ImportInvitationToken(msg),
-                                        )
-                                    })
-                                    .warning("Invitation token is invalid or expired")
-                                    .size(text::P1_SIZE)
-                                    .padding(10),
-                                )
-                                .spacing(10),
-                        )
-                        .push(row_next)
-                        .spacing(20),
-                )
-                .padding(15),
-            )
-        },
-    )
-    .padding(15);
-
-    let msg_next = (!imported_descriptor.value.is_empty() && imported_descriptor.valid).then_some(
-        Message::ImportRemoteWallet(message::ImportRemoteWallet::ConfirmDescriptor),
-    );
-    let row_next = row![Space::fill_width(), btn_next(msg_next)];
-
-    let col_descriptor = collapse::Collapse::new(
-        Column::new()
-            .spacing(5)
-            .push(h4_bold("Load a wallet from descriptor").style(theme::text::primary))
-            .push(text("Creates a new wallet from the descriptor").style(theme::text::secondary)),
-        Column::new()
-            .spacing(5)
-            .push(h4_bold("Load a wallet from descriptor").style(theme::text::primary))
-            .push(text("Creates a new wallet from the descriptor").style(theme::text::secondary)),
+    let invitation_form = column![
+        new::b5_bold("Paste invitation:"),
+        form::Form::new_trimmed("Invitation", invitation, |msg| {
+            Message::ImportRemoteWallet(message::ImportRemoteWallet::ImportInvitationToken(msg))
+        })
+        .warning("Invitation token is invalid or expired"),
+    ]
+    .spacing(10);
+    let invitation_content: Element<'a, Message> = if let Some(wallet) = invitation_wallet {
+        let wallet_label = row![
+            Space::with_width(15),
+            new::caption("Accept invitation for wallet:"),
+            new::b5_bold(wallet),
+        ]
+        .spacing(5);
+        let accept = row![
+            Space::fill_width(),
+            btn_accept(Some(Message::ImportRemoteWallet(
+                message::ImportRemoteWallet::AcceptInvitation,
+            ))),
+            Space::fill_width(),
+        ];
+        column![
+            Space::with_height(0),
+            wallet_label,
+            accept,
+            Space::with_width(5),
+        ]
+        .spacing(20)
+        .into()
+    } else {
         Container::new(
-            Column::new()
-                .push(Space::with_height(0))
-                .push(
-                    Column::new()
-                        .push(text("Descriptor:").bold())
-                        .push(
-                            form::Form::new_trimmed("Descriptor", imported_descriptor, |msg| {
-                                Message::ImportRemoteWallet(
-                                    message::ImportRemoteWallet::ImportDescriptor(msg),
-                                )
-                            })
-                            .warning("Either descriptor is invalid or incompatible with network")
-                            .size(text::P1_SIZE)
-                            .padding(10),
-                        )
-                        .push(text("or").bold())
-                        .push(button::primary(None, "Import descriptor").on_press(
-                            Message::ImportRemoteWallet(
-                                message::ImportRemoteWallet::ImportDescriptorFromFile,
-                            ),
-                        ))
-                        .spacing(10),
-                )
-                .push(row_next)
-                .spacing(20),
+            column![
+                Space::with_height(0),
+                invitation_form,
+                row![Space::fill_width(), btn_next(fetch_invitation)],
+            ]
+            .spacing(20),
         )
-        .padding(15),
+        .padding(15)
+        .into()
+    };
+
+    let invitation = collapse::Collapse::new(
+        column![
+            new::h3_semi("Load a shared wallet").style(theme::text::primary),
+            new::caption("If you received an invitation to join a shared wallet")
+                .style(theme::text::secondary),
+        ]
+        .spacing(5),
+        column![
+            new::h3_semi("Load a shared wallet").style(theme::text::primary),
+            new::caption("Type the invitation token you received by email")
+                .style(theme::text::secondary),
+        ]
+        .spacing(5),
+        invitation_content,
     )
     .padding(15);
+
+    let confirm_descriptor = (!imported_descriptor.value.is_empty() && imported_descriptor.valid)
+        .then_some(Message::ImportRemoteWallet(
+            message::ImportRemoteWallet::ConfirmDescriptor,
+        ));
+    let descriptor_form = column![
+        new::b5_bold("Descriptor:"),
+        form::Form::new_trimmed("Descriptor", imported_descriptor, |msg| {
+            Message::ImportRemoteWallet(message::ImportRemoteWallet::ImportDescriptor(msg))
+        })
+        .warning("Either descriptor is invalid or incompatible with network"),
+        new::b5_bold("or"),
+        button::primary(None, "Import descriptor").on_press(Message::ImportRemoteWallet(
+            message::ImportRemoteWallet::ImportDescriptorFromFile,
+        )),
+    ]
+    .spacing(10);
+    let descriptor_content = Container::new(
+        column![
+            Space::with_height(0),
+            descriptor_form,
+            row![Space::fill_width(), btn_next(confirm_descriptor)],
+        ]
+        .spacing(20),
+    )
+    .padding(15);
+
+    let descriptor = collapse::Collapse::new(
+        column![
+            new::h3_semi("Load a wallet from descriptor").style(theme::text::primary),
+            new::caption("Creates a new wallet from the descriptor").style(theme::text::secondary),
+        ]
+        .spacing(5),
+        column![
+            new::h3_semi("Load a wallet from descriptor").style(theme::text::primary),
+            new::caption("Creates a new wallet from the descriptor").style(theme::text::secondary),
+        ]
+        .spacing(5),
+        descriptor_content,
+    )
+    .padding(15);
+
+    let error = error.map(|e| card::error("Something wrong happened", e.to_string()));
+    let other_options = column![
+        card::simple(invitation).padding(0),
+        card::simple(descriptor).padding(0)
+    ]
+    .spacing(20);
+    let content = column![error, wallets, other_options, Space::with_height(10),]
+        .width(Length::Fill)
+        .align_x(Alignment::Center)
+        .spacing(50);
 
     layout(
         progress,
         network,
         email,
         "Add wallet",
-        Column::new()
-            .spacing(50)
-            .push_maybe(error.map(|e| card::error("Something wrong happened", e.to_string())))
-            .push(card_wallets)
-            .push(card::simple(col_invitation_token).padding(0))
-            .push(card::simple(col_descriptor).padding(0))
-            .push(Space::with_height(10)),
+        content,
         Some(Message::Previous),
     )
 }

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -26,12 +26,13 @@ use liana::{
 use liana_ui::{
     component::{
         button::{
-            self, btn_backup_descriptor, btn_check_connection, btn_next, btn_select, EntryWidth,
+            self, btn_backend_options_help, btn_backup_descriptor, btn_check_connection, btn_next,
+            btn_select, EntryWidth,
         },
         card, collapse, form, installer as installer_layout,
         list::DeviceStatus,
         modal, scrollable, separation,
-        text::{self, h2, h3, h4_bold, new, p1_bold, p1_regular, text, Text as _},
+        text::{self, h2, h4_bold, new, p1_bold, p1_regular, text, Text as _},
     },
     icon, theme,
     widget::*,
@@ -1581,71 +1582,70 @@ pub fn recover_mnemonic<'a>(
 }
 
 pub fn choose_backend(progress: (usize, usize), network: Network) -> Element<'static, Message> {
+    const PADDING: [u16; 2] = [0, 10];
+    let local_title = Container::new(text::new::b1_bold("Use your own node"))
+        .padding(PADDING)
+        .width(Length::FillPortion(1));
+    let remote_title = Container::new(text::new::b1_bold("Use Liana Connect"))
+        .padding(PADDING)
+        .width(Length::FillPortion(1));
+    let titles = row![local_title, remote_title].spacing(20);
+
+    let local_description =
+        Container::new(text::new::caption(LOCAL_WALLET_DESC).style(theme::text::secondary))
+            .padding(PADDING)
+            .width(Length::FillPortion(1));
+    let remote_description =
+        Container::new(text::new::caption(REMOTE_BACKEND_DESC).style(theme::text::secondary))
+            .padding(PADDING)
+            .width(Length::FillPortion(1));
+    let descriptions = row![local_description, remote_description].spacing(20);
+
+    let local_action = Container::new(
+        button::secondary(None, "Select")
+            .on_press(Message::SelectBackend(
+                message::SelectBackend::ContinueWithLocalWallet(true),
+            ))
+            .width(200),
+    )
+    .padding(PADDING)
+    .center_x(Length::FillPortion(1));
+    let remote_action = Container::new(
+        button::secondary(None, "Select")
+            .on_press(Message::SelectBackend(
+                message::SelectBackend::ContinueWithLocalWallet(false),
+            ))
+            .width(200),
+    )
+    .padding(PADDING)
+    .center_x(Length::FillPortion(1));
+    let actions = row![local_action, remote_action].spacing(20);
+
+    let help_link = tooltip::Tooltip::new(
+        btn_backend_options_help(Message::OpenUrl(
+            help::CHANGE_BACKEND_OR_NODE_URL.to_string(),
+        )),
+        Container::new(new::caption(help::CHANGE_BACKEND_OR_NODE_URL))
+            .style(theme::card::simple)
+            .padding(10),
+        tooltip::Position::Bottom,
+    );
+
+    let content = column![
+        titles,
+        descriptions,
+        actions,
+        Space::with_height(20),
+        help_link,
+    ]
+    .spacing(20);
+
     layout(
         progress,
         network,
         None,
         "Choose backend",
-        Column::new()
-            .push(
-                Row::new()
-                    .spacing(20)
-                    .push(
-                        Column::new()
-                            .spacing(20)
-                            .width(Length::FillPortion(1))
-                            .push(h3("Use your own node"))
-                            .push(text::p2_medium(LOCAL_WALLET_DESC).style(theme::text::secondary)),
-                    )
-                    .push(
-                        Column::new()
-                            .spacing(20)
-                            .width(Length::FillPortion(1))
-                            .push(h3("Use Liana Connect"))
-                            .push(
-                                text::p2_medium(REMOTE_BACKEND_DESC).style(theme::text::secondary),
-                            ),
-                    ),
-            )
-            .push(
-                Row::new()
-                    .spacing(20)
-                    .push(
-                        Container::new(
-                            button::secondary(None, "Select")
-                                .on_press(Message::SelectBackend(
-                                    message::SelectBackend::ContinueWithLocalWallet(true),
-                                ))
-                                .width(Length::Fixed(200.0)),
-                        )
-                        .width(Length::FillPortion(1)),
-                    )
-                    .push(
-                        Container::new(
-                            button::secondary(None, "Select")
-                                .on_press(Message::SelectBackend(
-                                    message::SelectBackend::ContinueWithLocalWallet(false),
-                                ))
-                                .width(Length::Fixed(200.0)),
-                        )
-                        .width(Length::FillPortion(1)),
-                    ),
-            )
-            .push(Space::with_height(20)) // ensures mouse cursor is not already on link when arriving at this step
-            .push(tooltip::Tooltip::new(
-                button::link(
-                    Some(icon::link_icon()),
-                    "More information about backend and node options",
-                )
-                .on_press(Message::OpenUrl(
-                    help::CHANGE_BACKEND_OR_NODE_URL.to_string(),
-                )),
-                Container::new(text(help::CHANGE_BACKEND_OR_NODE_URL))
-                    .style(theme::card::simple)
-                    .padding(10),
-                tooltip::Position::Bottom,
-            ))
-            .spacing(20),
+        content,
         Some(Message::Previous),
     )
 }

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -32,7 +32,7 @@ use liana_ui::{
         card, form, installer as installer_layout,
         list::{self, DeviceStatus, EntryAccent},
         modal, scrollable, separation,
-        text::{self, h2, new, p1_regular, text, Text as _},
+        text::{self, new, text, Text as _},
     },
     icon, theme,
     widget::*,
@@ -1654,20 +1654,23 @@ pub fn login(
     network: Network,
     connection_step: Element<Message>,
 ) -> Element<Message> {
+    let content = Container::new(
+        column![
+            installer_layout::screen_intro("Liana Connect", None, true),
+            connection_step,
+        ]
+        .spacing(50)
+        .align_x(Alignment::Center)
+        .width(Length::FillPortion(1)),
+    )
+    .center_x(Length::Fill);
+
     layout(
         progress,
         network,
         None,
         "Login",
-        Container::new(
-            Column::new()
-                .spacing(50)
-                .align_x(Alignment::Center)
-                .width(Length::FillPortion(1))
-                .push(h2("Liana Connect"))
-                .push(connection_step),
-        )
-        .center_x(Length::Fill),
+        content,
         Some(Message::Previous),
     )
 }
@@ -1679,122 +1682,136 @@ pub fn connection_step_enter_email<'a>(
     accounts: &'a [String],
     auth_error: Option<&'a str>,
 ) -> Element<'a, Message> {
-    Column::new()
-        .spacing(20)
-        .push_maybe(if !accounts.is_empty() {
-            Some(text("Choose an account you are already using:"))
-        } else {
-            None
+    let accounts_row = accounts.iter().fold(row![].spacing(10), |row, account| {
+        row.push(
+            Button::new(Container::new(new::caption(account)).padding(5))
+                .style(theme::button::secondary)
+                .on_press(Message::SelectBackend(
+                    message::SelectBackend::SelectConnectAccount(account.clone()),
+                )),
+        )
+    });
+    let email_prompt: Element<'_, Message> = if accounts.is_empty() {
+        new::caption("Enter an email you want to associate with the wallet:").into()
+    } else {
+        new::caption("Or enter a new email you want to associate with the wallet:").into()
+    };
+    let send_token_msg = (!(processing || !email.valid || email.value.trim().is_empty()))
+        .then_some(Message::SelectBackend(message::SelectBackend::RequestOTP));
+    let accounts_prompt: Option<Element<'_, Message>> = (!accounts.is_empty())
+        .then_some(new::caption("Choose an account you are already using:").into());
+    column![
+        accounts_prompt,
+        accounts_row.wrap(),
+        connection_error.map(|error| -> Element<'_, Message> {
+            new::caption(error.to_string())
+                .style(theme::text::warning)
+                .into()
+        }),
+        auth_error.map(|error| -> Element<'_, Message> {
+            new::caption(error.to_string())
+                .style(theme::text::warning)
+                .into()
+        }),
+        email_prompt,
+        form::Form::new_trimmed("email", email, |msg| {
+            Message::SelectBackend(message::SelectBackend::EmailEdited(msg))
         })
-        .push(
-            accounts
-                .iter()
-                .fold(Row::new().spacing(10), |row, a| {
-                    row.push(
-                        Button::new(Container::new(p1_regular(a)).padding(5))
-                            .style(theme::button::secondary)
-                            .on_press(Message::SelectBackend(
-                                message::SelectBackend::SelectConnectAccount(a.clone()),
-                            )),
-                    )
-                })
-                .wrap(),
-        )
-        .push_maybe(connection_error.map(|e| text(e.to_string()).style(theme::text::warning)))
-        .push_maybe(auth_error.map(|e| text(e.to_string()).style(theme::text::warning)))
-        .push(if accounts.is_empty() {
-            text("Enter an email you want to associate with the wallet:")
-        } else {
-            text("Or enter a new email you want to associate with the wallet:")
-        })
-        .push(
-            form::Form::new_trimmed("email", email, |msg| {
-                Message::SelectBackend(message::SelectBackend::EmailEdited(msg))
-            })
-            .size(text::P1_SIZE)
-            .padding(10)
-            .warning("Email is not valid"),
-        )
-        .push(
-            Row::new().push(Space::with_width(Length::Fill)).push(
-                button::secondary(None, "Send token")
-                    .on_press_maybe(if processing || !email.valid {
-                        None
-                    } else {
-                        Some(Message::SelectBackend(message::SelectBackend::RequestOTP))
-                    })
-                    .width(Length::Fixed(200.0)),
-            ),
-        )
-        .into()
+        .padding(10)
+        .warning("Email is not valid"),
+        row![
+            Space::fill_width(),
+            button::secondary(None, "Send token")
+                .on_press_maybe(send_token_msg)
+                .width(200),
+        ],
+    ]
+    .spacing(20)
+    .into()
+}
+
+fn otp_intro<'a>(email: &'a str) -> Column<'a, Message> {
+    column![
+        new::caption(email).style(theme::text::success),
+        new::caption("An authentication token has been emailed to you"),
+    ]
+    .spacing(20)
+}
+
+fn otp_form<'a>(otp: &'a form::Value<String>) -> form::Form<'a, Message> {
+    form::Form::new_trimmed("Token", otp, |msg| {
+        Message::SelectBackend(message::SelectBackend::OTPEdited(msg))
+    })
+    .padding(10)
+    .warning("Token is not valid")
 }
 
 pub fn connection_step_enter_otp<'a>(
     email: &'a str,
-    otp: &form::Value<String>,
+    otp: &'a form::Value<String>,
     processing: bool,
-    connection_error: Option<&Error>,
-    auth_error: Option<&'static str>,
+    connection_error: Option<&'a Error>,
+    auth_error: Option<&'a str>,
 ) -> Element<'a, Message> {
-    Column::new()
-        .spacing(20)
-        .push(text(email).style(theme::text::success))
-        .push(text("An authentication token has been emailed to you"))
-        .push_maybe(connection_error.map(|e| text(e.to_string()).style(theme::text::warning)))
-        .push_maybe(auth_error.map(|e| text(e.to_string()).style(theme::text::warning)))
-        .push(
-            form::Form::new_trimmed("Token", otp, |msg| {
-                Message::SelectBackend(message::SelectBackend::OTPEdited(msg))
-            })
-            .size(text::P1_SIZE)
-            .padding(10)
-            .warning("Token is not valid"),
-        )
-        .push(
-            Row::new()
-                .spacing(10)
-                .push(
-                    button::secondary(Some(icon::previous_icon()), "Change Email")
-                        .on_press(Message::SelectBackend(message::SelectBackend::EditEmail)),
-                )
-                .push(
-                    button::secondary(None, "Resend token").on_press_maybe(if processing {
-                        None
-                    } else {
-                        Some(Message::SelectBackend(message::SelectBackend::RequestOTP))
-                    }),
-                ),
-        )
-        .into()
+    let resend_token =
+        (!processing).then_some(Message::SelectBackend(message::SelectBackend::RequestOTP));
+    column![
+        otp_intro(email),
+        connection_error.map(|error| -> Element<'_, Message> {
+            new::caption(error.to_string())
+                .style(theme::text::warning)
+                .into()
+        }),
+        auth_error.map(|error| -> Element<'_, Message> {
+            new::caption(error.to_string())
+                .style(theme::text::warning)
+                .into()
+        }),
+        otp_form(otp),
+        row![
+            button::secondary(Some(icon::previous_icon()), "Change Email")
+                .on_press(Message::SelectBackend(message::SelectBackend::EditEmail)),
+            button::secondary(None, "Resend token").on_press_maybe(resend_token),
+        ]
+        .spacing(10),
+    ]
+    .spacing(20)
+    .into()
 }
 
 pub fn connection_step_connected<'a>(
     email: &'a str,
     processing: bool,
-    connection_error: Option<&Error>,
-    auth_error: Option<&'static str>,
+    connection_error: Option<&'a Error>,
+    auth_error: Option<&'a str>,
 ) -> Element<'a, Message> {
-    Column::new()
-        .spacing(20)
-        .push(text(email).style(theme::text::success))
-        .push_maybe(connection_error.map(|e| text(e.to_string()).style(theme::text::warning)))
-        .push_maybe(auth_error.map(|e| text(e.to_string()).style(theme::text::warning)))
-        .push(Container::new(
-            Row::new()
-                .spacing(10)
-                .push(
-                    button::secondary(Some(icon::previous_icon()), "Change Email")
-                        .on_press(Message::SelectBackend(message::SelectBackend::EditEmail)),
-                )
-                .push(
-                    button::secondary(None, "Continue").on_press_maybe(if processing {
-                        None
-                    } else {
-                        Some(Message::Next)
-                    }),
+    let msg_next = (!processing).then_some(Message::Next);
+    column![
+        new::caption(email).style(theme::text::success),
+        connection_error.map(|error| -> Element<'_, Message> {
+            new::caption(error.to_string())
+                .style(theme::text::warning)
+                .into()
+        }),
+        auth_error.map(|error| -> Element<'_, Message> {
+            new::caption(error.to_string())
+                .style(theme::text::warning)
+                .into()
+        }),
+        Container::new(
+            row![
+                button::secondary(Some(icon::previous_icon()), "Change Email").on_press_maybe(
+                    (!processing)
+                        .then_some(Message::SelectBackend(message::SelectBackend::EditEmail))
                 ),
-        ))
-        .into()
+                Space::fill_width(),
+                button::secondary(None, "Continue").on_press_maybe(msg_next),
+            ]
+            .spacing(10),
+        ),
+    ]
+    .spacing(20)
+    .into()
 }
 
 pub const REMOTE_BACKEND_DESC: &str = "Use our service to instantly be ready to transact. Wizardsardine runs the infrastructure, allowing multiple computers or participants to connect and synchronize.\n\nThis is a simpler and safer option for people who want Wizardsardine to keep a backup of their descriptor. You are still in control of your keys, and Wizardsardine does not have any control over your funds, but it will be able to see your wallet's information, associated to an email address. Privacy focused users should run their own infrastructure instead.";

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -10,7 +10,7 @@ use iced::{
 };
 
 use liana::miniscript::bitcoin::bip32::ChildNumber;
-use liana_ui::component::button::BtnWidth;
+use liana_ui::component::button::{btn_next, BtnWidth};
 use liana_ui::component::text::{self, p2_regular};
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -625,13 +625,8 @@ pub fn register_descriptor<'a>(
             .on_toggle(Message::UserActionDone),
     );
 
-    let next_button = if !created_desc || (done && !processing) {
-        button::secondary(None, "Next")
-            .on_press(Message::Next)
-            .width(200)
-    } else {
-        button::secondary(None, "Next").width(200)
-    };
+    let next = (!created_desc || (done && !processing)).then_some(Message::Next);
+    let next_button = btn_next(next);
 
     let content = Column::new()
         .push_maybe(warning)
@@ -1563,6 +1558,7 @@ pub fn backup_mnemonic<'a>(
     words: &'a [&'static str; 12],
     done: bool,
 ) -> Element<'a, Message> {
+    let msg_next = done.then_some(Message::Next);
     layout(
         progress,
         email,
@@ -1590,13 +1586,7 @@ pub fn backup_mnemonic<'a>(
                     .label("I have backed up my mnemonic")
                     .on_toggle(Message::UserActionDone),
             )
-            .push(if done {
-                button::secondary(None, "Next")
-                    .on_press(Message::Next)
-                    .width(Length::Fixed(200.0))
-            } else {
-                button::secondary(None, "Next").width(Length::Fixed(200.0))
-            })
+            .push(btn_next(msg_next))
             .push(Space::with_height(20.0))
             .spacing(50),
         true,
@@ -1938,6 +1928,7 @@ pub fn wallet_alias<'a>(
     email: Option<&'a str>,
     wallet_alias: &form::Value<String>,
 ) -> Element<'a, Message> {
+    let msg_next = wallet_alias.valid.then_some(Message::Next);
     layout(
         progress,
         email,
@@ -1957,15 +1948,7 @@ pub fn wallet_alias<'a>(
                         "You will be able to change it later in Settings > Wallet",
                     )),
             )
-            .push(
-                button::secondary(None, "Next")
-                    .width(Length::Fixed(200.0))
-                    .on_press_maybe(if wallet_alias.valid {
-                        Some(Message::Next)
-                    } else {
-                        None
-                    }),
-            )
+            .push(btn_next(msg_next))
             .spacing(50),
         true,
         Some(Message::Previous),

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -1105,111 +1105,55 @@ pub fn define_electrum<'a>(
 }
 
 pub fn select_bitcoind_type<'a>(progress: (usize, usize)) -> Element<'a, Message> {
+    let existing_node_title = Container::new(text::new::b5_bold("I already have a node"))
+        .padding(20)
+        .width(Length::FillPortion(1));
+    let managed_node_title = Container::new(text::new::b5_bold(
+        "I want Liana to automatically install a Bitcoin node on my device",
+    ))
+    .padding(20)
+    .width(Length::FillPortion(1));
+    let titles = row![existing_node_title, managed_node_title].spacing(20);
+
+    let existing_node_description = Container::new(
+        text::new::caption(
+            "Select this option if you already have a Bitcoin node running locally or remotely. Liana will connect to it.",
+        )
+        .style(theme::text::secondary),
+    )
+    .padding(20)
+    .width(Length::FillPortion(1));
+    let managed_node_description = Container::new(
+        text::new::caption(
+            "Liana will install a pruned node on your computer. You won't need to do anything except have some disk space available (~30GB required on mainnet) and wait for the initial synchronization with the network (it can take some days depending on your internet connection speed).",
+        )
+        .style(theme::text::secondary),
+    )
+    .padding(20)
+    .width(Length::FillPortion(1));
+    let descriptions = row![existing_node_description, managed_node_description].spacing(20);
+
+    let existing_node_action =
+        Container::new(button::secondary(None, "Select").width(300).on_press(
+            Message::SelectBitcoindType(message::SelectBitcoindTypeMsg::UseExternal(true)),
+        ))
+        .padding(20)
+        .center_x(Length::FillPortion(1));
+    let managed_node_action =
+        Container::new(button::secondary(None, "Select").width(300).on_press(
+            Message::SelectBitcoindType(message::SelectBitcoindTypeMsg::UseExternal(false)),
+        ))
+        .padding(20)
+        .center_x(Length::FillPortion(1));
+    let actions = row![existing_node_action, managed_node_action].spacing(20);
+
+    let content = column![titles, descriptions, actions].max_width(800);
+
     layout(
         progress,
         None,
         "Bitcoin node management",
-        Column::new()
-            .push(
-                Row::new()
-                    .align_y(Alignment::Start)
-                    .spacing(20)
-                    .push(
-                        Container::new(
-                            Column::new()
-                                .spacing(20)
-                                .width(Length::Fixed(300.0))
-                                .push(text("I already have a node").bold()),
-                        )
-                        .padding(20),
-                    )
-                    .push(
-                        Container::new(
-                            Column::new().spacing(20).width(Length::Fixed(300.0)).push(
-                                text(
-                                    "I want Liana to automatically install \
-                                    a Bitcoin node on my device",
-                                )
-                                .bold(),
-                            ),
-                        )
-                        .padding(20),
-                    ),
-            )
-            .push(
-                Row::new()
-                    .align_y(Alignment::Start)
-                    .spacing(20)
-                    .push(
-                        Container::new(
-                            Column::new()
-                                .spacing(20)
-                                .width(Length::Fixed(300.0))
-                                .align_x(Alignment::Start)
-                                .push(text(
-                                    "Select this option if you already have \
-                                    a Bitcoin node running locally or remotely. \
-                                    Liana will connect to it.",
-                                )),
-                        )
-                        .padding(20),
-                    )
-                    .push(
-                        Container::new(
-                            Column::new()
-                                .spacing(20)
-                                .width(Length::Fixed(300.0))
-                                .align_x(Alignment::Start)
-                                .push(text(
-                                    "Liana will install a pruned node \
-                                    on your computer. You won't need to do anything \
-                                    except have some disk space available \
-                                    (~30GB required on mainnet) and \
-                                    wait for the initial synchronization with the \
-                                    network (it can take some days depending on \
-                                    your internet connection speed).",
-                                )),
-                        )
-                        .padding(20),
-                    ),
-            )
-            .push(
-                Row::new()
-                    .align_y(Alignment::End)
-                    .spacing(20)
-                    .push(
-                        Container::new(
-                            Column::new()
-                                .spacing(20)
-                                .width(Length::Fixed(300.0))
-                                .align_x(Alignment::Center)
-                                .push(
-                                    button::secondary(None, "Select")
-                                        .width(Length::Fixed(300.0))
-                                        .on_press(Message::SelectBitcoindType(
-                                            message::SelectBitcoindTypeMsg::UseExternal(true),
-                                        )),
-                                ),
-                        )
-                        .padding(20),
-                    )
-                    .push(
-                        Container::new(
-                            Column::new()
-                                .spacing(20)
-                                .width(Length::Fixed(300.0))
-                                .align_x(Alignment::Center)
-                                .push(
-                                    button::secondary(None, "Select")
-                                        .width(Length::Fixed(300.0))
-                                        .on_press(Message::SelectBitcoindType(
-                                            message::SelectBitcoindTypeMsg::UseExternal(false),
-                                        )),
-                                ),
-                        )
-                        .padding(20),
-                    ),
-            ),
+        content,
         true,
         Some(Message::Previous),
     )

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -242,90 +242,61 @@ pub fn import_descriptor<'a>(
     progress: (usize, usize),
     network: Network,
     email: Option<&'a str>,
-    imported_descriptor: &form::Value<String>,
+    imported_descriptor: &'a form::Value<String>,
     imported_backup: bool,
     wrong_network: bool,
     error: Option<&String>,
 ) -> Element<'a, Message> {
     let valid = !imported_descriptor.value.is_empty() && imported_descriptor.valid;
 
-    let col_descriptor = Column::new()
-        .push(text("Descriptor:").bold())
-        .push(Space::with_height(10))
-        .push(
-            form::Form::new_trimmed("Descriptor", imported_descriptor, |msg| {
-                Message::DefineDescriptor(message::DefineDescriptor::ImportDescriptor(msg))
-            })
-            .warning(if wrong_network {
-                "The descriptor is for another network"
-            } else {
-                "Failed to read the descriptor"
-            })
-            .size(text::P1_SIZE)
-            .padding(10),
-        );
+    let import_backup: Option<Element<'a, Message>> = (!valid && !imported_backup).then_some(
+        row![
+            button::primary(None, "Import backup").on_press(Message::ImportBackup),
+            Space::fill_width()
+        ]
+        .into(),
+    );
+    let backup_imported: Option<Element<'a, Message>> = imported_backup.then_some(
+        row![
+            new::b5_bold("Backup successfully imported!"),
+            Space::fill_width()
+        ]
+        .into(),
+    );
+    let or: Option<Element<'a, Message>> = (!valid && !imported_backup)
+        .then_some(row![new::b5_bold("or"), Space::fill_width()].into());
+    let descriptor = (!imported_backup).then_some(column![
+        new::b5_bold("Descriptor:"),
+        Space::with_height(10),
+        form::Form::new_trimmed("Descriptor", imported_descriptor, |msg| {
+            Message::DefineDescriptor(message::DefineDescriptor::ImportDescriptor(msg))
+        })
+        .warning(if wrong_network {
+            "The descriptor is for another network"
+        } else {
+            "Failed to read the descriptor"
+        })
+        .padding(10),
+    ]);
+    let rescan = new::caption(
+        "If you are using a Bitcoin Core node, \
+                you will need to perform a rescan of \
+                the blockchain after creating the wallet \
+                in order to see your coins and past \
+                transactions. This can be done in \
+                Settings > Node.",
+    );
 
-    let descriptor = if imported_backup {
-        None
-    } else {
-        Some(col_descriptor)
-    };
-
-    let or = if !valid && !imported_backup {
-        Some(
-            Row::new()
-                .push(text("or").bold())
-                .push(Space::with_width(Length::Fill)),
-        )
-    } else {
-        None
-    };
-
-    let import_backup = if !valid && !imported_backup {
-        Some(
-            Row::new()
-                .push(button::primary(None, "Import backup").on_press(Message::ImportBackup))
-                .push(Space::with_width(Length::Fill)),
-        )
-    } else {
-        None
-    };
-
-    let backup_imported = if imported_backup {
-        Some(
-            Row::new()
-                .push(text("Backup successfully imported!").bold())
-                .push(Space::with_width(Length::Fill)),
-        )
-    } else {
-        None
-    };
+    let import = column![import_backup, backup_imported, or, descriptor, rescan].spacing(20);
+    let button_next = btn_next(valid.then_some(Message::Next));
+    let error_card = error.map(|e| card::error("Invalid descriptor", e.to_string()));
 
     layout(
         progress,
         network,
         email,
         "Import the wallet",
-        Column::new()
-            .push(
-                Column::new()
-                    .spacing(20)
-                    .push_maybe(import_backup)
-                    .push_maybe(backup_imported)
-                    .push_maybe(or)
-                    .push_maybe(descriptor)
-                    .push(text(
-                        "If you are using a Bitcoin Core node, \
-                you will need to perform a rescan of \
-                the blockchain after creating the wallet \
-                in order to see your coins and past \
-                transactions. This can be done in \
-                Settings > Node.",
-                    )),
-            )
-            .push(btn_next(valid.then_some(Message::Next)))
-            .push_maybe(error.map(|e| card::error("Invalid descriptor", e.to_string())))
-            .spacing(50),
+        column![import, button_next, error_card].spacing(50),
         Some(Message::Previous),
     )
 }

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -27,8 +27,8 @@ use liana_ui::{
         badge::Tile,
         button::{
             self, btn_accept, btn_backend_options_help, btn_backup_descriptor, btn_change_email,
-            btn_check_connection, btn_connect_another_email, btn_next, btn_resend_token,
-            btn_select, btn_send_token, EntryWidth,
+            btn_check_connection, btn_connect_another_email, btn_mnemonic_word, btn_next,
+            btn_resend_token, btn_select, btn_send_token, btn_skip, EntryWidth,
         },
         card, form, installer as installer_layout,
         list::{self, DeviceStatus, EntryAccent},
@@ -1485,83 +1485,90 @@ pub fn backup_mnemonic<'a>(
     )
 }
 
-fn mnemonic_suggestions<'a>(current: usize, suggestions: &'a [String]) -> Container<'a, Message> {
-    let suggestions = if !suggestions.is_empty() {
+fn mnemonic_suggestions<'a>(current: usize, suggestions: &'a [String]) -> Element<'a, Message> {
+    let s = if !suggestions.is_empty() {
         suggestions.iter().fold(Row::new().spacing(5), |row, sugg| {
-            row.push(
-                Button::new(text(sugg))
-                    .style(theme::button::secondary)
-                    .on_press(Message::MnemonicWord(current, sugg.to_string())),
-            )
+            row.push(btn_mnemonic_word(
+                sugg,
+                Message::MnemonicWord(current, sugg.to_string()),
+            ))
         })
     } else {
         Row::new()
     };
-
-    Container::new(suggestions)
-        // Fixed height in order to not move words list
-        .height(Length::Fixed(50.0))
+    scrollable::horizontal_thin(s).into()
 }
 
 fn mnemonic_word_row<'a>(i: usize, word: &'a str, valid: bool) -> Row<'a, Message> {
-    let number = Container::new(text(format!("#{}", i + 1)).small()).width(Length::Fixed(50.0));
+    let number = Container::new(new::caption(format!("#{}", i + 1))).width(Length::Fixed(30.0));
     let input =
         Container::new(TextInput::new("", word).on_input(move |msg| Message::MnemonicWord(i, msg)))
             .width(Length::Fixed(100.0));
-    let valid_icon: Option<Element<'a, Message>> =
-        valid.then_some(icon::circle_check_icon().style(theme::text::success).into());
+    let valid_icon: Element<'a, Message> = if valid {
+        icon::circle_check_icon().style(theme::text::success).into()
+    } else {
+        Space::with_width(20).into()
+    };
 
     row![number, input, valid_icon]
-        .spacing(10)
+        .spacing(5)
         .align_y(Alignment::Center)
 }
 
-fn mnemonic_words<'a>(words: &'a [(String, bool); 12]) -> Column<'a, Message> {
-    words
-        .iter()
-        .enumerate()
-        .fold(Column::new().spacing(5), |words, (i, (word, valid))| {
-            words.push(mnemonic_word_row(i, word, *valid))
-        })
+fn mnemonic_words_column<'a>(
+    words: impl Iterator<Item = (usize, &'a (String, bool))>,
+) -> Column<'a, Message> {
+    words.fold(Column::new().spacing(5), |words, (i, (word, valid))| {
+        words.push(mnemonic_word_row(i, word, *valid))
+    })
 }
 
-fn mnemonic_recovery_form<'a>(
+fn mnemonic_words<'a>(words: &'a [(String, bool); 12]) -> Element<'a, Message> {
+    Container::new(
+        row![
+            mnemonic_words_column(words.iter().enumerate().take(6)),
+            mnemonic_words_column(words.iter().enumerate().skip(6)),
+        ]
+        .spacing(10),
+    )
+    .center_x(Length::Fill)
+    .into()
+}
+
+fn import_mnemonic_entry<'a>(
+    network: Network,
     words: &'a [(String, bool); 12],
     current: usize,
     suggestions: &'a [String],
+    recover: bool,
     error: Option<&'a String>,
-) -> Column<'a, Message> {
+    next: Option<Message>,
+) -> Element<'a, Message> {
     let error = error.map(|e| card::invalid(new::caption(e).style(theme::text::error)));
-
-    column![
-        mnemonic_suggestions(current, suggestions),
+    let next = row![Space::fill_width(), btn_next(next),].align_y(Alignment::Center);
+    let form = column![
         mnemonic_words(words),
-        Space::with_height(Length::Fixed(50.0)),
+        mnemonic_suggestions(current, suggestions),
         error,
     ]
-    .align_x(Alignment::Center)
-}
+    .spacing(5)
+    .align_x(Alignment::Center);
+    let content = column![form, next].spacing(20);
+    let accent = Some(match network {
+        Network::Bitcoin => EntryAccent::Bitcoin,
+        _ => EntryAccent::Testnet,
+    });
 
-fn mnemonic_start_actions<'a>() -> Row<'a, Message> {
-    row![
-        button::secondary(None, "Import mnemonic")
-            .on_press(Message::ImportMnemonic(true))
-            .width(Length::Fixed(200.0)),
-        button::secondary(None, "Skip")
-            .on_press(Message::Skip)
-            .width(Length::Fixed(200.0)),
-    ]
-    .spacing(10)
-}
-
-fn mnemonic_recovery_actions<'a>(button_next: Element<'a, Message>) -> Row<'a, Message> {
-    row![
-        button::secondary(None, "Cancel")
-            .on_press(Message::ImportMnemonic(false))
-            .width(Length::Fixed(200.0)),
-        button_next,
-    ]
-    .spacing(10)
+    list::entry_collapsible(list::CollapsibleEntry {
+        accent,
+        tile: Tile::Import,
+        title: "Import mnemonic",
+        collapsed_subtitle: None,
+        expanded_subtitle: None,
+        content: content.into(),
+        expanded: recover,
+        on_toggle: Message::ImportMnemonic(!recover),
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1577,20 +1584,30 @@ pub fn recover_mnemonic<'a>(
 ) -> Element<'a, Message> {
     let msg_next =
         (!words.iter().any(|(_, valid)| !valid) && error.is_none()).then_some(Message::Next);
-    let button_next = btn_next(msg_next);
-    let form = recover.then_some(mnemonic_recovery_form(words, current, suggestions, error));
-    let actions = if recover {
-        mnemonic_recovery_actions(button_next.into())
-    } else {
-        mnemonic_start_actions()
-    };
+    let skip = row![Space::fill_width(), btn_skip(Some(Message::Skip))];
+    let content = column![
+        new::caption(prompt::RECOVER_MNEMONIC_HELP),
+        import_mnemonic_entry(
+            network,
+            words,
+            current,
+            suggestions,
+            recover,
+            error,
+            msg_next,
+        ),
+        skip,
+    ]
+    .spacing(50)
+    .width(EntryWidth::Standard);
+    let content = Container::new(content).center_x(Length::Fill);
 
     layout(
         progress,
         network,
         email,
         "Import Mnemonic",
-        column![text(prompt::RECOVER_MNEMONIC_HELP), form, actions].spacing(50),
+        content,
         Some(Message::Previous),
     )
 }

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -10,7 +10,7 @@ use iced::{
 };
 
 use liana::miniscript::bitcoin::bip32::ChildNumber;
-use liana_ui::component::button::{btn_next, BtnWidth};
+use liana_ui::component::button::{btn_backup_descriptor, btn_next, BtnWidth};
 use liana_ui::component::text::{self, p2_regular};
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -633,82 +633,73 @@ pub fn backup_descriptor<'a>(
     keys: &'a HashMap<Fingerprint, settings::KeySetting>,
     error: Option<&Error>,
     done: bool,
+    help_open: bool,
 ) -> Element<'a, Message> {
-    let backup_button = if done {
-        button::secondary(Some(icon::backup_icon()), "Back Up Descriptor")
-            .on_press(Message::BackupDescriptor)
-    } else {
-        button::primary(Some(icon::backup_icon()), "Back Up Descriptor")
-            .on_press(Message::BackupDescriptor)
-    };
+    let descriptor_str = descriptor.to_string();
+
+    let backup_button = btn_backup_descriptor(Some(Message::BackupDescriptor), done);
+
+    let copy_button = button::btn_copy(Some(Message::Clipboard(descriptor_str.clone())));
+
+    let help_button = modal::optional_section(
+        help_open,
+        "Learn more".to_string(),
+        || Message::ShowBackupDescriptorHelp(false),
+        || Message::ShowBackupDescriptorHelp(true),
+    );
+    let help = help_open.then_some(text::new::caption(prompt::BACKUP_DESCRIPTOR_HELP));
+    let intro = column![
+        text::new::caption(prompt::BACKUP_DESCRIPTOR_MESSAGE),
+        help_button,
+        help,
+    ]
+    .max_width(1000);
+
+    let error_card = error.map(|e| card::error("Failed to export backup", e.to_string()));
+
+    let descriptor_scroll =
+        scrollable::horizontal_thin(column![text::new::caption(descriptor_str)])
+            .width(Length::Fill);
+    let descriptor_actions = row![Space::fill_width(), backup_button];
+    let descriptor_header = row![descriptor_scroll, copy_button]
+        .align_y(Alignment::Center)
+        .spacing(10);
+    let descriptor_card = card::simple(
+        column![
+            text::new::b5_bold("The descriptor:"),
+            descriptor_header,
+            descriptor_actions,
+        ]
+        .spacing(10),
+    )
+    .max_width(1500);
+
+    let policy_card = card::simple(display_policy(descriptor.policy(), keys))
+        .width(Length::Fill)
+        .max_width(1500);
+
+    let backup_checkbox = checkbox(done)
+        .label("I have backed up my descriptor")
+        .on_toggle(Message::UserActionDone);
+
+    let next_button = btn_next(done.then_some(Message::Next));
+
+    let content = column![
+        intro,
+        error_card,
+        descriptor_card,
+        policy_card,
+        backup_checkbox,
+        next_button,
+        Space::with_height(20),
+    ]
+    .spacing(50);
 
     layout(
         progress,
         email,
         "Back Up your wallet configuration (Descriptor)",
-        Column::new()
-            .push(
-                Column::new()
-                    .push(text(prompt::BACKUP_DESCRIPTOR_MESSAGE))
-                    .push(
-                        collapse::Collapse::new(
-                            Row::new()
-                                .align_y(Alignment::Center)
-                                .spacing(10)
-                                .push(text("Learn more").small().bold())
-                                .push(icon::collapse_icon()),
-                            Row::new()
-                                .align_y(Alignment::Center)
-                                .spacing(10)
-                                .push(text("Learn more").small().bold())
-                                .push(icon::collapsed_icon()),
-                            help_backup(),
-                        )
-                        .style(theme::button::transparent),
-                    )
-                    .max_width(1000),
-            )
-            .push_maybe(error.map(|e| card::error("Failed to export backup", e.to_string())))
-            .push(
-                card::simple(
-                    Column::new()
-                        .push(text("The descriptor:").small().bold())
-                        .push(
-                            Row::new()
-                                .align_y(Alignment::Center)
-                                .spacing(10)
-                                .push(
-                                    scrollable::horizontal_thin(
-                                        Column::new().push(text(descriptor.to_string()).small()),
-                                    )
-                                    .width(Length::Fill),
-                                )
-                                .push(button::btn_copy(Some(Message::Clipboard(
-                                    descriptor.to_string(),
-                                )))),
-                        )
-                        .push(
-                            Row::new()
-                                .push(Space::with_width(Length::Fill))
-                                .push(backup_button),
-                        )
-                        .spacing(10),
-                )
-                .max_width(1500),
-            )
-            .push(
-                card::simple(display_policy(descriptor.policy(), keys))
-                    .width(Length::Fill)
-                    .max_width(1500),
-            )
-            .push(
-                checkbox(done)
-                    .label("I have backed up my descriptor")
-                    .on_toggle(Message::UserActionDone),
-            )
-            .push(btn_next(done.then_some(Message::Next)))
-            .push(Space::with_height(20.0))
-            .spacing(50),
+        content,
         true,
         Some(Message::Previous),
     )
@@ -878,10 +869,6 @@ fn expire_message_units(sequence: u32) -> Vec<String> {
             })
             .collect()
     }
-}
-
-pub fn help_backup<'a>() -> Element<'a, Message> {
-    text(prompt::BACKUP_DESCRIPTOR_HELP).small().into()
 }
 
 pub fn define_bitcoin_node<'a>(

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -635,31 +635,30 @@ pub fn backup_descriptor<'a>(
     done: bool,
     help_open: bool,
 ) -> Element<'a, Message> {
-    let descriptor_str = descriptor.to_string();
-
-    let backup_button = btn_backup_descriptor(Some(Message::BackupDescriptor), done);
-
-    let copy_button = button::btn_copy(Some(Message::Clipboard(descriptor_str.clone())));
-
     let help_button = modal::optional_section(
         help_open,
         "Learn more".to_string(),
-        || Message::ShowBackupDescriptorHelp(false),
         || Message::ShowBackupDescriptorHelp(true),
+        || Message::ShowBackupDescriptorHelp(false),
     );
     let help = help_open.then_some(text::new::caption(prompt::BACKUP_DESCRIPTOR_HELP));
     let intro = column![
         text::new::caption(prompt::BACKUP_DESCRIPTOR_MESSAGE),
         help_button,
         help,
-    ]
-    .max_width(1000);
+    ];
 
     let error_card = error.map(|e| card::error("Failed to export backup", e.to_string()));
 
+    let descriptor_str = descriptor.to_string();
+
+    let backup_button = btn_backup_descriptor(Some(Message::BackupDescriptor), !done);
+    let copy_button = column![
+        button::btn_copy(Some(Message::Clipboard(descriptor_str.clone()))),
+        Space::with_height(10)
+    ];
     let descriptor_scroll =
-        scrollable::horizontal_thin(column![text::new::caption(descriptor_str)])
-            .width(Length::Fill);
+        scrollable::horizontal_thin(text::new::caption(descriptor_str)).width(Length::Fill);
     let descriptor_actions = row![Space::fill_width(), backup_button];
     let descriptor_header = row![descriptor_scroll, copy_button]
         .align_y(Alignment::Center)
@@ -671,18 +670,16 @@ pub fn backup_descriptor<'a>(
             descriptor_actions,
         ]
         .spacing(10),
-    )
-    .max_width(1500);
+    );
 
-    let policy_card = card::simple(display_policy(descriptor.policy(), keys))
-        .width(Length::Fill)
-        .max_width(1500);
+    let policy_card = card::simple(display_policy(descriptor.policy(), keys)).width(Length::Fill);
 
     let backup_checkbox = checkbox(done)
         .label("I have backed up my descriptor")
         .on_toggle(Message::UserActionDone);
 
-    let next_button = btn_next(done.then_some(Message::Next));
+    let button_next = btn_next(done.then_some(Message::Next));
+    let row_next = row![Space::fill_width(), button_next];
 
     let content = column![
         intro,
@@ -690,9 +687,10 @@ pub fn backup_descriptor<'a>(
         descriptor_card,
         policy_card,
         backup_checkbox,
-        next_button,
+        row_next,
         Space::with_height(20),
     ]
+    .max_width(800)
     .spacing(50);
 
     layout(

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -1163,117 +1163,94 @@ pub fn start_internal_bitcoind<'a>(
     install_state: Option<&InstallState>,
 ) -> Element<'a, Message> {
     let version = crate::node::bitcoind::VERSION;
-    let msg_next = if let Some(Ok(_)) = started {
-        Some(Message::Next)
-    } else {
-        None
+    let msg_next = matches!(started, Some(Ok(_))).then_some(Message::Next);
+    let status = |icon: Option<Text<'static>>, label: Text<'static>| {
+        match icon {
+            Some(icon) => row![icon, label],
+            None => row![label],
+        }
+        .spacing(10)
+        .align_y(Alignment::Center)
     };
+    let empty_status = || row![].spacing(10).align_y(Alignment::Center);
+
+    let download = download_state.map(|state| match state {
+        DownloadState::Idle => empty_status(),
+        DownloadState::Downloading { progress } => status(
+            None,
+            new::caption(format!(
+                "Downloading Bitcoin Core {version}... {progress:.2}%"
+            )),
+        ),
+        DownloadState::Finished(_) => status(
+            Some(icon::circle_check_icon().style(theme::text::success)),
+            new::caption("Download complete").style(theme::text::success),
+        ),
+        DownloadState::Errored(e) => status(
+            Some(icon::circle_cross_icon().style(theme::text::error)),
+            new::caption(format!("Download failed: '{e}'.")).style(theme::text::error),
+        ),
+    });
+
+    let install: Element<'static, Message> = match (install_state, exe_path, download_state) {
+        (Some(InstallState::InProgress), _, _) => {
+            status(None, new::caption("Installing bitcoind...")).into()
+        }
+        (Some(InstallState::Finished), _, _) => status(
+            Some(icon::circle_check_icon().style(theme::text::success)),
+            new::caption("Installation complete").style(theme::text::success),
+        )
+        .into(),
+        (Some(InstallState::Errored(e)), _, _) => status(
+            Some(icon::circle_cross_icon().style(theme::text::error)),
+            new::caption(format!("Installation failed: '{e}'.")).style(theme::text::error),
+        )
+        .into(),
+        (None, Some(_), _) => status(
+            Some(icon::circle_check_icon().style(theme::text::success)),
+            new::caption("Liana-managed bitcoind already installed").style(theme::text::success),
+        )
+        .into(),
+        (None, None, Some(DownloadState::Downloading { progress })) => {
+            row![progress_bar(0.0..=100.0, *progress)]
+                .spacing(10)
+                .align_y(Alignment::Center)
+                .into()
+        }
+        (None, None, _) => empty_status().into(),
+    };
+
+    let started: Element<'static, Message> = match started {
+        Some(Ok(())) => status(
+            Some(icon::circle_check_icon().style(theme::text::success)),
+            new::caption("Started").style(theme::text::success),
+        )
+        .into(),
+        Some(Err(e)) => status(
+            Some(icon::circle_cross_icon().style(theme::text::error)),
+            new::caption(e.to_string()).style(theme::text::error),
+        )
+        .into(),
+        None => match (install_state, exe_path) {
+            // We have either just installed bitcoind or it was already installed.
+            (Some(InstallState::Finished), _) | (None, Some(_)) => {
+                status(None, new::caption("Starting...")).into()
+            }
+            _ => Space::with_height(25).into(),
+        },
+    };
+
+    let button_next = row![Space::fill_width(), btn_next(msg_next)];
+    let error = error.map(|e| card::invalid(new::caption(e)));
+    let content = column![download, install, started, button_next, error].spacing(50);
+
     layout(
         progress,
         network,
         None,
         "Start Bitcoin full node",
-        Column::new()
-            .push_maybe(download_state.map(|s| {
-                match s {
-                    DownloadState::Finished(_) => Row::new()
-                        .spacing(10)
-                        .align_y(Alignment::Center)
-                        .push(icon::circle_check_icon().style(theme::text::success))
-                        .push(new::caption("Download complete").style(theme::text::success)),
-                    DownloadState::Downloading { progress } => Row::new()
-                        .spacing(10)
-                        .align_y(Alignment::Center)
-                        .push(new::caption(format!(
-                            "Downloading Bitcoin Core {version}... {progress:.2}%"
-                        ))),
-                    DownloadState::Errored(e) => Row::new()
-                        .spacing(10)
-                        .align_y(Alignment::Center)
-                        .push(icon::circle_cross_icon().style(theme::text::error))
-                        .push(
-                            new::caption(format!("Download failed: '{e}'."))
-                                .style(theme::text::error),
-                        ),
-                    _ => Row::new().spacing(10).align_y(Alignment::Center),
-                }
-            }))
-            .push(Container::new(if let Some(state) = install_state {
-                match state {
-                    InstallState::InProgress => Row::new()
-                        .spacing(10)
-                        .align_y(Alignment::Center)
-                        .push("Installing bitcoind..."),
-                    InstallState::Finished => Row::new()
-                        .spacing(10)
-                        .align_y(Alignment::Center)
-                        .push(icon::circle_check_icon().style(theme::text::success))
-                        .push(new::caption("Installation complete").style(theme::text::success)),
-                    InstallState::Errored(e) => Row::new()
-                        .spacing(10)
-                        .align_y(Alignment::Center)
-                        .push(icon::circle_cross_icon().style(theme::text::error))
-                        .push(
-                            new::caption(format!("Installation failed: '{e}'."))
-                                .style(theme::text::error),
-                        ),
-                }
-            } else if exe_path.is_some() {
-                Row::new()
-                    .spacing(10)
-                    .align_y(Alignment::Center)
-                    .push(icon::circle_check_icon().style(theme::text::success))
-                    .push(
-                        new::caption("Liana-managed bitcoind already installed")
-                            .style(theme::text::success),
-                    )
-            } else if let Some(DownloadState::Downloading { progress }) = download_state {
-                Row::new()
-                    .spacing(10)
-                    .align_y(Alignment::Center)
-                    .push(progress_bar(0.0..=100.0, *progress))
-            } else {
-                Row::new().spacing(10).align_y(Alignment::Center)
-            }))
-            .push_maybe(if started.is_some() {
-                started.map(|res| {
-                    if res.is_ok() {
-                        Container::new(
-                            Row::new()
-                                .spacing(10)
-                                .align_y(Alignment::Center)
-                                .push(icon::circle_check_icon().style(theme::text::success))
-                                .push(new::caption("Started").style(theme::text::success)),
-                        )
-                    } else {
-                        Container::new(
-                            Row::new()
-                                .spacing(10)
-                                .align_y(Alignment::Center)
-                                .push(icon::circle_cross_icon().style(theme::text::error))
-                                .push(
-                                    new::caption(res.as_ref().err().unwrap().to_string())
-                                        .style(theme::text::error),
-                                ),
-                        )
-                    }
-                })
-            } else {
-                match (install_state, exe_path) {
-                    // We have either just installed bitcoind or it was already installed.
-                    (Some(InstallState::Finished), _) | (None, Some(_)) => Some(Container::new(
-                        Row::new()
-                            .spacing(10)
-                            .align_y(Alignment::Center)
-                            .push(new::caption("Starting...")),
-                    )),
-                    _ => Some(Container::new(Space::with_height(Length::Fixed(25.0)))),
-                }
-            })
-            .spacing(50)
-            .push(btn_next(msg_next))
-            .push_maybe(error.map(|e| card::invalid(new::caption(e)))),
-        Some(message::Message::InternalBitcoind(
+        content,
+        Some(Message::InternalBitcoind(
             message::InternalBitcoindMsg::Previous,
         )),
     )

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -26,15 +26,18 @@ use liana_ui::{
     component::{
         badge::Tile,
         button::{
-            self, btn_accept, btn_backend_options_help, btn_backup_descriptor,
-            btn_check_connection, btn_next, btn_select, EntryWidth,
+            self, btn_accept, btn_backend_options_help, btn_backup_descriptor, btn_change_email,
+            btn_check_connection, btn_connect_another_email, btn_next, btn_resend_token,
+            btn_select, btn_send_token, EntryWidth,
         },
         card, form, installer as installer_layout,
         list::{self, DeviceStatus, EntryAccent},
         modal, scrollable, separation,
         text::{self, new, text, Text as _},
     },
-    icon, theme,
+    icon,
+    spacing::VSpacing,
+    theme,
     widget::*,
     Variant,
 };
@@ -1649,60 +1652,63 @@ pub fn choose_backend(progress: (usize, usize), network: Network) -> Element<'st
     )
 }
 
-pub fn login(
+pub fn login<'a>(
     progress: (usize, usize),
     network: Network,
-    connection_step: Element<Message>,
-) -> Element<Message> {
+    prompt: &'static str,
+    accent: Option<&'a str>,
+    connection_step: Element<'a, Message>,
+    previous_message: Option<Message>,
+) -> Element<'a, Message> {
     let content = Container::new(
         column![
-            installer_layout::screen_intro("Liana Connect", None, true),
+            installer_layout::screen_intro(
+                "Liana Connect",
+                Some(installer_layout::intro_prompt(prompt, accent)),
+                true,
+            ),
             connection_step,
         ]
-        .spacing(50)
+        .spacing(VSpacing::L)
         .align_x(Alignment::Center)
-        .width(Length::FillPortion(1)),
+        .width(button::STANDARD_ENTRY_WIDTH),
     )
     .center_x(Length::Fill);
 
-    layout(
-        progress,
-        network,
-        None,
-        "Login",
-        content,
-        Some(Message::Previous),
-    )
+    layout(progress, network, None, "Login", content, previous_message)
 }
 
-pub fn connection_step_enter_email<'a>(
-    email: &'a form::Value<String>,
-    processing: bool,
-    connection_error: Option<&'a Error>,
+pub fn connection_step_select_account<'a>(
+    progress: (usize, usize),
+    network: Network,
     accounts: &'a [String],
+    processing: bool,
+    selected_email: Option<&'a str>,
+    connection_error: Option<&'a Error>,
     auth_error: Option<&'a str>,
 ) -> Element<'a, Message> {
-    let accounts_row = accounts.iter().fold(row![].spacing(10), |row, account| {
-        row.push(
-            Button::new(Container::new(new::caption(account)).padding(5))
-                .style(theme::button::secondary)
-                .on_press(Message::SelectBackend(
+    let header_content = installer_layout::screen_intro(
+        "Liana Connect",
+        Some(installer_layout::intro_prompt(
+            "Select an account to continue",
+            None,
+        )),
+        false,
+    );
+    let accounts = accounts.iter().fold(
+        column![].spacing(VSpacing::M).align_x(Alignment::Center),
+        |accounts, account| {
+            let is_selected = selected_email == Some(account.as_str());
+            accounts.push(list::account_select_entry(
+                text::short_email(account, 40),
+                processing && is_selected,
+                (!processing).then_some(Message::SelectBackend(
                     message::SelectBackend::SelectConnectAccount(account.clone()),
                 )),
-        )
-    });
-    let email_prompt: Element<'_, Message> = if accounts.is_empty() {
-        new::caption("Enter an email you want to associate with the wallet:").into()
-    } else {
-        new::caption("Or enter a new email you want to associate with the wallet:").into()
-    };
-    let send_token_msg = (!(processing || !email.valid || email.value.trim().is_empty()))
-        .then_some(Message::SelectBackend(message::SelectBackend::RequestOTP));
-    let accounts_prompt: Option<Element<'_, Message>> = (!accounts.is_empty())
-        .then_some(new::caption("Choose an account you are already using:").into());
-    column![
-        accounts_prompt,
-        accounts_row.wrap(),
+            ))
+        },
+    );
+    let list_content = column![
         connection_error.map(|error| -> Element<'_, Message> {
             new::caption(error.to_string())
                 .style(theme::text::warning)
@@ -1713,50 +1719,122 @@ pub fn connection_step_enter_email<'a>(
                 .style(theme::text::warning)
                 .into()
         }),
-        email_prompt,
-        form::Form::new_trimmed("email", email, |msg| {
+        accounts,
+    ]
+    .spacing(VSpacing::M);
+    let new_email = btn_connect_another_email((!processing).then_some(Message::SelectBackend(
+        message::SelectBackend::ConnectWithAnotherEmail,
+    )));
+
+    installer_layout::layout_with_scrollable_list(
+        installer_layout::LayoutConfig {
+            variant: Variant::Liana,
+            network,
+            email: None,
+            is_ws_admin: false,
+            nav_bar: installer_layout::NavBar::StepTitle {
+                progress,
+                title: "Login",
+                previous_message: (!processing).then_some(Message::Previous),
+            },
+            content_width: button::STANDARD_ENTRY_WIDTH,
+        },
+        Some(header_content),
+        list_content,
+        Some(new_email.into()),
+        None,
+    )
+}
+
+pub fn connection_step_enter_email<'a>(
+    progress: (usize, usize),
+    network: Network,
+    email: &'a form::Value<String>,
+    processing: bool,
+    connection_error: Option<&'a Error>,
+    auth_error: Option<&'a str>,
+    can_go_back_to_accounts: bool,
+) -> Element<'a, Message> {
+    let previous = (!processing).then_some(if can_go_back_to_accounts {
+        Message::SelectBackend(message::SelectBackend::BackToConnectAccounts)
+    } else {
+        Message::Previous
+    });
+    let can_send_token = !(processing || !email.valid || email.value.trim().is_empty());
+    let email_form = (if processing {
+        form::Form::new_disabled("Email", email)
+    } else {
+        form::Form::new_trimmed("Email", email, |msg| {
             Message::SelectBackend(message::SelectBackend::EmailEdited(msg))
         })
-        .padding(10)
-        .warning("Email is not valid"),
-        row![
-            Space::fill_width(),
-            button::secondary(None, "Send token")
-                .on_press_maybe(send_token_msg)
-                .width(200),
-        ],
-    ]
-    .spacing(20)
-    .into()
-}
-
-fn otp_intro<'a>(email: &'a str) -> Column<'a, Message> {
-    column![
-        new::caption(email).style(theme::text::success),
-        new::caption("An authentication token has been emailed to you"),
-    ]
-    .spacing(20)
-}
-
-fn otp_form<'a>(otp: &'a form::Value<String>) -> form::Form<'a, Message> {
-    form::Form::new_trimmed("Token", otp, |msg| {
-        Message::SelectBackend(message::SelectBackend::OTPEdited(msg))
     })
+    .on_submit_maybe(
+        can_send_token.then_some(Message::SelectBackend(message::SelectBackend::RequestOTP)),
+    )
+    .id("login_email")
     .padding(10)
-    .warning("Token is not valid")
+    .warning("Email is not valid");
+    let content = column![
+        Container::new(email_form).width(Length::Fill),
+        connection_error.map(|error| -> Element<'_, Message> {
+            new::caption(error.to_string())
+                .style(theme::text::warning)
+                .into()
+        }),
+        auth_error.map(|error| -> Element<'_, Message> {
+            new::caption(error.to_string())
+                .style(theme::text::warning)
+                .into()
+        }),
+        btn_send_token(
+            can_send_token.then_some(Message::SelectBackend(message::SelectBackend::RequestOTP,))
+        ),
+    ]
+    .spacing(VSpacing::L)
+    .width(Length::Fill);
+
+    login(
+        progress,
+        network,
+        "Enter the email associated with your account",
+        None,
+        content.into(),
+        previous,
+    )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn connection_step_enter_otp<'a>(
+    progress: (usize, usize),
+    network: Network,
     email: &'a str,
     otp: &'a form::Value<String>,
     processing: bool,
     connection_error: Option<&'a Error>,
     auth_error: Option<&'a str>,
+    can_go_back_to_accounts: bool,
 ) -> Element<'a, Message> {
+    let previous = (!processing).then_some(if can_go_back_to_accounts {
+        Message::SelectBackend(message::SelectBackend::BackToConnectAccounts)
+    } else {
+        Message::SelectBackend(message::SelectBackend::EditEmail)
+    });
+    let otp_form = (if processing {
+        form::Form::new_disabled("Token", otp)
+    } else {
+        form::Form::new_trimmed("Token", otp, |msg| {
+            Message::SelectBackend(message::SelectBackend::OTPEdited(msg))
+        })
+    })
+    .id("login_code")
+    .padding(10)
+    .warning("Token is not valid");
     let resend_token =
         (!processing).then_some(Message::SelectBackend(message::SelectBackend::RequestOTP));
-    column![
-        otp_intro(email),
+    let change_email =
+        (!processing).then_some(Message::SelectBackend(message::SelectBackend::EditEmail));
+    let content = column![
+        Container::new(otp_form).width(Length::Fill),
         connection_error.map(|error| -> Element<'_, Message> {
             new::caption(error.to_string())
                 .style(theme::text::warning)
@@ -1767,27 +1845,41 @@ pub fn connection_step_enter_otp<'a>(
                 .style(theme::text::warning)
                 .into()
         }),
-        otp_form(otp),
         row![
-            button::secondary(Some(icon::previous_icon()), "Change Email")
-                .on_press(Message::SelectBackend(message::SelectBackend::EditEmail)),
-            button::secondary(None, "Resend token").on_press_maybe(resend_token),
+            btn_change_email(change_email),
+            btn_resend_token(resend_token),
         ]
         .spacing(10),
     ]
-    .spacing(20)
-    .into()
+    .spacing(VSpacing::L)
+    .width(Length::Fill);
+
+    login(
+        progress,
+        network,
+        "An authentication token has been emailed to ",
+        Some(email),
+        content.into(),
+        previous,
+    )
 }
 
 pub fn connection_step_connected<'a>(
+    progress: (usize, usize),
+    network: Network,
     email: &'a str,
     processing: bool,
     connection_error: Option<&'a Error>,
     auth_error: Option<&'a str>,
+    can_go_back_to_accounts: bool,
 ) -> Element<'a, Message> {
+    let previous = (!processing).then_some(if can_go_back_to_accounts {
+        Message::SelectBackend(message::SelectBackend::BackToConnectAccounts)
+    } else {
+        Message::SelectBackend(message::SelectBackend::EditEmail)
+    });
     let msg_next = (!processing).then_some(Message::Next);
-    column![
-        new::caption(email).style(theme::text::success),
+    let content = column![
         connection_error.map(|error| -> Element<'_, Message> {
             new::caption(error.to_string())
                 .style(theme::text::warning)
@@ -1800,18 +1892,27 @@ pub fn connection_step_connected<'a>(
         }),
         Container::new(
             row![
-                button::secondary(Some(icon::previous_icon()), "Change Email").on_press_maybe(
+                btn_change_email(
                     (!processing)
-                        .then_some(Message::SelectBackend(message::SelectBackend::EditEmail))
+                        .then_some(Message::SelectBackend(message::SelectBackend::EditEmail,))
                 ),
                 Space::fill_width(),
-                button::secondary(None, "Continue").on_press_maybe(msg_next),
+                btn_next(msg_next),
             ]
             .spacing(10),
         ),
     ]
-    .spacing(20)
-    .into()
+    .spacing(VSpacing::L)
+    .width(Length::Fill);
+
+    login(
+        progress,
+        network,
+        "Connected to ",
+        Some(email),
+        content.into(),
+        previous,
+    )
 }
 
 pub const REMOTE_BACKEND_DESC: &str = "Use our service to instantly be ready to transact. Wizardsardine runs the infrastructure, allowing multiple computers or participants to connect and synchronize.\n\nThis is a simpler and safer option for people who want Wizardsardine to keep a backup of their descriptor. You are still in control of your keys, and Wizardsardine does not have any control over your funds, but it will be able to see your wallet's information, associated to an email address. Privacy focused users should run their own infrastructure instead.";

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -1485,6 +1485,85 @@ pub fn backup_mnemonic<'a>(
     )
 }
 
+fn mnemonic_suggestions<'a>(current: usize, suggestions: &'a [String]) -> Container<'a, Message> {
+    let suggestions = if !suggestions.is_empty() {
+        suggestions.iter().fold(Row::new().spacing(5), |row, sugg| {
+            row.push(
+                Button::new(text(sugg))
+                    .style(theme::button::secondary)
+                    .on_press(Message::MnemonicWord(current, sugg.to_string())),
+            )
+        })
+    } else {
+        Row::new()
+    };
+
+    Container::new(suggestions)
+        // Fixed height in order to not move words list
+        .height(Length::Fixed(50.0))
+}
+
+fn mnemonic_word_row<'a>(i: usize, word: &'a str, valid: bool) -> Row<'a, Message> {
+    let number = Container::new(text(format!("#{}", i + 1)).small()).width(Length::Fixed(50.0));
+    let input =
+        Container::new(TextInput::new("", word).on_input(move |msg| Message::MnemonicWord(i, msg)))
+            .width(Length::Fixed(100.0));
+    let valid_icon: Option<Element<'a, Message>> =
+        valid.then_some(icon::circle_check_icon().style(theme::text::success).into());
+
+    row![number, input, valid_icon]
+        .spacing(10)
+        .align_y(Alignment::Center)
+}
+
+fn mnemonic_words<'a>(words: &'a [(String, bool); 12]) -> Column<'a, Message> {
+    words
+        .iter()
+        .enumerate()
+        .fold(Column::new().spacing(5), |words, (i, (word, valid))| {
+            words.push(mnemonic_word_row(i, word, *valid))
+        })
+}
+
+fn mnemonic_recovery_form<'a>(
+    words: &'a [(String, bool); 12],
+    current: usize,
+    suggestions: &'a [String],
+    error: Option<&'a String>,
+) -> Column<'a, Message> {
+    let error = error.map(|e| card::invalid(new::caption(e).style(theme::text::error)));
+
+    column![
+        mnemonic_suggestions(current, suggestions),
+        mnemonic_words(words),
+        Space::with_height(Length::Fixed(50.0)),
+        error,
+    ]
+    .align_x(Alignment::Center)
+}
+
+fn mnemonic_start_actions<'a>() -> Row<'a, Message> {
+    row![
+        button::secondary(None, "Import mnemonic")
+            .on_press(Message::ImportMnemonic(true))
+            .width(Length::Fixed(200.0)),
+        button::secondary(None, "Skip")
+            .on_press(Message::Skip)
+            .width(Length::Fixed(200.0)),
+    ]
+    .spacing(10)
+}
+
+fn mnemonic_recovery_actions<'a>(button_next: Element<'a, Message>) -> Row<'a, Message> {
+    row![
+        button::secondary(None, "Cancel")
+            .on_press(Message::ImportMnemonic(false))
+            .width(Length::Fixed(200.0)),
+        button_next,
+    ]
+    .spacing(10)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn recover_mnemonic<'a>(
     progress: (usize, usize),
@@ -1499,96 +1578,19 @@ pub fn recover_mnemonic<'a>(
     let msg_next =
         (!words.iter().any(|(_, valid)| !valid) && error.is_none()).then_some(Message::Next);
     let button_next = btn_next(msg_next);
+    let form = recover.then_some(mnemonic_recovery_form(words, current, suggestions, error));
+    let actions = if recover {
+        mnemonic_recovery_actions(button_next.into())
+    } else {
+        mnemonic_start_actions()
+    };
 
     layout(
         progress,
         network,
         email,
         "Import Mnemonic",
-        Column::new()
-            .push(text(prompt::RECOVER_MNEMONIC_HELP))
-            .push_maybe(if recover {
-                Some(
-                    Column::new()
-                        .align_x(Alignment::Center)
-                        .push(
-                            Container::new(if !suggestions.is_empty() {
-                                suggestions.iter().fold(Row::new().spacing(5), |row, sugg| {
-                                    row.push(
-                                        Button::new(text(sugg))
-                                            .style(theme::button::secondary)
-                                            .on_press(Message::MnemonicWord(
-                                                current,
-                                                sugg.to_string(),
-                                            )),
-                                    )
-                                })
-                            } else {
-                                Row::new()
-                            })
-                            // Fixed height in order to not move words list
-                            .height(Length::Fixed(50.0)),
-                        )
-                        .push(words.iter().enumerate().fold(
-                            Column::new().spacing(5),
-                            |acc, (i, (word, valid))| {
-                                acc.push(
-                                    Row::new()
-                                        .spacing(10)
-                                        .align_y(Alignment::Center)
-                                        .push(
-                                            Container::new(text(format!("#{}", i + 1)).small())
-                                                .width(Length::Fixed(50.0)),
-                                        )
-                                        .push(
-                                            Container::new(TextInput::new("", word).on_input(
-                                                move |msg| Message::MnemonicWord(i, msg),
-                                            ))
-                                            .width(Length::Fixed(100.0)),
-                                        )
-                                        .push_maybe(if *valid {
-                                            Some(
-                                                icon::circle_check_icon()
-                                                    .style(theme::text::success),
-                                            )
-                                        } else {
-                                            None
-                                        }),
-                                )
-                            },
-                        ))
-                        .push(Space::with_height(Length::Fixed(50.0)))
-                        .push_maybe(
-                            error.map(|e| card::invalid(text(e).style(theme::text::error))),
-                        ),
-                )
-            } else {
-                None
-            })
-            .push(if !recover {
-                Row::new()
-                    .spacing(10)
-                    .push(
-                        button::secondary(None, "Import mnemonic")
-                            .on_press(Message::ImportMnemonic(true))
-                            .width(Length::Fixed(200.0)),
-                    )
-                    .push(
-                        button::secondary(None, "Skip")
-                            .on_press(Message::Skip)
-                            .width(Length::Fixed(200.0)),
-                    )
-            } else {
-                Row::new()
-                    .spacing(10)
-                    .push(
-                        button::secondary(None, "Cancel")
-                            .on_press(Message::ImportMnemonic(false))
-                            .width(Length::Fixed(200.0)),
-                    )
-                    .push(button_next)
-            })
-            .spacing(50),
+        column![text(prompt::RECOVER_MNEMONIC_HELP), form, actions].spacing(50),
         Some(Message::Previous),
     )
 }

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -238,6 +238,7 @@ pub fn import_wallet_or_descriptor<'a>(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn import_descriptor<'a>(
     progress: (usize, usize),
     network: Network,
@@ -246,26 +247,23 @@ pub fn import_descriptor<'a>(
     imported_backup: bool,
     wrong_network: bool,
     error: Option<&String>,
+    paste_descriptor_expanded: bool,
 ) -> Element<'a, Message> {
     let valid = !imported_descriptor.value.is_empty() && imported_descriptor.valid;
-
-    let import_backup: Option<Element<'a, Message>> = (!valid && !imported_backup).then_some(
-        row![
-            button::primary(None, "Import backup").on_press(Message::ImportBackup),
-            Space::fill_width()
-        ]
-        .into(),
+    let accent = Some(match network {
+        Network::Bitcoin => EntryAccent::Bitcoin,
+        _ => EntryAccent::Testnet,
+    });
+    let import_backup = list::entry_action_accent(
+        accent,
+        Tile::Import,
+        "Import a backup",
+        None::<String>,
+        None,
+        button::EntryWidth::Standard,
+        Some(Message::ImportBackup),
     );
-    let backup_imported: Option<Element<'a, Message>> = imported_backup.then_some(
-        row![
-            new::b5_bold("Backup successfully imported!"),
-            Space::fill_width()
-        ]
-        .into(),
-    );
-    let or: Option<Element<'a, Message>> = (!valid && !imported_backup)
-        .then_some(row![new::b5_bold("or"), Space::fill_width()].into());
-    let descriptor = (!imported_backup).then_some(column![
+    let descriptor_form = column![
         new::b5_bold("Descriptor:"),
         Space::with_height(10),
         form::Form::new_trimmed("Descriptor", imported_descriptor, |msg| {
@@ -277,26 +275,59 @@ pub fn import_descriptor<'a>(
             "Failed to read the descriptor"
         })
         .padding(10),
-    ]);
-    let rescan = new::caption(
-        "If you are using a Bitcoin Core node, \
-                you will need to perform a rescan of \
-                the blockchain after creating the wallet \
-                in order to see your coins and past \
-                transactions. This can be done in \
-                Settings > Node.",
+    ];
+    let paste_descriptor = list::entry_collapsible(list::CollapsibleEntry {
+        accent,
+        tile: Tile::Paste,
+        title: "Paste a descriptor",
+        collapsed_subtitle: Some("Creates a new wallet from the pasted descriptor"),
+        expanded_subtitle: Some("Creates a new wallet from the pasted descriptor"),
+        content: descriptor_form.into(),
+        expanded: paste_descriptor_expanded,
+        on_toggle: Message::DefineDescriptor(message::DefineDescriptor::ShowImportDescriptor(
+            !paste_descriptor_expanded,
+        )),
+    });
+    let import = column![import_backup, paste_descriptor].spacing(20);
+    let backup_imported: Option<Element<'_, Message>> = imported_backup.then_some(
+        row![
+            new::b5_bold("Backup successfully imported!"),
+            Space::fill_width()
+        ]
+        .into(),
     );
+    let button_next = row![
+        Space::fill_width(),
+        btn_next(valid.then_some(Message::Next))
+    ];
 
-    let import = column![import_backup, backup_imported, or, descriptor, rescan].spacing(20);
-    let button_next = btn_next(valid.then_some(Message::Next));
     let error_card = error.map(|e| card::error("Invalid descriptor", e.to_string()));
+
+    let content = column![
+        import,
+        backup_imported,
+        new::caption(
+            "If you are using a Bitcoin Core node, \
+                    you will need to perform a rescan of \
+                    the blockchain after creating the wallet \
+                    in order to see your coins and past \
+                    transactions. This can be done in \
+                    Settings > Node.",
+        ),
+        button_next,
+        error_card
+    ]
+    .spacing(50)
+    .width(EntryWidth::Standard);
+
+    let content = Container::new(content).center_x(Length::Fill);
 
     layout(
         progress,
         network,
         email,
         "Import the wallet",
-        column![import, button_next, error_card].spacing(50),
+        content,
         Some(Message::Previous),
     )
 }

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -1601,22 +1601,14 @@ pub fn choose_backend(progress: (usize, usize), network: Network) -> Element<'st
             .width(Length::FillPortion(1));
     let descriptions = row![local_description, remote_description].spacing(20);
 
-    let local_action = Container::new(
-        button::secondary(None, "Select")
-            .on_press(Message::SelectBackend(
-                message::SelectBackend::ContinueWithLocalWallet(true),
-            ))
-            .width(200),
-    )
+    let local_action = Container::new(btn_select(Some(Message::SelectBackend(
+        message::SelectBackend::ContinueWithLocalWallet(true),
+    ))))
     .padding(PADDING)
     .center_x(Length::FillPortion(1));
-    let remote_action = Container::new(
-        button::secondary(None, "Select")
-            .on_press(Message::SelectBackend(
-                message::SelectBackend::ContinueWithLocalWallet(false),
-            ))
-            .width(200),
-    )
+    let remote_action = Container::new(btn_select(Some(Message::SelectBackend(
+        message::SelectBackend::ContinueWithLocalWallet(false),
+    ))))
     .padding(PADDING)
     .center_x(Length::FillPortion(1));
     let actions = row![local_action, remote_action].spacing(20);

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -10,7 +10,7 @@ use iced::{
 };
 
 use liana::miniscript::bitcoin::bip32::ChildNumber;
-use liana_ui::component::button::{btn_backup_descriptor, btn_next, BtnWidth};
+use liana_ui::component::button::{btn_backup_descriptor, btn_next, btn_select, BtnWidth};
 use liana_ui::component::text::{self, p2_regular};
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -1133,18 +1133,16 @@ pub fn select_bitcoind_type<'a>(progress: (usize, usize)) -> Element<'a, Message
     .width(Length::FillPortion(1));
     let descriptions = row![existing_node_description, managed_node_description].spacing(20);
 
-    let existing_node_action =
-        Container::new(button::secondary(None, "Select").width(300).on_press(
-            Message::SelectBitcoindType(message::SelectBitcoindTypeMsg::UseExternal(true)),
-        ))
-        .padding(20)
-        .center_x(Length::FillPortion(1));
-    let managed_node_action =
-        Container::new(button::secondary(None, "Select").width(300).on_press(
-            Message::SelectBitcoindType(message::SelectBitcoindTypeMsg::UseExternal(false)),
-        ))
-        .padding(20)
-        .center_x(Length::FillPortion(1));
+    let existing_node_action = Container::new(btn_select(Some(Message::SelectBitcoindType(
+        message::SelectBitcoindTypeMsg::UseExternal(true),
+    ))))
+    .padding(20)
+    .center_x(Length::FillPortion(1));
+    let managed_node_action = Container::new(btn_select(Some(Message::SelectBitcoindType(
+        message::SelectBitcoindTypeMsg::UseExternal(false),
+    ))))
+    .padding(20)
+    .center_x(Length::FillPortion(1));
     let actions = row![existing_node_action, managed_node_action].spacing(20);
 
     let content = column![titles, descriptions, actions].max_width(800);

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -10,7 +10,9 @@ use iced::{
 };
 
 use liana::miniscript::bitcoin::bip32::ChildNumber;
-use liana_ui::component::button::{btn_backup_descriptor, btn_next, btn_select, BtnWidth};
+use liana_ui::component::button::{
+    btn_backup_descriptor, btn_next, btn_secondary, btn_select, BtnWidth,
+};
 use liana_ui::component::text::{self, p2_regular};
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -880,84 +882,61 @@ pub fn define_bitcoin_node<'a>(
 ) -> Element<'a, Message> {
     let msg_next = is_running.and_then(|r| r.is_ok().then_some(Message::Next));
     let button_next = btn_next(msg_next);
-
-    let col = Column::new()
-        .push(
-            available_node_types.fold(
-                Row::new()
-                    .push(text("Node type:").small().bold())
-                    .spacing(10),
-                |row, node_type| {
-                    row.push(radio(
-                        match node_type {
-                            NodeType::Bitcoind => "Bitcoin Core",
-                            NodeType::Electrum => "Electrum",
-                        },
-                        node_type,
-                        Some(selected_node_type),
-                        |new_selection| {
-                            Message::DefineNode(message::DefineNode::NodeTypeSelected(
-                                new_selection,
-                            ))
-                        },
-                    ))
-                    .spacing(30)
-                    .align_y(Alignment::Center)
+    let node_type = available_node_types.fold(
+        row![text::new::b5_bold("Node type:")].spacing(10),
+        |row, node_type| {
+            row.push(radio(
+                match node_type {
+                    NodeType::Bitcoind => "Bitcoin Core",
+                    NodeType::Electrum => "Electrum",
                 },
-            ),
-        )
-        .push(node_view)
-        .push_maybe(if waiting_for_ping_result {
-            Some(Container::new(
-                Row::new()
-                    .spacing(10)
-                    .align_y(Alignment::Center)
-                    .push(text("Checking connection...")),
+                node_type,
+                Some(selected_node_type),
+                |new_selection| {
+                    Message::DefineNode(message::DefineNode::NodeTypeSelected(new_selection))
+                },
             ))
-        } else if is_running.is_some() {
-            is_running.map(|res| {
-                if res.is_ok() {
-                    Container::new(
-                        Row::new()
-                            .spacing(10)
-                            .align_y(Alignment::Center)
-                            .push(icon::circle_check_icon().style(theme::text::success))
-                            .push(text("Connection checked").style(theme::text::success)),
-                    )
-                } else {
-                    Container::new(
-                        Row::new()
-                            .spacing(10)
-                            .align_y(Alignment::Center)
-                            .push(icon::circle_cross_icon().style(theme::text::error))
-                            .push(text("Connection failed").style(theme::text::error)),
-                    )
-                }
-            })
+            .spacing(30)
+            .align_y(Alignment::Center)
+        },
+    );
+
+    let connection_status = if waiting_for_ping_result {
+        Container::new(row![text::new::caption("Checking connection...")].spacing(10))
+    } else if let Some(res) = is_running {
+        let status = if res.is_ok() {
+            row![
+                icon::circle_check_icon().style(theme::text::success),
+                text::new::caption("Connection checked").style(theme::text::success),
+            ]
         } else {
-            Some(Container::new(Space::with_height(Length::Fixed(21.0))))
-        })
-        .push(
-            Row::new()
-                .spacing(10)
-                .push(Container::new(
-                    button::secondary(None, "Check connection")
-                        .on_press_maybe(if can_try_ping && !waiting_for_ping_result {
-                            Some(Message::DefineNode(DefineNode::Ping))
-                        } else {
-                            None
-                        })
-                        .width(BtnWidth::XL),
-                ))
-                .push(button_next),
-        )
-        .spacing(50);
+            row![
+                icon::circle_cross_icon().style(theme::text::error),
+                text::new::caption("Connection failed").style(theme::text::error),
+            ]
+        };
+        Container::new(status.align_y(Alignment::Center).spacing(10))
+    } else {
+        Container::new(Space::with_height(21))
+    };
+
+    let check_connection =
+        (can_try_ping && !waiting_for_ping_result).then_some(Message::DefineNode(DefineNode::Ping));
+    let button_check_connection = Container::new(btn_secondary(
+        None,
+        "Check connection",
+        BtnWidth::XL,
+        check_connection,
+    ));
+    let actions = row![button_check_connection, button_next].spacing(10);
+
+    let content = column![node_type, node_view, connection_status, actions].spacing(50);
 
     layout(
         progress,
         None,
         "Set up connection to the Bitcoin node",
-        col,
+        content,
         true,
         Some(Message::Previous),
     )
@@ -979,129 +958,108 @@ pub fn define_bitcoind<'a>(
         false
     };
 
-    let col_address = Column::new()
-        .push(text("Address:").bold())
-        .push(
-            form::Form::new_trimmed("Address", address, |msg| {
-                Message::DefineNode(DefineNode::DefineBitcoind(
-                    DefineBitcoind::ConfigFieldEdited(ConfigField::Address, msg),
-                ))
-            })
-            .warning("Please enter correct address")
-            .size(text::P1_SIZE)
-            .padding(10),
+    let address_msg = |msg| {
+        Message::DefineNode(DefineNode::DefineBitcoind(
+            DefineBitcoind::ConfigFieldEdited(ConfigField::Address, msg),
+        ))
+    };
+    let address_input = form::Form::new_trimmed("Address", address, address_msg)
+        .warning("Please enter correct address")
+        .component_label(text::new::b5_bold("Address:"))
+        .padding(10);
+    let loopback_warning = (!is_loopback && address.valid).then_some(
+        text::new::caption(
+            "Connection to a remote Bitcoin node is not supported. Insert an IP address bound to the same machine running Liana (ignore this warning if that's already the case)",
         )
-        .push_maybe(if !is_loopback && address.valid {
-            Some(
-                iced::widget::Text::new(
-                    "Connection to a remote Bitcoin node \
-                    is not supported. Insert an IP address bound to the same machine \
-                    running Liana (ignore this warning if that's already the case)",
-                )
-                .style(theme::text::warning)
-                .size(text::CAPTION_SIZE),
-            )
-        } else {
-            None
-        })
-        .spacing(10);
+        .style(theme::text::warning),
+    );
+    let address = column![address_input, loopback_warning].spacing(10);
 
-    let col_auth = Column::new()
-        .push(
-            [RpcAuthType::CookieFile, RpcAuthType::UserPass]
-                .iter()
-                .fold(
-                    Row::new()
-                        .push(text("RPC authentication:").small().bold())
-                        .spacing(10),
-                    |row, auth_type| {
-                        row.push(radio(
-                            format!("{auth_type}"),
-                            *auth_type,
-                            Some(*selected_auth_type),
-                            |new_selection| {
-                                Message::DefineNode(DefineNode::DefineBitcoind(
-                                    DefineBitcoind::RpcAuthTypeSelected(new_selection),
-                                ))
-                            },
+    let auth_type = [RpcAuthType::CookieFile, RpcAuthType::UserPass]
+        .iter()
+        .fold(
+            row![text::new::b5_bold("RPC authentication:")].spacing(10),
+            |row, auth_type| {
+                row.push(radio(
+                    format!("{auth_type}"),
+                    *auth_type,
+                    Some(*selected_auth_type),
+                    |new_selection| {
+                        Message::DefineNode(DefineNode::DefineBitcoind(
+                            DefineBitcoind::RpcAuthTypeSelected(new_selection),
                         ))
-                        .spacing(30)
-                        .align_y(Alignment::Center)
                     },
-                ),
-        )
-        .push(match selected_auth_type {
-            RpcAuthType::CookieFile => Row::new().push(
+                ))
+                .spacing(30)
+                .align_y(Alignment::Center)
+            },
+        );
+    let auth_fields = match selected_auth_type {
+        RpcAuthType::CookieFile => {
+            row![
                 form::Form::new_trimmed("Cookie path", &rpc_auth_vals.cookie_path, |msg| {
                     Message::DefineNode(DefineNode::DefineBitcoind(
                         DefineBitcoind::ConfigFieldEdited(ConfigField::CookieFilePath, msg),
                     ))
                 })
                 .warning("Please enter correct path")
-                .size(text::P1_SIZE)
                 .padding(10),
-            ),
-            RpcAuthType::UserPass => Row::new()
-                .push(
-                    form::Form::new_trimmed("User", &rpc_auth_vals.user, |msg| {
-                        Message::DefineNode(DefineNode::DefineBitcoind(
-                            DefineBitcoind::ConfigFieldEdited(ConfigField::User, msg),
-                        ))
-                    })
-                    .warning("Please enter correct user")
-                    .size(text::P1_SIZE)
-                    .padding(10),
-                )
-                .push(
-                    form::Form::new_trimmed("Password", &rpc_auth_vals.password, |msg| {
-                        Message::DefineNode(DefineNode::DefineBitcoind(
-                            DefineBitcoind::ConfigFieldEdited(ConfigField::Password, msg),
-                        ))
-                    })
-                    .warning("Please enter correct password")
-                    .size(text::P1_SIZE)
-                    .padding(10),
-                )
-                .spacing(10),
-        })
-        .spacing(10);
+            ]
+        }
+        RpcAuthType::UserPass => row![
+            form::Form::new_trimmed("User", &rpc_auth_vals.user, |msg| {
+                Message::DefineNode(DefineNode::DefineBitcoind(
+                    DefineBitcoind::ConfigFieldEdited(ConfigField::User, msg),
+                ))
+            })
+            .warning("Please enter correct user")
+            .padding(10),
+            form::Form::new_trimmed("Password", &rpc_auth_vals.password, |msg| {
+                Message::DefineNode(DefineNode::DefineBitcoind(
+                    DefineBitcoind::ConfigFieldEdited(ConfigField::Password, msg),
+                ))
+            })
+            .warning("Please enter correct password")
+            .padding(10),
+        ]
+        .spacing(10),
+    };
+    let auth = column![auth_type, auth_fields].spacing(10);
 
-    Column::new()
-        .push(col_address)
-        .push(col_auth)
-        .spacing(50)
-        .into()
+    column![address, auth].spacing(50).into()
 }
 
 pub fn define_electrum<'a>(
     address: &form::Value<String>,
     validate_domain: bool,
 ) -> Element<'a, Message> {
-    let checkbox = validate_domain_checkbox(address, validate_domain, |b| {
+    let validate_certificate_msg = |b| {
         Message::DefineNode(DefineNode::DefineElectrum(
             message::DefineElectrum::ValidDomainChanged(b),
         ))
-    });
-    let col_address = Column::new()
-        .push(text("Address:").bold())
-        .push(
-            form::Form::new_trimmed("127.0.0.1:50001", address, |msg| {
-                Message::DefineNode(DefineNode::DefineElectrum(
-                    message::DefineElectrum::ConfigFieldEdited(electrum::ConfigField::Address, msg),
-                ))
-            })
-            .warning(
-                "Please enter correct address (including port), \
-                optionally prefixed with tcp:// or ssl://",
-            )
-            .size(text::P1_SIZE)
-            .padding(10),
-        )
-        .push_maybe(checkbox)
-        .push(text(electrum::ADDRESS_NOTES))
-        .spacing(10);
+    };
+    let checkbox = validate_domain_checkbox(address, validate_domain, validate_certificate_msg);
 
-    Column::new().push(col_address).spacing(50).into()
+    let address_msg = |msg| {
+        Message::DefineNode(DefineNode::DefineElectrum(
+            message::DefineElectrum::ConfigFieldEdited(electrum::ConfigField::Address, msg),
+        ))
+    };
+    let address_input = form::Form::new_trimmed("127.0.0.1:50001", address, address_msg)
+        .warning(
+            "Please enter correct address (including port), \
+        optionally prefixed with tcp:// or ssl://",
+        )
+        .component_label(text::new::b5_bold("Address:"))
+        .padding(10);
+    let address = column![
+        address_input,
+        checkbox,
+        text::new::caption(electrum::ADDRESS_NOTES),
+    ]
+    .spacing(10);
+
+    column![address].spacing(50).into()
 }
 
 pub fn select_bitcoind_type<'a>(progress: (usize, usize)) -> Element<'a, Message> {

--- a/liana-gui/src/launcher.rs
+++ b/liana-gui/src/launcher.rs
@@ -10,7 +10,7 @@ use liana_ui::{
         button::{btn_add_wallet, btn_delete_wallet, btn_remove, btn_select, EntryWidth},
         card, installer as installer_layout,
         list::{self, EntryAccent},
-        network_banner, notification,
+        notification,
         text::new,
     },
     icon, image, theme,
@@ -268,12 +268,6 @@ impl Launcher {
             self.network,
             body,
         );
-
-        let content: Element<'_, Message> = if self.network != Network::Bitcoin {
-            column![network_banner(self.network), content].into()
-        } else {
-            content
-        };
 
         if let Some(modal) = &self.delete_wallet_modal {
             Modal::new(Container::new(content).height(Length::Fill), modal.view())

--- a/liana-gui/src/launcher.rs
+++ b/liana-gui/src/launcher.rs
@@ -1,14 +1,19 @@
 use iced::{
     alignment::Horizontal,
-    widget::{checkbox, column, row, Button, Space},
+    widget::{checkbox, column, row, Space},
     Alignment, Length, Subscription, Task,
 };
 
 use liana::miniscript::bitcoin::Network;
 use liana_ui::{
     component::{
-        button::{self, btn_delete_wallet},
-        card, network_banner, notification, pick_list, scrollable,
+        button::{
+            self, btn_add_wallet, btn_delete_wallet, btn_remove, btn_select, btn_share_xpubs,
+            EntryWidth,
+        },
+        card,
+        list::{self, EntryAccent},
+        network_banner, notification, pick_list, scrollable,
         text::new,
     },
     icon, image, theme,
@@ -226,8 +231,7 @@ impl Launcher {
             _ => None,
         };
 
-        let share_xpubs =
-            button::secondary(None, "Share Xpubs").on_press(Message::View(ViewMessage::ShareXpubs));
+        let share_xpubs = btn_share_xpubs(Some(Message::View(ViewMessage::ShareXpubs)));
 
         let network_picker = pick_list::pick_list(
             self.displayed_networks.as_slice(),
@@ -261,17 +265,12 @@ impl Launcher {
                     let list = wallets.iter().enumerate().fold(
                         Column::new().spacing(20),
                         |col, (i, settings)| {
-                            col.push(
-                                wallets_list_item(self.network, settings, i).map(Message::View),
-                            )
+                            col.push(entry_wallet(self.network, settings, i).map(Message::View))
                         },
                     );
                     let add_wallet_msg = Message::View(ViewMessage::AddWalletToList(true));
                     let add_wallet =
-                        column![button::secondary(Some(icon::plus_icon()), "Add wallet")
-                            .on_press(add_wallet_msg)
-                            .padding(10)
-                            .width(500)];
+                        column![btn_add_wallet(Some(add_wallet_msg))].width(EntryWidth::Standard);
 
                     list.push(add_wallet).into()
                 }
@@ -311,9 +310,7 @@ fn add_wallet_menu<'a>() -> Element<'a, ViewMessage> {
     let create_wallet = column![
         image::create_new_wallet_icon().width(ICON_SIZE),
         new::caption("Create a new Liana wallet").style(theme::text::secondary),
-        button::secondary(None, "Select")
-            .width(200)
-            .on_press(ViewMessage::CreateWallet),
+        btn_select(Some(ViewMessage::CreateWallet)),
     ]
     .spacing(20)
     .align_x(Alignment::Center);
@@ -321,9 +318,7 @@ fn add_wallet_menu<'a>() -> Element<'a, ViewMessage> {
     let add_existing_wallet = column![
         image::restore_wallet_icon().width(ICON_SIZE),
         new::caption("Add an existing Liana wallet").style(theme::text::secondary),
-        button::secondary(None, "Select")
-            .width(200)
-            .on_press(ViewMessage::ImportWallet),
+        btn_select(Some(ViewMessage::ImportWallet)),
     ]
     .spacing(20)
     .align_x(Alignment::Center);
@@ -337,47 +332,41 @@ fn add_wallet_menu<'a>() -> Element<'a, ViewMessage> {
     .into()
 }
 
-fn wallets_list_item(
-    network: Network,
-    settings: &WalletSettings,
-    i: usize,
-) -> Element<'_, ViewMessage> {
-    let title = if let Some(alias) = &settings.alias {
-        new::b5_bold(alias)
-    } else {
-        new::b5_bold(format!("My Liana {network:?} wallet"))
-    };
+fn entry_wallet(network: Network, settings: &WalletSettings, i: usize) -> Element<'_, ViewMessage> {
+    let title = settings
+        .alias
+        .clone()
+        .unwrap_or(format!("My Liana {network:?} wallet"));
 
     let checksum = new::caption(format!("Liana-{}", settings.descriptor_checksum))
         .style(theme::text::secondary);
-
     let email = settings.remote_backend_auth.as_ref().map(|auth| {
         row![
             Space::fill_width(),
             new::caption(&auth.email).style(theme::text::secondary)
         ]
     });
+    let subtitle = Some(column![checksum, email].into());
 
-    let wallet_details = column![title, checksum, email];
-    let wallet_button = Container::new(
-        Button::new(wallet_details)
-            .on_press(ViewMessage::Run(i))
-            .padding(15)
-            .style(theme::button::container_border)
-            .width(500),
-    )
-    .style(theme::card::simple);
-    let delete_button = Button::new(icon::trash_icon())
-        .style(theme::button::secondary)
-        .padding(10)
-        .on_press(ViewMessage::DeleteWallet(DeleteWalletMessage::ShowModal(i)));
+    let accent = Some(match network {
+        Network::Bitcoin => EntryAccent::Bitcoin,
+        _ => EntryAccent::Testnet,
+    });
 
-    Container::new(
-        row![wallet_button, delete_button]
-            .align_y(Alignment::Center)
-            .spacing(20),
-    )
-    .into()
+    let entry = list::entry_wallet(
+        accent,
+        title,
+        subtitle,
+        None,
+        None,
+        Some(ViewMessage::Run(i)),
+    );
+
+    let delete_button = btn_remove(Some(ViewMessage::DeleteWallet(
+        DeleteWalletMessage::ShowModal(i),
+    )));
+
+    row![entry, delete_button].align_y(Alignment::Center).into()
 }
 
 /// Returns the list of displayed networks.

--- a/liana-gui/src/launcher.rs
+++ b/liana-gui/src/launcher.rs
@@ -7,13 +7,10 @@ use iced::{
 use liana::miniscript::bitcoin::Network;
 use liana_ui::{
     component::{
-        button::{
-            self, btn_add_wallet, btn_delete_wallet, btn_remove, btn_select, btn_share_xpubs,
-            EntryWidth,
-        },
-        card,
+        button::{btn_add_wallet, btn_delete_wallet, btn_remove, btn_select, EntryWidth},
+        card, installer as installer_layout,
         list::{self, EntryAccent},
-        network_banner, notification, pick_list, scrollable,
+        network_banner, notification,
         text::new,
     },
     icon, image, theme,
@@ -221,29 +218,12 @@ impl Launcher {
     }
 
     pub fn view(&self) -> Element<'_, Message> {
-        let logo = Container::new(image::liana_brand_grey().width(200)).width(Length::Fill);
-
-        let back_to_wallet_list = match &self.state {
-            State::Wallets { add_wallet, .. } if *add_wallet => Some(
-                button::secondary(Some(icon::previous_icon()), "Back to wallet list")
-                    .on_press(Message::View(ViewMessage::AddWalletToList(false))),
-            ),
+        let previous_message = match &self.state {
+            State::Wallets { add_wallet, .. } if *add_wallet => {
+                Some(Message::View(ViewMessage::AddWalletToList(false)))
+            }
             _ => None,
         };
-
-        let share_xpubs = btn_share_xpubs(Some(Message::View(ViewMessage::ShareXpubs)));
-
-        let network_picker = pick_list::pick_list(
-            self.displayed_networks.as_slice(),
-            Some(self.network),
-            |n| Message::View(ViewMessage::SelectNetwork(n)),
-        )
-        .padding(10);
-
-        let header = row![logo, back_to_wallet_list, share_xpubs, network_picker]
-            .spacing(20)
-            .align_y(Alignment::Center)
-            .padding(100);
 
         let title = if matches!(self.state, State::Wallets { .. }) {
             new::d0("Welcome back")
@@ -278,19 +258,21 @@ impl Launcher {
             State::NoWallet => column![add_wallet_menu().map(Message::View)].into(),
         };
 
-        let body = Container::new(
-            column![title, error, wallets]
-                .align_x(Alignment::Center)
-                .spacing(30),
-        )
-        .center_x(Length::Fill);
+        let body = column![title, error, wallets]
+            .align_x(Alignment::Center)
+            .spacing(30);
 
-        let content = scrollable::vertical(column![header, body, Space::with_height(100),]);
+        let content = launcher_layout(
+            previous_message,
+            self.displayed_networks.as_slice(),
+            self.network,
+            body,
+        );
 
         let content: Element<'_, Message> = if self.network != Network::Bitcoin {
             column![network_banner(self.network), content].into()
         } else {
-            content.into()
+            content
         };
 
         if let Some(modal) = &self.delete_wallet_modal {
@@ -303,6 +285,33 @@ impl Launcher {
             content
         }
     }
+}
+
+fn launcher_layout<'a>(
+    previous_message: Option<Message>,
+    networks: &'a [Network],
+    selected_network: Network,
+    content: impl Into<Element<'a, Message>>,
+) -> Element<'a, Message> {
+    let content = Container::new(content).center_x(Length::Fill);
+
+    installer_layout::layout(
+        installer_layout::LayoutConfig {
+            variant: liana_ui::Variant::Liana,
+            network: selected_network,
+            email: None,
+            is_ws_admin: false,
+            nav_bar: installer_layout::NavBar::Launcher {
+                previous_message,
+                share_xpubs_message: Some(Message::View(ViewMessage::ShareXpubs)),
+                networks,
+                selected_network,
+                on_network_selected: |network| Message::View(ViewMessage::SelectNetwork(network)),
+            },
+            content_width: 800.0,
+        },
+        content,
+    )
 }
 
 fn add_wallet_menu<'a>() -> Element<'a, ViewMessage> {

--- a/liana-gui/src/launcher.rs
+++ b/liana-gui/src/launcher.rs
@@ -1,14 +1,18 @@
 use iced::{
     alignment::Horizontal,
-    widget::{checkbox, Button, Space},
+    widget::{checkbox, column, row, Button, Space},
     Alignment, Length, Subscription, Task,
 };
 
 use liana::miniscript::bitcoin::Network;
 use liana_ui::{
-    component::{button, card, network_banner, notification, pick_list, scrollable, text::*},
+    component::{
+        button::{self, btn_delete_wallet},
+        card, network_banner, notification, pick_list, scrollable,
+        text::new,
+    },
     icon, image, theme,
-    widget::{modal::Modal, Column, ColumnExt, Container, Element, Row, RowExt, SpaceExt},
+    widget::{modal::Modal, Column, Container, Element, SpaceExt},
 };
 use lianad::config::ConfigError;
 use tokio::runtime::Handle;
@@ -212,102 +216,84 @@ impl Launcher {
     }
 
     pub fn view(&self) -> Element<'_, Message> {
-        let content = Into::<Element<ViewMessage>>::into(scrollable::vertical(
-            Column::new()
-                .push(
-                    Row::new()
-                        .spacing(20)
-                        .push(
-                            Container::new(image::liana_brand_grey().width(Length::Fixed(200.0)))
-                                .width(Length::Fill),
-                        )
-                        .push_maybe(if let State::Wallets { add_wallet, .. } = &self.state {
-                            if *add_wallet {
-                                Some(
-                                    button::secondary(
-                                        Some(icon::previous_icon()),
-                                        "Back to wallet list",
-                                    )
-                                    .on_press(ViewMessage::AddWalletToList(false)),
-                                )
-                            } else {
-                                None
-                            }
-                        } else {
-                            None
-                        })
-                        .push(
-                            button::secondary(None, "Share Xpubs")
-                                .on_press(ViewMessage::ShareXpubs),
-                        )
-                        .push(
-                            pick_list::pick_list(
-                                self.displayed_networks.as_slice(),
-                                Some(self.network),
-                                ViewMessage::SelectNetwork,
-                            )
-                            .padding(10),
-                        )
-                        .align_y(Alignment::Center)
-                        .padding(100),
-                )
-                .push(
-                    Container::new(
-                        Column::new()
-                            .align_x(Alignment::Center)
-                            .spacing(30)
-                            .push(if matches!(self.state, State::Wallets { .. }) {
-                                text("Welcome back").size(50).bold()
-                            } else {
-                                text("Welcome").size(50).bold()
-                            })
-                            .push_maybe(self.error.as_ref().map(|e| card::simple(text(e))))
-                            .push(match &self.state {
-                                State::Unchecked => Column::new(),
-                                State::Wallets {
-                                    wallets,
-                                    add_wallet,
-                                } => {
-                                    if *add_wallet {
-                                        Column::new().push(add_wallet_menu())
-                                    } else {
-                                        let col = wallets.iter().enumerate().fold(
-                                            Column::new().spacing(20),
-                                            |col, (i, settings)| {
-                                                col.push(wallets_list_item(
-                                                    self.network,
-                                                    settings,
-                                                    i,
-                                                ))
-                                            },
-                                        );
-                                        col.push(
-                                            Column::new().push(
-                                                button::secondary(
-                                                    Some(icon::plus_icon()),
-                                                    "Add wallet",
-                                                )
-                                                .on_press(ViewMessage::AddWalletToList(true))
-                                                .padding(10)
-                                                .width(Length::Fixed(500.0)),
-                                            ),
-                                        )
-                                    }
-                                }
-                                State::NoWallet => Column::new().push(add_wallet_menu()),
-                            })
-                            .align_x(Alignment::Center),
-                    )
-                    .center_x(Length::Fill),
-                )
-                .push(Space::with_height(Length::Fixed(100.0))),
-        ))
-        .map(Message::View);
-        let content = if self.network != Network::Bitcoin {
-            Column::with_children(vec![network_banner(self.network).into(), content]).into()
-        } else {
-            content
+        let logo = Container::new(image::liana_brand_grey().width(200)).width(Length::Fill);
+
+        let back_to_wallet_list = match &self.state {
+            State::Wallets { add_wallet, .. } if *add_wallet => Some(
+                button::secondary(Some(icon::previous_icon()), "Back to wallet list")
+                    .on_press(Message::View(ViewMessage::AddWalletToList(false))),
+            ),
+            _ => None,
         };
+
+        let share_xpubs =
+            button::secondary(None, "Share Xpubs").on_press(Message::View(ViewMessage::ShareXpubs));
+
+        let network_picker = pick_list::pick_list(
+            self.displayed_networks.as_slice(),
+            Some(self.network),
+            |n| Message::View(ViewMessage::SelectNetwork(n)),
+        )
+        .padding(10);
+
+        let header = row![logo, back_to_wallet_list, share_xpubs, network_picker]
+            .spacing(20)
+            .align_y(Alignment::Center)
+            .padding(100);
+
+        let title = if matches!(self.state, State::Wallets { .. }) {
+            new::d0("Welcome back")
+        } else {
+            new::d0("Welcome")
+        };
+
+        let error = self.error.as_ref().map(|e| card::simple(new::caption(e)));
+
+        let wallets: Element<'_, Message> = match &self.state {
+            State::Unchecked => column![].into(),
+            State::Wallets {
+                wallets,
+                add_wallet,
+            } => {
+                if *add_wallet {
+                    column![add_wallet_menu().map(Message::View)].into()
+                } else {
+                    let list = wallets.iter().enumerate().fold(
+                        Column::new().spacing(20),
+                        |col, (i, settings)| {
+                            col.push(
+                                wallets_list_item(self.network, settings, i).map(Message::View),
+                            )
+                        },
+                    );
+                    let add_wallet_msg = Message::View(ViewMessage::AddWalletToList(true));
+                    let add_wallet =
+                        column![button::secondary(Some(icon::plus_icon()), "Add wallet")
+                            .on_press(add_wallet_msg)
+                            .padding(10)
+                            .width(500)];
+
+                    list.push(add_wallet).into()
+                }
+            }
+            State::NoWallet => column![add_wallet_menu().map(Message::View)].into(),
+        };
+
+        let body = Container::new(
+            column![title, error, wallets]
+                .align_x(Alignment::Center)
+                .spacing(30),
+        )
+        .center_x(Length::Fill);
+
+        let content = scrollable::vertical(column![header, body, Space::with_height(100),]);
+
+        let content: Element<'_, Message> = if self.network != Network::Bitcoin {
+            column![network_banner(self.network), content].into()
+        } else {
+            content.into()
+        };
+
         if let Some(modal) = &self.delete_wallet_modal {
             Modal::new(Container::new(content).height(Length::Fill), modal.view())
                 .on_blur(Some(Message::View(ViewMessage::DeleteWallet(
@@ -321,42 +307,34 @@ impl Launcher {
 }
 
 fn add_wallet_menu<'a>() -> Element<'a, ViewMessage> {
-    Row::new()
-        .align_y(Alignment::End)
-        .spacing(20)
-        .push(
-            Container::new(
-                Column::new()
-                    .spacing(20)
-                    .align_x(Alignment::Center)
-                    .push(image::create_new_wallet_icon().width(Length::Fixed(100.0)))
-                    .push(p1_regular("Create a new Liana wallet").style(theme::text::secondary))
-                    .push(
-                        button::secondary(None, "Select")
-                            .width(Length::Fixed(200.0))
-                            .on_press(ViewMessage::CreateWallet),
-                    )
-                    .align_x(Alignment::Center),
-            )
-            .padding(20),
-        )
-        .push(
-            Container::new(
-                Column::new()
-                    .spacing(20)
-                    .align_x(Alignment::Center)
-                    .push(image::restore_wallet_icon().width(Length::Fixed(100.0)))
-                    .push(p1_regular("Add an existing Liana wallet").style(theme::text::secondary))
-                    .push(
-                        button::secondary(None, "Select")
-                            .width(Length::Fixed(200.0))
-                            .on_press(ViewMessage::ImportWallet),
-                    )
-                    .align_x(Alignment::Center),
-            )
-            .padding(20),
-        )
-        .into()
+    const ICON_SIZE: u32 = 100;
+    let create_wallet = column![
+        image::create_new_wallet_icon().width(ICON_SIZE),
+        new::caption("Create a new Liana wallet").style(theme::text::secondary),
+        button::secondary(None, "Select")
+            .width(200)
+            .on_press(ViewMessage::CreateWallet),
+    ]
+    .spacing(20)
+    .align_x(Alignment::Center);
+
+    let add_existing_wallet = column![
+        image::restore_wallet_icon().width(ICON_SIZE),
+        new::caption("Add an existing Liana wallet").style(theme::text::secondary),
+        button::secondary(None, "Select")
+            .width(200)
+            .on_press(ViewMessage::ImportWallet),
+    ]
+    .spacing(20)
+    .align_x(Alignment::Center);
+
+    row![
+        Container::new(create_wallet).padding(20),
+        Container::new(add_existing_wallet).padding(20),
+    ]
+    .align_y(Alignment::End)
+    .spacing(20)
+    .into()
 }
 
 fn wallets_list_item(
@@ -364,52 +342,40 @@ fn wallets_list_item(
     settings: &WalletSettings,
     i: usize,
 ) -> Element<'_, ViewMessage> {
+    let title = if let Some(alias) = &settings.alias {
+        new::b5_bold(alias)
+    } else {
+        new::b5_bold(format!("My Liana {network:?} wallet"))
+    };
+
+    let checksum = new::caption(format!("Liana-{}", settings.descriptor_checksum))
+        .style(theme::text::secondary);
+
+    let email = settings.remote_backend_auth.as_ref().map(|auth| {
+        row![
+            Space::fill_width(),
+            new::caption(&auth.email).style(theme::text::secondary)
+        ]
+    });
+
+    let wallet_details = column![title, checksum, email];
+    let wallet_button = Container::new(
+        Button::new(wallet_details)
+            .on_press(ViewMessage::Run(i))
+            .padding(15)
+            .style(theme::button::container_border)
+            .width(500),
+    )
+    .style(theme::card::simple);
+    let delete_button = Button::new(icon::trash_icon())
+        .style(theme::button::secondary)
+        .padding(10)
+        .on_press(ViewMessage::DeleteWallet(DeleteWalletMessage::ShowModal(i)));
+
     Container::new(
-        Row::new()
+        row![wallet_button, delete_button]
             .align_y(Alignment::Center)
-            .spacing(20)
-            .push(
-                Container::new(
-                    Button::new(
-                        Column::new()
-                            .push(if let Some(alias) = &settings.alias {
-                                p1_bold(alias)
-                            } else {
-                                p1_bold(format!(
-                                    "My Liana {} wallet",
-                                    match network {
-                                        Network::Bitcoin => "Bitcoin",
-                                        Network::Signet => "Signet",
-                                        Network::Testnet => "Testnet",
-                                        Network::Testnet4 => "Testnet4",
-                                        Network::Regtest => "Regtest",
-                                        _ => "",
-                                    }
-                                ))
-                            })
-                            .push(
-                                p1_regular(format!("Liana-{}", settings.descriptor_checksum))
-                                    .style(theme::text::secondary),
-                            )
-                            .push_maybe(settings.remote_backend_auth.as_ref().map(|auth| {
-                                Row::new()
-                                    .push(Space::with_width(Length::Fill))
-                                    .push(p1_regular(&auth.email).style(theme::text::secondary))
-                            })),
-                    )
-                    .on_press(ViewMessage::Run(i))
-                    .padding(15)
-                    .style(theme::button::container_border)
-                    .width(Length::Fixed(500.0)),
-                )
-                .style(theme::card::simple),
-            )
-            .push(
-                Button::new(icon::trash_icon())
-                    .style(theme::button::secondary)
-                    .padding(10)
-                    .on_press(ViewMessage::DeleteWallet(DeleteWalletMessage::ShowModal(i))),
-            ),
+            .spacing(20),
     )
     .into()
 }
@@ -550,15 +516,10 @@ impl DeleteWalletModal {
     }
 
     fn view(&self) -> Element<'_, Message> {
-        let mut confirm_button = button::secondary(None, "Delete wallet")
-            .width(Length::Fixed(200.0))
-            .style(theme::button::destructive);
-        if self.warning.is_none() {
-            confirm_button = confirm_button.on_press(ViewMessage::DeleteWallet(
+        let confirm_button =
+            btn_delete_wallet(self.warning.is_none().then_some(ViewMessage::DeleteWallet(
                 DeleteWalletMessage::Confirm(self.wallet_settings.wallet_id()),
-            ));
-        }
-        // Use separate `Row`s for help text in order to have better spacing.
+            )));
         let help_text_1 = format!(
             "Are you sure you want to {} for the wallet {}",
             if self.wallet_settings.remote_backend_auth.is_some() {
@@ -581,68 +542,71 @@ impl DeleteWalletModal {
             None => Some("(If you are using a Liana-managed Bitcoin node, it will not be affected by this action.)"),
         };
         let help_text_3 = "WARNING: This cannot be undone.";
-
-        Into::<Element<ViewMessage>>::into(
-            card::simple(
-                Column::new()
-                    .spacing(10)
-                    .push(Container::new(
-                        h4_bold(if let Some(alias) = &self.wallet_settings.alias {
-                            format!(
-                                "Delete configuration for {} (Liana-{})",
-                                alias, &self.wallet_settings.descriptor_checksum
-                            )
-                        } else {
-                            format!(
-                                "Delete configuration for Liana-{}",
-                                &self.wallet_settings.descriptor_checksum
-                            )
-                        })
-                        .style(theme::text::destructive)
-                        .width(Length::Fill),
-                    ))
-                    .push(Row::new().push(text(help_text_1)))
-                    .push_maybe(
-                        help_text_2
-                            .map(|t| Row::new().push(p1_regular(t).style(theme::text::secondary))),
-                    )
-                    .push(Row::new())
-                    .push_maybe(self.wallet_settings.remote_backend_auth.as_ref().map(|a| {
-                        checkbox(self.delete_liana_connect)
-                        .label(match self.user_role {
-                                Some(UserRole::Owner) | None => "Also permanently delete this wallet from Liana Connect (for all members).".to_string(),
-                                Some(UserRole::Member) => format!("Also disassociate {} from this Liana Connect wallet.", a.email),
-                            })
-                        .on_toggle_maybe(if !self.deleted {
-                                Some(|v| {
-                                    ViewMessage::DeleteWallet(DeleteWalletMessage::DeleteLianaConnect(v))
-                                })
-                            } else {
-                                None
-                            })
-                    }))
-                    .push(Row::new().push(text(help_text_3)))
-                    .push_maybe(self.warning.as_ref().map(|w| {
-                        notification::warning(w.to_string(), w.to_string()).width(Length::Fill)
-                    }))
-                    .push(
-                        Container::new(if !self.deleted {
-                            Row::new().push(confirm_button)
-                        } else {
-                            Row::new()
-                                .spacing(10)
-                                .push(icon::circle_check_icon().style(theme::text::success))
-                                .push(
-                                    text("Wallet successfully deleted").style(theme::text::success),
-                                )
-                        })
-                        .align_x(Horizontal::Center)
-                        .width(Length::Fill),
-                    ),
+        let title = if let Some(alias) = &self.wallet_settings.alias {
+            format!(
+                "Delete configuration for {} (Liana-{})",
+                alias, &self.wallet_settings.descriptor_checksum
             )
-            .width(Length::Fixed(700.0)),
-        )
-        .map(Message::View)
+        } else {
+            format!(
+                "Delete configuration for Liana-{}",
+                &self.wallet_settings.descriptor_checksum
+            )
+        };
+        let title = Container::new(
+            new::h3_semi(title)
+                .style(theme::text::destructive)
+                .width(Length::Fill),
+        );
+        let help_text_1 = row![new::caption(help_text_1)];
+        let help_text_2 = help_text_2.map(|t| row![new::caption(t).style(theme::text::secondary)]);
+        let liana_connect_delete = self.wallet_settings.remote_backend_auth.as_ref().map(|a| {
+            checkbox(self.delete_liana_connect)
+                .label(match self.user_role {
+                    Some(UserRole::Owner) | None => {
+                        "Also permanently delete this wallet from Liana Connect (for all members)."
+                            .to_string()
+                    }
+                    Some(UserRole::Member) => format!(
+                        "Also disassociate {} from this Liana Connect wallet.",
+                        a.email
+                    ),
+                })
+                .on_toggle_maybe(if !self.deleted {
+                    Some(|v| ViewMessage::DeleteWallet(DeleteWalletMessage::DeleteLianaConnect(v)))
+                } else {
+                    None
+                })
+        });
+        let help_text_3 = row![new::caption(help_text_3)];
+        let warning = self
+            .warning
+            .as_ref()
+            .map(|w| notification::warning(w.to_string(), w.to_string()).width(Length::Fill));
+        let footer = Container::new(if !self.deleted {
+            row![confirm_button]
+        } else {
+            row![
+                icon::circle_check_icon().style(theme::text::success),
+                new::caption("Wallet successfully deleted").style(theme::text::success),
+            ]
+            .spacing(10)
+        })
+        .align_x(Horizontal::Center)
+        .width(Length::Fill);
+        let content = column![
+            title,
+            help_text_1,
+            help_text_2,
+            Space::with_height(0),
+            liana_connect_delete,
+            help_text_3,
+            warning,
+            footer,
+        ]
+        .spacing(10);
+
+        Into::<Element<ViewMessage>>::into(card::simple(content).width(700)).map(Message::View)
     }
 }
 

--- a/liana-ui/src/component/badge.rs
+++ b/liana-ui/src/component/badge.rs
@@ -105,15 +105,31 @@ icon_badge!(backup, backup_icon, simple);
 icon_badge!(restore, restore_icon, simple);
 
 pub fn tile<'a, M>(name: Tile) -> Container<'a, M> {
+    tile_with_tone(name, None)
+}
+
+pub fn tile_accent<'a, M>(name: Tile) -> Container<'a, M> {
+    tile_with_tone(name, Some(TileStyle::Accent))
+}
+
+fn tile_with_tone<'a, M>(name: Tile, tone: Option<TileStyle>) -> Container<'a, M> {
+    let none = tone.is_none();
     let spec = tile_spec(name);
-    let tone = spec.tone;
+    let tone = tone.unwrap_or(spec.tone);
     let size = spec.size;
     let icon =
         spec.icon
             .width(size.size)
             .size(size.icon_size)
-            .style(move |theme: &theme::Theme| iced::widget::text::Style {
-                color: Some(tile_tone(theme, tone).fg),
+            .style(move |theme: &theme::Theme| {
+                let tone = if !theme.is_business() && none {
+                    TileStyle::Accent
+                } else {
+                    tone
+                };
+                iced::widget::text::Style {
+                    color: Some(tile_tone(theme, tone).fg),
+                }
             });
 
     Container::new(icon)

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -29,7 +29,7 @@ const MENU_TEXT_COMPACT_SIZE: u32 = 18;
 const MENU_ICON_SIZE: u32 = ICON_SIZE_L as u32;
 const AUXILIARY_PADDING: [u16; 2] = [14 /* Top/Bottom */, 20 /* Left/Right */];
 const LIST_ENTRY_ACCENT_WIDTH: f32 = 4.0;
-const LIST_ENTRY_PADDING: [u16; 2] = [14 /* Top/Bottom */, 20 /* Left/Right */];
+pub const LIST_ENTRY_PADDING: [u16; 2] = [14 /* Top/Bottom */, 20 /* Left/Right */];
 
 const ICON_BTN_SIZE: f32 = 40.0;
 const ICON_BTN_PADDING: f32 = 10.0;
@@ -218,27 +218,43 @@ pub fn list_entry_with_state<'a, M: 'a + Clone, T: Into<Element<'a, M>>>(
             .padding(LIST_ENTRY_PADDING)
             .width(Length::Fill),
     )
-    .style(move |theme, status| {
-        let status = if !clickable && status == Status::Disabled {
-            Status::Active
-        } else {
-            status
-        };
-        let mut style = theme::button::list_entry(theme, status);
-        if let Some(color) = accent {
-            // The accent card behind carries the shadow; keep the inner card flat.
-            style.shadow = Default::default();
-            if status == Status::Hovered {
-                // Hover border matches the entry's accent stripe.
-                style.border.color = color(theme);
-            }
-        }
-        style
-    })
+    .style(move |theme, status| list_entry_style(theme, status, accent, clickable))
     .on_press_maybe(msg)
     .padding(0)
     .width(Length::Fill);
 
+    list_entry_card(button, accent, width)
+}
+
+pub fn list_entry_style(
+    theme: &Theme,
+    status: Status,
+    accent: Option<ListEntryAccent>,
+    clickable: bool,
+) -> Style {
+    let status = if !clickable && status == Status::Disabled {
+        Status::Active
+    } else {
+        status
+    };
+    let mut style = theme::button::list_entry(theme, status);
+    if let Some(color) = accent {
+        // The accent card behind carries the shadow; keep the inner card flat.
+        style.shadow = Default::default();
+        if status == Status::Hovered {
+            // Hover border matches the entry's accent stripe.
+            style.border.color = color(theme);
+        }
+    }
+    style
+}
+
+pub fn list_entry_card<'a, M: 'a>(
+    entry: impl Into<Element<'a, M>>,
+    accent: Option<ListEntryAccent>,
+    width: EntryWidth,
+) -> Element<'a, M> {
+    let entry = entry.into();
     let entry: Element<'a, M> = if let Some(color) = accent {
         let accent_card = Container::new(Space::with_height(Length::Fill))
             .width(Length::Fill)
@@ -270,14 +286,14 @@ pub fn list_entry_with_state<'a, M: 'a + Clone, T: Into<Element<'a, M>>>(
         // stripe that wraps the left rounded corners.
         Stack::new()
             .width(Length::Fill)
-            .push(Container::new(button).padding(Padding {
+            .push(Container::new(entry).padding(Padding {
                 left: LIST_ENTRY_ACCENT_WIDTH,
                 ..Padding::ZERO
             }))
             .push_under(accent_card)
             .into()
     } else {
-        button.into()
+        entry
     };
 
     container(entry).width(width).into()
@@ -997,5 +1013,5 @@ pub fn btn_backend_options_help<T: Clone + 'static>(msg: T) -> Button<'static, T
 }
 
 pub fn btn_accept<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
-    btn_secondary(None, "Accept", BtnWidth::M, msg)
+    btn_primary(Some(icon::check_icon()), "Accept", BtnWidth::M, msg)
 }

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -965,3 +965,14 @@ pub fn btn_optional_section<'a, T: Clone + 'a>(content: Row<'a, T>, msg: T) -> B
         .style(theme::button::optional_section)
         .on_press(msg)
 }
+
+pub fn btn_backup_descriptor<'a, T: Clone + 'a>(msg: Option<T>, primary: bool) -> Button<'a, T> {
+    let icon = Some(icon::backup_icon());
+    let label = "Back Up Descriptor";
+    let width = BtnWidth::XL;
+    if primary {
+        btn_primary(icon, label, width, msg)
+    } else {
+        btn_secondary(icon, label, width, msg)
+    }
+}

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -939,3 +939,9 @@ pub fn btn_add_payment<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
 pub fn btn_add_label<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
     btn_tertiary(Some(icon::edit_icon()), "Edit label", BtnWidth::L, msg)
 }
+
+pub fn btn_delete_wallet<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    destructive(None, "Delete wallet")
+        .width(Length::Fixed(200.0))
+        .on_press_maybe(msg)
+}

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -995,3 +995,7 @@ pub fn btn_backend_options_help<T: Clone + 'static>(msg: T) -> Button<'static, T
     )
     .on_press(msg)
 }
+
+pub fn btn_accept<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_secondary(None, "Accept", BtnWidth::M, msg)
+}

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -246,11 +246,25 @@ pub fn list_entry_with_state<'a, M: 'a + Clone, T: Into<Element<'a, M>>>(
             .style(move |theme| container::Style {
                 background: Some(Background::Color(color(theme))),
                 border: Border {
-                    radius: theme.colors.buttons.list_entry_radius.unwrap_or(0.0).into(),
+                    radius: theme
+                        .colors
+                        .buttons
+                        .list_entry_radius
+                        .unwrap_or(theme::button::BUTTON_RADIUS)
+                        .into(),
                     ..Default::default()
                 },
                 shadow: theme.colors.buttons.list_entry.active.shadow,
                 ..Default::default()
+            });
+        let accent_card = Container::new(accent_card)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(Padding {
+                top: 1.0,
+                right: 1.0,
+                bottom: 1.0,
+                left: 0.0,
             });
         // White card inset on the left by the accent width so the accent card behind shows as a
         // stripe that wraps the left rounded corners.

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -959,3 +959,9 @@ pub fn btn_delete_wallet<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
         .width(Length::Fixed(200.0))
         .on_press_maybe(msg)
 }
+
+pub fn btn_optional_section<'a, T: Clone + 'a>(content: Row<'a, T>, msg: T) -> Button<'a, T> {
+    Button::new(content)
+        .style(theme::button::optional_section)
+        .on_press(msg)
+}

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -976,3 +976,14 @@ pub fn btn_backup_descriptor<'a, T: Clone + 'a>(msg: Option<T>, primary: bool) -
         btn_secondary(icon, label, width, msg)
     }
 }
+
+pub fn btn_check_connection<'a, T: Clone + 'a>(msg: Option<T>, primary: bool) -> Button<'a, T> {
+    let label = "Check connection";
+    let width = BtnWidth::L;
+
+    if primary {
+        btn_primary(None, label, width, msg)
+    } else {
+        btn_secondary(None, label, width, msg)
+    }
+}

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -987,3 +987,11 @@ pub fn btn_check_connection<'a, T: Clone + 'a>(msg: Option<T>, primary: bool) ->
         btn_secondary(None, label, width, msg)
     }
 }
+
+pub fn btn_backend_options_help<T: Clone + 'static>(msg: T) -> Button<'static, T> {
+    link(
+        Some(icon::link_icon()),
+        "More information about backend and node options",
+    )
+    .on_press(msg)
+}

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -589,6 +589,14 @@ pub fn btn_ok<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
     btn_primary(None, "OK", BtnWidth::M, msg)
 }
 
+pub fn btn_overwrite<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_secondary(None, "Overwrite", BtnWidth::M, msg)
+}
+
+pub fn btn_ignore<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_secondary(None, "Ignore", BtnWidth::M, msg)
+}
+
 pub fn btn_email_wizardsardine<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
     btn_primary(None, "Email WS", BtnWidth::Auto, msg)
 }

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -1023,3 +1023,7 @@ pub fn btn_backend_options_help<T: Clone + 'static>(msg: T) -> Button<'static, T
 pub fn btn_accept<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
     btn_primary(Some(icon::check_icon()), "Accept", BtnWidth::M, msg)
 }
+
+pub fn btn_modal_previous<'a, T: Clone + 'a>(msg: T) -> Button<'a, T> {
+    transparent(Some(icon::previous_icon().size(25)), "").on_press(msg)
+}

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -745,7 +745,7 @@ pub fn btn_add_recovery_path<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T>
 }
 
 pub fn btn_skip<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
-    btn_secondary(None, "Skip", BtnWidth::XL, msg)
+    btn_secondary(None, "Skip", BtnWidth::M, msg)
 }
 
 pub fn btn_skip_registration<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -4,7 +4,7 @@ use super::{
     modal::BTN_W,
     text::{
         new::{button_text, button_text_compact, caption, BUTTON_TEXT_COMPACT_SPEC},
-        p1_regular, panel_title, text,
+        panel_title, text,
     },
     tooltip,
 };
@@ -39,6 +39,7 @@ const BTN_PADDING: [u16; 2] = [9 /* Top/Bottom */, 14 /* Left/Right */];
 const BTN_PADDING_COMPACT: [u16; 2] = [7 /* Top/Bottom */, 12 /* Left/Right */];
 
 pub type ListEntryAccent = fn(&Theme) -> Color;
+pub type ButtonStyle = fn(&theme::Theme, Status) -> Style;
 
 pub fn menu<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str, compact: bool) -> Button<'a, T> {
     Button::new(
@@ -362,12 +363,14 @@ pub enum BtnWidth {
     XXL = 330,
     /// Default to Length::Shrink
     Auto,
+    Fill,
 }
 
 impl From<BtnWidth> for Length {
     fn from(value: BtnWidth) -> Self {
         match value {
             BtnWidth::Auto => Length::Shrink,
+            BtnWidth::Fill => Length::Fill,
             v => (v as u16 as u32).into(),
         }
     }
@@ -382,6 +385,7 @@ pub enum EntryWidth {
     Deletable,
     Fill,
     Shrink,
+    Custom(f32),
 }
 
 impl From<EntryWidth> for Length {
@@ -394,6 +398,7 @@ impl From<EntryWidth> for Length {
             }
             EntryWidth::Fill => Length::Fill,
             EntryWidth::Shrink => Length::Shrink,
+            EntryWidth::Custom(v) => Length::Fixed(v),
         }
     }
 }
@@ -473,13 +478,13 @@ pub fn btn_high<'a, T: Clone + 'a>(selected: bool, msg: Option<T>) -> Button<'a,
     btn_feerate("High", selected, msg)
 }
 
-/// Secondary button with preset width.
-pub fn btn_secondary_with_tooltip<'a, T: Clone + 'a>(
+fn btn_with_tooltip<'a, T: Clone + 'a>(
     icon: Option<Text<'a>>,
     label: &'a str,
     tooltip: Option<&'a str>,
     width: BtnWidth,
     msg: Option<T>,
+    style: ButtonStyle,
 ) -> Button<'a, T> {
     Button::new(content_with_tooltip(
         icon,
@@ -488,7 +493,7 @@ pub fn btn_secondary_with_tooltip<'a, T: Clone + 'a>(
         false,
     ))
     .width(width)
-    .style(theme::button::secondary)
+    .style(style)
     .on_press_maybe(msg)
     .padding(0)
 }
@@ -535,9 +540,13 @@ pub fn btn_flat<'a, T: Clone + 'a>(
     btn
 }
 
-/// Save button: primary. Width M.
-pub fn btn_save<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
-    btn_primary(None, "Save", BtnWidth::M, msg)
+/// Save button: primary or secondary. Width M.
+pub fn btn_save<'a, T: Clone + 'a>(msg: Option<T>, primary: bool) -> Button<'a, T> {
+    if primary {
+        btn_primary(None, "Save", BtnWidth::M, msg)
+    } else {
+        btn_secondary(None, "Save", BtnWidth::M, msg)
+    }
 }
 
 /// Cancel button: destructive. Width M.
@@ -565,9 +574,9 @@ pub fn btn_generate<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
     btn_primary(None, "Generate", BtnWidth::M, msg)
 }
 
-/// Clear button: secondary. Width M.
+/// Clear button: destructive. Width M.
 pub fn btn_clear<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
-    btn_secondary(None, "Clear", BtnWidth::M, msg)
+    btn_destructive(None, "Clear", BtnWidth::M, msg)
 }
 
 /// Retry button: secondary. Width M.
@@ -603,11 +612,11 @@ pub fn btn_dismiss<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
 }
 
 pub fn btn_customize<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
-    btn_secondary(None, "Customize", BtnWidth::M, msg)
+    btn_tertiary(None, "Customize", BtnWidth::M, msg)
 }
 
 pub fn btn_clear_all<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
-    btn_secondary(None, "Clear all", BtnWidth::M, msg)
+    btn_tertiary(None, "Clear all", BtnWidth::M, msg)
 }
 
 pub fn btn_unlock<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
@@ -706,11 +715,11 @@ pub fn btn_skip_registration<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T>
 }
 
 pub fn btn_resend_token<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
-    btn_secondary(None, "Resend token", BtnWidth::XL, msg)
+    btn_tertiary(None, "Resend token", BtnWidth::XL, msg)
 }
 
 pub fn btn_change_email<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
-    btn_secondary(
+    btn_tertiary(
         Some(icon::previous_icon()),
         "Change email",
         BtnWidth::XL,
@@ -725,17 +734,17 @@ pub fn btn_connect_another_email<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a
 pub fn btn_verify_compact<'a, T: Clone + 'a>(msg: T) -> Button<'a, T> {
     button_compact(
         "Verify on hardware device",
-        theme::button::secondary,
+        theme::button::tertiary,
         Some(msg),
     )
 }
 
 pub fn btn_show_qr_compact<'a, T: Clone + 'a>(msg: T) -> Button<'a, T> {
-    button_compact("Show QR Code", theme::button::secondary, Some(msg))
+    button_compact("Show QR Code", theme::button::tertiary, Some(msg))
 }
 
 pub fn btn_show_qr<'a, T: Clone + 'a>(msg: T) -> Button<'a, T> {
-    btn_secondary(
+    btn_tertiary(
         Some(icon::qr_icon()),
         "Show QR Code",
         BtnWidth::XL,
@@ -744,12 +753,112 @@ pub fn btn_show_qr<'a, T: Clone + 'a>(msg: T) -> Button<'a, T> {
 }
 
 pub fn btn_verify<'a, T: Clone + 'a>(msg: T) -> Button<'a, T> {
-    btn_secondary(
+    btn_tertiary(
         Some(icon::usb_icon()),
         "Verify on hardware device",
         BtnWidth::XXL,
         Some(msg),
     )
+}
+
+pub fn btn_register_on_device<'a, T: Clone + 'a>(msg: T) -> Button<'a, T> {
+    btn_tertiary(
+        Some(icon::chip_icon()),
+        "Register on device",
+        BtnWidth::XL,
+        Some(msg),
+    )
+}
+
+pub fn btn_see_transaction_details<'a, T: Clone + 'a>(msg: T) -> Button<'a, T> {
+    btn_tertiary(None, "See transaction details", BtnWidth::XL, Some(msg))
+}
+
+pub fn btn_export<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_tertiary(Some(icon::backup_icon()), "Export", BtnWidth::M, msg)
+}
+
+pub fn btn_import<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_tertiary(Some(icon::restore_icon()), "Import", BtnWidth::M, msg)
+}
+
+pub fn btn_sign<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_primary(None, "Sign", BtnWidth::M, msg)
+}
+
+pub fn btn_broadcast<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_primary(None, "Broadcast", BtnWidth::M, msg)
+}
+
+pub fn btn_new<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_tertiary(Some(icon::plus_icon()), "New", BtnWidth::M, msg)
+}
+
+pub fn btn_processing<'a, T: Clone + 'a>() -> Button<'a, T> {
+    btn_tertiary(None, "Processing...", BtnWidth::M, None)
+}
+
+pub fn btn_backup_encrypt_descriptor<'a, T: Clone + 'a>(msg: T) -> Button<'a, T> {
+    let backup_label = "Back up encrypted descriptor";
+    let backup_tooltip = "An encrypted descriptor file (.bed) you can store anywhere. To decrypt it, you need one of your signing devices or xpubs.";
+    btn_with_tooltip(
+        Some(icon::backup_icon()),
+        backup_label,
+        Some(backup_tooltip),
+        BtnWidth::Auto,
+        Some(msg),
+        theme::button::tertiary,
+    )
+}
+
+pub fn btn_update<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    if let Some(msg) = msg {
+        btn_tertiary(None, "Update", BtnWidth::L, Some(msg))
+    } else {
+        btn_tertiary(None, "Updating", BtnWidth::M, None)
+    }
+}
+
+pub fn btn_edit<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_tertiary(Some(icon::edit_icon()), "Edit", BtnWidth::S, msg)
+}
+
+pub fn btn_set<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_primary(Some(icon::edit_icon()), "Set", BtnWidth::S, msg)
+}
+
+pub fn btn_add_recovery_option<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_tertiary(
+        Some(icon::plus_icon()),
+        "Add recovery option",
+        BtnWidth::XL,
+        msg,
+    )
+}
+
+const SAFETY_NET_DESCRIPTION: &str = "This adds a final recovery option containing keys from professional key agents.\n\nUse this option if you have been provided one or more Safety Net tokens.";
+
+pub fn btn_add_safety_net<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_with_tooltip(
+        Some(icon::plus_icon()),
+        "Add Safety Net",
+        Some(SAFETY_NET_DESCRIPTION),
+        BtnWidth::XL,
+        msg,
+        theme::button::tertiary,
+    )
+}
+
+pub fn btn_select<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_secondary(None, "Select", BtnWidth::M, msg)
+}
+
+pub fn btn_share_xpubs<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_tertiary(None, "Share Xpubs", BtnWidth::M, msg)
+}
+
+pub fn btn_add_wallet<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    auxiliary(Some(icon::plus_icon()), "Add wallet", msg)
 }
 
 /// Full-width "Show QR Code" button for an optional modal section, with an
@@ -761,13 +870,13 @@ pub fn btn_show_qr_section<'a, M: 'a + 'static>(
     let mut btn = Button::new(
         Row::new()
             .push(icon::qr_icon().size(30))
-            .push(p1_regular("Show QR Code"))
+            .push(button_text("Show QR Code"))
             .push_maybe(tt.map(tooltip))
             .spacing(20)
             .align_y(Vertical::Center)
             .padding(15),
     )
-    .style(theme::button::secondary)
+    .style(theme::button::tertiary)
     .width(Length::Fill);
     if let Some(msg) = msg {
         btn = btn.on_press(msg);
@@ -788,10 +897,16 @@ pub fn btn_copy<'a, T: Clone + 'a>(msg: Option<T>) -> BistateButton<'a, T> {
             .center_y(size),
     )
     .on_press_maybe(msg)
-    .style(theme::button::transparent)
+    .style(move |theme, status| {
+        let mut button_style = theme::button::transparent(theme, status);
+        if status == Status::Hovered {
+            button_style.text_color = theme.colors.general.accent;
+        }
+        button_style
+    })
 }
 
-pub fn btn_edit<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+pub fn btn_icon_edit<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
     clickable_icon_with_size(icon::edit_icon(), msg, CLICKABLE_ICON_SIZE)
 }
 
@@ -806,7 +921,7 @@ pub fn btn_delete<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
 }
 
 pub fn btn_previous<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
-    btn_secondary(None, "< Previous", BtnWidth::M, msg)
+    btn_tertiary(None, "< Previous", BtnWidth::M, msg)
 }
 
 pub fn btn_next<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
@@ -818,5 +933,5 @@ pub fn btn_next<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
 }
 
 pub fn btn_add_payment<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
-    btn_secondary(Some(icon::plus_icon()), "Add payment", BtnWidth::Auto, msg)
+    btn_tertiary(Some(icon::plus_icon()), "Add payment", BtnWidth::Auto, msg)
 }

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -1027,3 +1027,7 @@ pub fn btn_accept<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
 pub fn btn_modal_previous<'a, T: Clone + 'a>(msg: T) -> Button<'a, T> {
     transparent(Some(icon::previous_icon().size(25)), "").on_press(msg)
 }
+
+pub fn btn_mnemonic_word<'a, T: Clone + 'a>(word: &str, msg: T) -> Button<'a, T> {
+    button_compact(word, theme::button::tertiary, Some(msg)).width(BtnWidth::S)
+}

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -935,3 +935,7 @@ pub fn btn_next<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
 pub fn btn_add_payment<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
     btn_tertiary(Some(icon::plus_icon()), "Add payment", BtnWidth::Auto, msg)
 }
+
+pub fn btn_add_label<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
+    btn_tertiary(Some(icon::edit_icon()), "Edit label", BtnWidth::L, msg)
+}

--- a/liana-ui/src/component/collapse.rs
+++ b/liana-ui/src/component/collapse.rs
@@ -23,9 +23,12 @@ pub struct Collapse<'a, Message> {
     after: Element<'a, Message, Theme, Renderer>,
     content: Element<'a, Message, Theme, Renderer>,
     init_expanded: bool,
+    expanded: Option<bool>,
+    on_toggle: Option<Box<dyn Fn() -> Message + 'a>>,
     padding: Padding,
     width: Length,
     header_style: Box<dyn Fn(&Theme, button::Status) -> button::Style + 'a>,
+    style_bounds: bool,
 }
 
 impl<'a, Message: 'a> Collapse<'a, Message> {
@@ -39,14 +42,32 @@ impl<'a, Message: 'a> Collapse<'a, Message> {
             after: after.into(),
             content: content.into(),
             init_expanded: false,
+            expanded: None,
+            on_toggle: None,
             padding: Padding::ZERO,
             width: Length::Fill,
             header_style: Box::new(crate::theme::button::transparent_border),
+            style_bounds: false,
         }
     }
 
     pub fn collapsed(mut self, state: bool) -> Self {
         self.init_expanded = state;
+        self
+    }
+
+    pub fn expanded(mut self, state: bool) -> Self {
+        self.expanded = Some(state);
+        self
+    }
+
+    pub fn on_toggle(mut self, on_toggle: impl Fn() -> Message + 'a) -> Self {
+        self.on_toggle = Some(Box::new(on_toggle));
+        self
+    }
+
+    pub fn style_bounds(mut self) -> Self {
+        self.style_bounds = true;
         self
     }
 
@@ -86,6 +107,9 @@ impl<'a, Message: 'a> Widget<Message, Theme, Renderer> for Collapse<'a, Message>
     }
 
     fn diff(&self, tree: &mut Tree) {
+        if let Some(expanded) = self.expanded {
+            tree.state.downcast_mut::<CollapseState>().expanded = expanded;
+        }
         tree.diff_children(&[&self.before, &self.after, &self.content]);
     }
 
@@ -174,7 +198,11 @@ impl<'a, Message: 'a> Widget<Message, Theme, Renderer> for Collapse<'a, Message>
         // Handle click on header to toggle.
         if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) = event {
             if cursor.is_over(header_bounds) {
-                state.expanded = !state.expanded;
+                if let Some(on_toggle) = &self.on_toggle {
+                    shell.publish(on_toggle());
+                } else {
+                    state.expanded = !state.expanded;
+                }
                 shell.invalidate_layout();
                 shell.request_redraw();
                 shell.capture_event();
@@ -223,10 +251,15 @@ impl<'a, Message: 'a> Widget<Message, Theme, Renderer> for Collapse<'a, Message>
         let style = (self.header_style)(theme, status);
 
         if let Some(background) = style.background {
+            let bounds = if self.style_bounds {
+                layout.bounds()
+            } else {
+                header_bounds
+            };
             renderer::Renderer::fill_quad(
                 renderer,
                 renderer::Quad {
-                    bounds: header_bounds,
+                    bounds,
                     border: style.border,
                     shadow: style.shadow,
                     snap: style.snap,

--- a/liana-ui/src/component/form.rs
+++ b/liana-ui/src/component/form.rs
@@ -49,8 +49,8 @@ impl FormSize {
         Padding {
             top: v,
             bottom: v,
-            left: 16.0,
-            right: 16.0,
+            left: 10.0,
+            right: 10.0,
         }
     }
 }

--- a/liana-ui/src/component/installer.rs
+++ b/liana-ui/src/component/installer.rs
@@ -138,8 +138,8 @@ fn identity_bar<'a, M: 'static + 'a + Clone>(
         Variant::LianaBusiness => 200,
     };
     let logo = match variant {
-        Variant::Liana => image::liana_wallet_logo(),
-        Variant::LianaBusiness => image::liana_business_logo(),
+        Variant::Liana => image::liana_wallet_logo().width(170),
+        Variant::LianaBusiness => image::liana_business_logo().width(200),
     }
     .width(logo_width)
     .height(IDENTITY_BAR_HEIGHT);

--- a/liana-ui/src/component/installer.rs
+++ b/liana-ui/src/component/installer.rs
@@ -1,0 +1,429 @@
+use iced::{
+    widget::{column, row, rule, stack, Space},
+    Alignment, Length, Padding,
+};
+use std::fmt::Display;
+
+use bitcoin::Network;
+
+use crate::{
+    component, icon, image,
+    spacing::{HSpacing, VSpacing},
+    theme,
+    widget::*,
+    Variant,
+};
+
+use super::{
+    button::{btn_breadcrumb_previous, btn_share_xpubs},
+    list, pick_list, pill, scrollable, text,
+};
+
+const USERBAR_HEIGHT: u32 = 44;
+const NAV_LEFT_SLOT_WIDTH: u32 = 200;
+const MAX_SCROLL_HEIGHT: u32 = 500;
+const HEADER_HEIGHT: u32 = 88;
+const CONTENT_TOP_SPACING: u32 = 72;
+const SCREEN_INTRO_SUB_WIDTH: u32 = 620;
+
+pub enum LayoutContent<'a, M> {
+    Scrollable(Element<'a, M>),
+    ScrollableList {
+        header: Option<Element<'a, M>>,
+        list: Element<'a, M>,
+        pinned: Option<Element<'a, M>>,
+        footer: Option<Element<'a, M>>,
+    },
+}
+
+pub struct LayoutConfig<'a, M> {
+    pub variant: Variant,
+    pub network: Network,
+    pub email: Option<&'a str>,
+    pub is_ws_admin: bool,
+    pub nav_bar: NavBar<'a, M>,
+    pub content_width: f32,
+}
+
+pub enum NavBar<'a, M> {
+    Steps {
+        progress: (usize, usize),
+        breadcrumb: Vec<String>,
+        previous_message: Option<M>,
+    },
+    StepTitle {
+        progress: (usize, usize),
+        title: &'a str,
+        previous_message: Option<M>,
+    },
+    Launcher {
+        previous_message: Option<M>,
+        share_xpubs_message: Option<M>,
+        networks: &'a [Network],
+        selected_network: Network,
+        on_network_selected: fn(Network) -> M,
+    },
+}
+
+pub fn screen_intro<'a, M: 'a>(
+    title: impl Display + 'a,
+    sub: Option<Element<'a, M>>,
+    extra_spacing: bool,
+) -> Element<'a, M> {
+    let spacing = if extra_spacing { 60 } else { 15 };
+    column![text::new::d3(title), sub]
+        .align_x(Alignment::Center)
+        .spacing(spacing)
+        .into()
+}
+
+pub fn intro_description<'a, M: 'a>(value: &'a str) -> Element<'a, M> {
+    Container::new(text::new::caption(value).style(theme::text::secondary))
+        .width(Length::Shrink)
+        .max_width(SCREEN_INTRO_SUB_WIDTH)
+        .align_x(Alignment::Center)
+        .into()
+}
+
+pub fn intro_prompt<'a, M: 'a>(prompt: &'a str, accent: Option<&'a str>) -> Element<'a, M> {
+    let accent = accent.map(|accent| text::new::h3_semi(accent).style(theme::text::accent));
+    Container::new(row![text::new::h3_semi(prompt), accent].wrap())
+        .center_x(Length::Fill)
+        .into()
+}
+
+fn breadcrumb_header<'a, M: 'a>(segments: &[String]) -> Element<'a, M> {
+    let mut row = row![].spacing(HSpacing::M).align_y(Alignment::Center);
+
+    for (i, segment) in segments.iter().enumerate() {
+        if i > 0 {
+            row = row.push(list::breadcrumb_chevron());
+        }
+        row = row.push(if i + 1 == segments.len() {
+            text::new::h3_semi(segment.clone()).style(theme::text::primary)
+        } else {
+            text::new::h3(segment.clone()).style(theme::text::muted)
+        });
+    }
+
+    row.wrap().into()
+}
+
+fn thin_separator<'a, M: 'a>() -> Container<'a, M> {
+    Container::new(rule::horizontal(1).style(|t: &theme::Theme| {
+        if t.is_business() {
+            theme::rule::separator(t)
+        } else {
+            theme::rule::transparent(t)
+        }
+    }))
+}
+
+fn identity_bar<'a, M: 'static + 'a + Clone>(
+    variant: Variant,
+    network: Network,
+    is_ws_admin: bool,
+    email: Option<&'a str>,
+) -> Element<'a, M> {
+    const IDENTITY_BAR_HEIGHT: u32 = 28;
+
+    let identity_theme = if network == Network::Bitcoin {
+        theme::container::top_bar
+    } else {
+        theme::banner::network
+    };
+
+    let logo_width = match variant {
+        Variant::Liana => 170,
+        Variant::LianaBusiness => 200,
+    };
+    let logo = match variant {
+        Variant::Liana => image::liana_wallet_logo(),
+        Variant::LianaBusiness => image::liana_business_logo(),
+    }
+    .width(logo_width)
+    .height(IDENTITY_BAR_HEIGHT);
+    let logo: Element<'a, M> = if variant == Variant::Liana && network != Network::Bitcoin {
+        Container::new(logo)
+            .padding([0, 20])
+            .height(USERBAR_HEIGHT)
+            .align_y(Alignment::Center)
+            .style(theme::container::top_bar)
+            .into()
+    } else {
+        Container::new(logo)
+            .padding([0, 20])
+            .height(USERBAR_HEIGHT)
+            .align_y(Alignment::Center)
+            .into()
+    };
+
+    let ws_admin_pill = is_ws_admin.then_some(pill::ws_admin());
+    let user = email.map(|e| {
+        let mut icon = icon::person_icon().size(16).style(theme::text::tertiary);
+        let e = component::text::short_email(e, 35);
+        let mut mail = text::new::caption(e).style(theme::text::accent);
+        if network != Network::Bitcoin {
+            icon = icon.style(theme::text::network_banner);
+            mail = mail.style(theme::text::network_banner);
+        }
+        row![icon, mail].spacing(HSpacing::ML)
+    });
+    let user = row![
+        Space::fill_width(),
+        ws_admin_pill,
+        user,
+        Space::with_width(20)
+    ]
+    .height(Length::Fill)
+    .align_y(Alignment::Center);
+    let identity_bar = row![logo, Space::fill_width()]
+        .spacing(HSpacing::ML)
+        .align_y(Alignment::Center)
+        .height(USERBAR_HEIGHT)
+        .width(Length::Fill);
+
+    let content = if network == Network::Bitcoin {
+        stack![identity_bar, user]
+    } else {
+        stack![
+            identity_bar,
+            Container::new(row![
+                Space::with_width(logo_width + 30),
+                Container::new(network_warning(network))
+                    .style(identity_theme)
+                    .padding(Padding {
+                        top: 0.0,
+                        right: 0.0,
+                        bottom: 0.0,
+                        left: 50.0,
+                    })
+                    .width(Length::Fill)
+                    .center_y(Length::Fill),
+            ]),
+            user
+        ]
+    };
+
+    Container::new(content)
+        .style(theme::container::top_bar)
+        .into()
+}
+
+fn network_warning<'a, M: 'a>(network: Network) -> Element<'a, M> {
+    row![
+        icon::warning_icon(),
+        text::new::caption("THIS IS A "),
+        text::new::b5_bold(match network {
+            Network::Signet => "SIGNET WALLET",
+            Network::Testnet => "TESTNET WALLET",
+            Network::Testnet4 => "TESTNET4 WALLET",
+            Network::Regtest => "REGTEST WALLET",
+            Network::Bitcoin => unreachable!(),
+            _ => "NON-MAINNET WALLET",
+        }),
+        text::new::caption(", COINS HAVE "),
+        text::new::b5_bold("NO VALUE"),
+    ]
+    .align_y(Alignment::Center)
+    .into()
+}
+
+fn step_dots<'a, M: 'a>((step, total): (usize, usize)) -> Element<'a, M> {
+    let mut dots = row![].spacing(HSpacing::XS).align_y(Alignment::Center);
+    for i in 0..total {
+        let filled = i < step;
+        let width = if i + 1 == step { 20.0 } else { 8.0 };
+        dots = dots.push(
+            Container::new(Space::new())
+                .width(width)
+                .height(8)
+                .style(if filled {
+                    theme::container::step_dot_filled
+                } else {
+                    theme::container::step_dot_track
+                }),
+        );
+    }
+    dots.push(Space::with_width(HSpacing::XS))
+        .push(
+            text::new::small_caption(format!("{step}/{total}"))
+                .style(|theme: &theme::Theme| theme::text::custom(theme.colors.general.accent)),
+        )
+        .into()
+}
+
+fn step_nav<'a, M: Clone + 'a>(
+    header: impl Into<Element<'a, M>>,
+    msg: Option<M>,
+    progress: (usize, usize),
+) -> Element<'a, M> {
+    let progress = if progress.1 > 0 {
+        step_dots(progress)
+    } else {
+        row![].into()
+    };
+
+    row![
+        previous_slot(msg),
+        Container::new(header).width(Length::Fill),
+        progress,
+        Space::with_width(20),
+    ]
+    .align_y(Alignment::Center)
+    .height(HEADER_HEIGHT)
+    .into()
+}
+
+fn previous_slot<'a, M: Clone + 'a>(msg: Option<M>) -> Container<'a, M> {
+    let content: Element<'a, M> = if msg.is_some() {
+        btn_breadcrumb_previous(msg).into()
+    } else {
+        Space::new().into()
+    };
+
+    Container::new(content).center_x(NAV_LEFT_SLOT_WIDTH)
+}
+
+fn launcher_nav<'a, M: Clone + 'a>(
+    previous_message: Option<M>,
+    share_xpubs_message: Option<M>,
+    networks: &'a [Network],
+    selected_network: Network,
+    on_network_selected: fn(Network) -> M,
+) -> Element<'a, M> {
+    let network_picker =
+        pick_list::pick_list(networks, Some(selected_network), on_network_selected).padding(10);
+
+    row![
+        previous_slot(previous_message),
+        Space::fill_width(),
+        btn_share_xpubs(share_xpubs_message),
+        network_picker,
+        Space::with_width(20),
+    ]
+    .spacing(20)
+    .align_y(Alignment::Center)
+    .height(HEADER_HEIGHT)
+    .into()
+}
+
+fn nav_bar<'a, M: Clone + 'a>(nav_bar: NavBar<'a, M>) -> Element<'a, M> {
+    match nav_bar {
+        NavBar::Steps {
+            progress,
+            breadcrumb,
+            previous_message,
+        } => step_nav(breadcrumb_header(&breadcrumb), previous_message, progress),
+        NavBar::StepTitle {
+            progress,
+            title,
+            previous_message,
+        } => step_nav(text::new::h3_semi(title), previous_message, progress),
+        NavBar::Launcher {
+            previous_message,
+            share_xpubs_message,
+            networks,
+            selected_network,
+            on_network_selected,
+        } => launcher_nav(
+            previous_message,
+            share_xpubs_message,
+            networks,
+            selected_network,
+            on_network_selected,
+        ),
+    }
+}
+
+pub fn layout_inner<'a, M: 'static + Clone + 'a>(
+    config: LayoutConfig<'a, M>,
+    content: LayoutContent<'a, M>,
+) -> Element<'a, M> {
+    let identity_bar = identity_bar(
+        config.variant,
+        config.network,
+        config.is_ws_admin,
+        config.email,
+    );
+    let top = column![identity_bar, thin_separator(), nav_bar(config.nav_bar),].width(Length::Fill);
+
+    let body: Element<'a, M> = match content {
+        LayoutContent::Scrollable(inner) => {
+            let inner = Container::new(inner)
+                .width(Length::Fill)
+                .max_width(config.content_width);
+            let content_body = Container::new(column![
+                Space::with_height(CONTENT_TOP_SPACING as f32),
+                Container::new(inner).center_x(Length::Fill),
+            ])
+            .width(Length::Fill);
+
+            scrollable::vertical_floating(content_body)
+                .height(Length::Fill)
+                .width(Length::Fill)
+                .into()
+        }
+        LayoutContent::ScrollableList {
+            header,
+            list,
+            pinned,
+            footer,
+        } => {
+            let header = Container::new(header).center_x(Length::Fill);
+            let list_body = Container::new(scrollable::vertical(list))
+                .max_height(MAX_SCROLL_HEIGHT)
+                .max_width(config.content_width);
+            let footer = footer.map(|f| {
+                column![
+                    thin_separator(),
+                    Space::with_height(VSpacing::S),
+                    f,
+                    Space::with_height(VSpacing::S),
+                ]
+            });
+
+            let body = column![header, list_body, pinned, Space::fill_height(), footer,]
+                .spacing(VSpacing::M)
+                .max_width(config.content_width);
+
+            Container::new(body)
+                .center_x(Length::Fill)
+                .height(Length::Fill)
+                .into()
+        }
+    };
+
+    let content = column![top, body].width(Length::Fill).height(Length::Fill);
+
+    Container::new(content)
+        .center_x(Length::Fill)
+        .height(Length::Fill)
+        .style(theme::container::background)
+        .into()
+}
+
+pub fn layout<'a, M: 'static + Clone + 'a>(
+    config: LayoutConfig<'a, M>,
+    content: impl Into<Element<'a, M>>,
+) -> Element<'a, M> {
+    layout_inner(config, LayoutContent::Scrollable(content.into()))
+}
+
+pub fn layout_with_scrollable_list<'a, M: 'static + Clone + 'a>(
+    config: LayoutConfig<'a, M>,
+    header_content: Option<Element<'a, M>>,
+    list_content: impl Into<Element<'a, M>>,
+    pinned_content: Option<Element<'a, M>>,
+    footer_content: Option<Element<'a, M>>,
+) -> Element<'a, M> {
+    layout_inner(
+        config,
+        LayoutContent::ScrollableList {
+            header: header_content,
+            list: list_content.into(),
+            pinned: pinned_content,
+            footer: footer_content,
+        },
+    )
+}

--- a/liana-ui/src/component/installer.rs
+++ b/liana-ui/src/component/installer.rs
@@ -138,8 +138,8 @@ fn identity_bar<'a, M: 'static + 'a + Clone>(
         Variant::LianaBusiness => 200,
     };
     let logo = match variant {
-        Variant::Liana => image::liana_wallet_logo().width(170),
-        Variant::LianaBusiness => image::liana_business_logo().width(200),
+        Variant::Liana => image::liana_wallet_logo(),
+        Variant::LianaBusiness => image::liana_business_logo(),
     }
     .width(logo_width)
     .height(IDENTITY_BAR_HEIGHT);

--- a/liana-ui/src/component/label.rs
+++ b/liana-ui/src/component/label.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 use super::{
-    button::{btn_cancel, btn_edit, btn_generate, btn_save},
+    button::{btn_cancel, btn_generate, btn_icon_edit, btn_save},
     form::{Form, Value},
     modal::modal_view,
 };
@@ -21,7 +21,7 @@ pub fn editable_label<'a, M: 'a + Clone>(label: impl Display, msg: M) -> Element
     if label.is_empty() {
         label = "(No label)".to_string();
     }
-    let edit = btn_edit(Some(msg));
+    let edit = btn_icon_edit(Some(msg));
     let label = new::h2(label);
     row![label, edit]
         .spacing(10)
@@ -60,7 +60,7 @@ where
     let ok = if is_new {
         btn_generate(confirm)
     } else {
-        btn_save(confirm)
+        btn_save(confirm, true)
     };
     let btn_row = row![Space::fill_width(), cancel, ok].spacing(12);
     let content = column![input, btn_row].spacing(28);

--- a/liana-ui/src/component/list.rs
+++ b/liana-ui/src/component/list.rs
@@ -12,7 +12,7 @@ use crate::{
     component::{
         badge::{self, Tile},
         button::{self, EntryWidth, ListEntryAccent},
-        form,
+        collapse, form,
         text::{self, new::caption},
         tooltip,
     },
@@ -23,6 +23,8 @@ use crate::{
 };
 
 use super::text::truncate;
+
+const COLLAPSIBLE_ENTRY_CONTENT_BOTTOM_PADDING: u16 = 10;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum EntryAccent {
@@ -220,6 +222,63 @@ pub fn entry_paste_xpub<'a, M: Clone + 'a>(
         Some(Button::new(icon::paste_icon()).on_press(on_paste).into()),
         EntryWidth::Standard,
     )
+}
+
+pub struct CollapsibleEntry<'a, M> {
+    pub accent: Option<EntryAccent>,
+    pub tile: Tile,
+    pub title: &'static str,
+    pub collapsed_subtitle: Option<&'static str>,
+    pub expanded_subtitle: Option<&'static str>,
+    pub content: Element<'a, M>,
+    pub expanded: bool,
+    pub on_toggle: M,
+}
+
+pub fn entry_collapsible<'a, M: Clone + 'static>(cfg: CollapsibleEntry<'a, M>) -> Element<'a, M> {
+    let accent = cfg.accent.map(entry_accent);
+    let entry = collapse::Collapse::new(
+        collapsible_entry_header(
+            cfg.tile,
+            cfg.title.to_string(),
+            cfg.collapsed_subtitle.map(str::to_string),
+        ),
+        collapsible_entry_header(
+            cfg.tile,
+            cfg.title.to_string(),
+            cfg.expanded_subtitle.map(str::to_string),
+        ),
+        Container::new(cfg.content).padding(iced::Padding {
+            left: button::LIST_ENTRY_PADDING[1].into(),
+            right: button::LIST_ENTRY_PADDING[1].into(),
+            bottom: COLLAPSIBLE_ENTRY_CONTENT_BOTTOM_PADDING.into(),
+            ..iced::Padding::ZERO
+        }),
+    )
+    .expanded(cfg.expanded)
+    .on_toggle(move || cfg.on_toggle.clone())
+    .style(move |theme, status| button::list_entry_style(theme, status, accent, true))
+    .style_bounds()
+    .padding(button::LIST_ENTRY_PADDING)
+    .width(Length::Fill);
+
+    button::list_entry_card(entry, accent, EntryWidth::Standard)
+}
+
+fn collapsible_entry_header<'a, M: Clone + 'a>(
+    tile: Tile,
+    title: String,
+    subtitle: Option<String>,
+) -> Element<'a, M> {
+    let content = row![
+        badge::tile_accent(tile),
+        Container::new(item_body(title, subtitle)).width(Length::Fill),
+    ]
+    .spacing(16)
+    .align_y(Alignment::Center)
+    .width(Length::Fill);
+
+    Container::new(content).width(Length::Fill).into()
 }
 
 pub fn entry_organization<'a, M: Clone + 'a>(
@@ -494,6 +553,26 @@ pub fn entry_action<'a, M: Clone + 'a>(
     leaf_entry(tile, title, subtitle, trailing, None, width, msg)
 }
 
+pub fn entry_action_accent<'a, M: Clone + 'a>(
+    accent: Option<EntryAccent>,
+    tile: Tile,
+    title: impl Display,
+    subtitle: Option<impl Display>,
+    trailing: Option<Element<'a, M>>,
+    width: EntryWidth,
+    msg: Option<M>,
+) -> Element<'a, M> {
+    leaf_entry(
+        tile,
+        title,
+        subtitle,
+        trailing,
+        accent.map(entry_accent),
+        width,
+        msg,
+    )
+}
+
 pub fn entry_no_devices<'a, M: Clone + 'a>(
     title: impl Display,
     subtitle: Option<impl Display>,
@@ -543,8 +622,14 @@ fn leaf_entry<'a, M: Clone + 'a>(
     width: EntryWidth,
     msg: Option<M>,
 ) -> Element<'a, M> {
+    let tile = if accent.is_some() {
+        badge::tile_accent(tile)
+    } else {
+        badge::tile(tile)
+    };
+
     list_entry_row(
-        Some(badge::tile(tile).into()),
+        Some(tile.into()),
         item_body(title, subtitle),
         trailing,
         accent,

--- a/liana-ui/src/component/list.rs
+++ b/liana-ui/src/component/list.rs
@@ -8,6 +8,7 @@ use iced::{
 };
 
 use crate::{
+    color,
     component::{
         badge::{self, Tile},
         button::{self, EntryWidth, ListEntryAccent},
@@ -15,15 +16,21 @@ use crate::{
         text::{self, new::caption},
         tooltip,
     },
-    icon, theme,
+    icon,
+    spacing::HSpacing,
+    theme,
     widget::{Button, Container, Element, Row},
 };
 
+use super::text::truncate;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum EntryStatus {
+pub enum EntryAccent {
     Simple,
     Warning,
     Success,
+    Bitcoin,
+    Testnet,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -283,18 +290,29 @@ fn with_delete_button<'a, M: Clone + 'a>(
 }
 
 pub fn entry_wallet<'a, M: Clone + 'a>(
-    status: EntryStatus,
+    accent: Option<EntryAccent>,
     title: impl Display,
-    role: Option<Element<'a, M>>,
     subtitle: Option<Element<'a, M>>,
-    trailing: Option<Element<'a, M>>,
+    role_pill: Option<Element<'a, M>>,
+    status_pill: Option<Element<'a, M>>,
     msg: Option<M>,
 ) -> Element<'a, M> {
+    let title = title.to_string();
+    let title = truncate(&title, 25);
+    let trailing = Some(
+        row![status_pill, entry_chevron()]
+            .spacing(HSpacing::ML)
+            .align_y(Alignment::Center)
+            .into(),
+    );
+
+    let accent = accent.map(|s| entry_accent(s));
+
     list_entry_row(
         Some(badge::tile(Tile::Wallet).into()),
-        wallet_body(title, role, subtitle),
+        wallet_body(title, role_pill, subtitle),
         trailing,
-        Some(status_accent(status)),
+        accent,
         EntryWidth::Standard,
         msg,
     )
@@ -611,9 +629,9 @@ fn body<'a, M: 'a>(
     Container::new(content).width(Length::Fill).into()
 }
 
-fn status_accent(status: EntryStatus) -> ListEntryAccent {
+fn entry_accent(status: EntryAccent) -> ListEntryAccent {
     match status {
-        EntryStatus::Simple => |theme| {
+        EntryAccent::Simple => |theme| {
             theme
                 .colors
                 .pills
@@ -621,7 +639,7 @@ fn status_accent(status: EntryStatus) -> ListEntryAccent {
                 .border
                 .unwrap_or(theme.colors.general.accent)
         },
-        EntryStatus::Warning => |theme| {
+        EntryAccent::Warning => |theme| {
             theme
                 .colors
                 .pills
@@ -629,7 +647,7 @@ fn status_accent(status: EntryStatus) -> ListEntryAccent {
                 .border
                 .unwrap_or(theme.colors.text.warning)
         },
-        EntryStatus::Success => |theme| {
+        EntryAccent::Success => |theme| {
             theme
                 .colors
                 .pills
@@ -637,6 +655,8 @@ fn status_accent(status: EntryStatus) -> ListEntryAccent {
                 .border
                 .unwrap_or(theme.colors.text.success)
         },
+        EntryAccent::Bitcoin => |t| t.colors.general.accent,
+        EntryAccent::Testnet => |_| color::BLUE,
     }
 }
 

--- a/liana-ui/src/component/list.rs
+++ b/liana-ui/src/component/list.rs
@@ -169,7 +169,7 @@ pub fn list_entry_row<'a, M: Clone + 'a>(
     button::list_entry(content, accent, width, msg)
 }
 
-pub fn entry_chevron<'a, M: 'a>() -> Element<'a, M> {
+pub fn right_chevron<'a, M: 'a>() -> Element<'a, M> {
     icon::chevron_right()
         .size(18)
         .style(theme::text::secondary)
@@ -225,13 +225,12 @@ pub fn entry_paste_xpub<'a, M: Clone + 'a>(
 pub fn entry_organization<'a, M: Clone + 'a>(
     title: impl Display,
     subtitle: Option<impl Display>,
-    trailing: Option<Element<'a, M>>,
     msg: Option<M>,
 ) -> Element<'a, M> {
-    list_entry_row(
+    list_entry_chevron(
         Some(badge::tile(Tile::Org).into()),
         section_body(title, subtitle),
-        trailing,
+        None,
         None,
         EntryWidth::Standard,
         msg,
@@ -265,7 +264,7 @@ pub fn account_entry<'a, M: Clone + 'a>(
     let entry = list_entry_row(
         Some(badge::tile(Tile::Account).into()),
         body,
-        Some(entry_chevron()),
+        Some(right_chevron()),
         None,
         EntryWidth::Deletable,
         on_select,
@@ -299,23 +298,37 @@ pub fn entry_wallet<'a, M: Clone + 'a>(
 ) -> Element<'a, M> {
     let title = title.to_string();
     let title = truncate(&title, 25);
-    let trailing = Some(
-        row![status_pill, entry_chevron()]
-            .spacing(HSpacing::ML)
-            .align_y(Alignment::Center)
-            .into(),
-    );
 
     let accent = accent.map(|s| entry_accent(s));
 
-    list_entry_row(
+    list_entry_chevron(
         Some(badge::tile(Tile::Wallet).into()),
         wallet_body(title, role_pill, subtitle),
-        trailing,
+        status_pill,
         accent,
         EntryWidth::Standard,
         msg,
     )
+}
+
+pub fn list_entry_chevron<'a, M: Clone + 'a>(
+    tile: Option<Element<'a, M>>,
+    body: impl Into<Element<'a, M>>,
+    trailing: Option<Element<'a, M>>,
+    accent: Option<ListEntryAccent>,
+    width: EntryWidth,
+    msg: Option<M>,
+) -> Element<'a, M> {
+    let trailing = row![trailing, right_chevron()]
+        .spacing(HSpacing::ML)
+        .align_y(Alignment::Center);
+    let body = Container::new(body).width(Length::Fill);
+    let content = row![tile, body, trailing]
+        .spacing(16)
+        .align_y(Alignment::Center)
+        .width(Length::Fill);
+
+    button::list_entry(content, accent, width, msg)
 }
 
 /// "(1 key)" / "({n} keys)" caption shown beside a wallet title; `None` for no keys.

--- a/liana-ui/src/component/list.rs
+++ b/liana-ui/src/component/list.rs
@@ -311,14 +311,7 @@ pub fn account_entry<'a, M: Clone + 'a>(
         (on_select, on_delete)
     };
 
-    let body: Element<'a, M> = if connecting {
-        text::new::b5_medium("Connecting...")
-            .width(Length::Fill)
-            .align_x(Horizontal::Center)
-            .into()
-    } else {
-        item_body(email, None::<String>)
-    };
+    let body = account_body(email, connecting);
 
     let entry = list_entry_row(
         Some(badge::tile(Tile::Account).into()),
@@ -330,6 +323,36 @@ pub fn account_entry<'a, M: Clone + 'a>(
     );
 
     with_delete_button(entry, on_delete)
+}
+
+pub fn account_select_entry<'a, M: Clone + 'a>(
+    email: impl Display,
+    connecting: bool,
+    on_select: Option<M>,
+) -> Element<'a, M> {
+    let on_select = if connecting { None } else { on_select };
+
+    let body = account_body(email, connecting);
+
+    list_entry_row(
+        Some(badge::tile(Tile::Account).into()),
+        body,
+        Some(right_chevron()),
+        None,
+        EntryWidth::Standard,
+        on_select,
+    )
+}
+
+fn account_body<'a, M: 'a>(email: impl Display, connecting: bool) -> Element<'a, M> {
+    if connecting {
+        text::new::b5_medium("Connecting...")
+            .width(Length::Fill)
+            .align_x(Horizontal::Center)
+            .into()
+    } else {
+        item_body(email, None::<String>)
+    }
 }
 
 /// Append a delete (cross) button after a [`EntryWidth::Deletable`] entry, in the reserved slot.

--- a/liana-ui/src/component/mod.rs
+++ b/liana-ui/src/component/mod.rs
@@ -7,6 +7,7 @@ pub mod checkbox;
 pub mod collapse;
 pub mod combobox;
 pub mod form;
+pub mod installer;
 pub mod label;
 pub mod list;
 pub mod modal;

--- a/liana-ui/src/component/modal/mod.rs
+++ b/liana-ui/src/component/modal/mod.rs
@@ -118,15 +118,9 @@ pub fn header<'a, M: 'a + Clone>(
     back_message: Option<M>,
     close_message: Option<M>,
 ) -> Element<'a, M> {
-    let back = back_message
-        .map(|m| button::transparent(Some(icon::arrow_back().size(25)), "").on_press(m));
+    let back = back_message.map(button::btn_modal_previous);
     let title = label.map(b1_bold);
-    let close = close_message.map(|m| {
-        Button::new(icon::cross_icon().size(40))
-            .padding(0)
-            .style(theme::button::transparent)
-            .on_press(m)
-    });
+    let close = close_message.map(|m| button::btn_modal_close(Some(m)));
     row![back, title, Space::with_width(Length::Fill), close]
         .align_y(Vertical::Center)
         .into()

--- a/liana-ui/src/component/modal/mod.rs
+++ b/liana-ui/src/component/modal/mod.rs
@@ -156,13 +156,13 @@ where
         .spacing(H_SPACING);
 
     Button::new(row)
-        .style(theme::button::transparent_border)
+        .style(theme::button::tertiary)
         .on_press(msg)
         .into()
 }
 
-/// Outer shell for a collapsible key/signer entry, routed through the
-/// `button::device*` helpers.
+/// Outer shell for a collapsible key/signer entry, routed through selectable
+/// list entries.
 pub fn collapsible_button<'a, Message, Closed, Expanded, Collapse>(
     collapsed: bool,
     closed_content: Closed,
@@ -176,9 +176,21 @@ where
     Message: Clone + 'static,
 {
     if collapsed {
-        button::device_with_height_clickable(expanded_content, None, None, false)
+        button::list_entry_with_state(
+            expanded_content,
+            None,
+            button::EntryWidth::Fill,
+            true,
+            false,
+            None,
+        )
     } else {
-        button::device(closed_content, Some(collapse_message()))
+        button::list_entry(
+            closed_content,
+            None,
+            button::EntryWidth::Fill,
+            Some(collapse_message()),
+        )
     }
 }
 
@@ -205,7 +217,7 @@ where
         form::Form::new_disabled(&input_placeholder, input_value)
     }
     .padding(10);
-    let paste = paste_message.map(|m| Button::new(icon::paste_icon()).on_press(m()));
+    let paste = paste_message.map(|m| button::btn_paste_icon(Some(m())));
 
     if collapsed {
         let icon = icon.map(|i| i.style(theme::text::primary));
@@ -222,12 +234,18 @@ where
             .align_y(Vertical::Center)
             .spacing(H_SPACING)
             .width(Length::Fill);
-        button::device_with_height_clickable(content, None, None, false)
+        button::list_entry_with_state(content, None, button::EntryWidth::Fill, true, false, None)
     } else {
         let content = row![icon, caption(label)]
             .spacing(H_SPACING)
-            .align_y(Vertical::Center);
-        button::device(content, Some(collapse_message()))
+            .align_y(Vertical::Center)
+            .width(Length::Fill);
+        button::list_entry(
+            content,
+            None,
+            button::EntryWidth::Fill,
+            Some(collapse_message()),
+        )
     }
 }
 
@@ -314,8 +332,14 @@ pub fn key_entry<'a, M: 'a + Clone>(
         tt
     ]
     .align_y(Vertical::Center)
-    .spacing(H_SPACING);
-    button::device(row, on_press)
+    .spacing(H_SPACING)
+    .width(Length::Fill);
+    button::list_entry(
+        row,
+        None,
+        button::EntryWidth::Custom(BTN_W as f32),
+        on_press,
+    )
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -390,8 +414,9 @@ where
         Option::<Element<'a, M>>::from(status)
     ]
     .align_y(Vertical::Center)
-    .spacing(H_SPACING);
-    button::device(row, on_press)
+    .spacing(H_SPACING)
+    .width(Length::Fill);
+    button::list_entry(row, None, button::EntryWidth::Fill, on_press)
 }
 
 /// Derivation-account picker: a dropdown over accounts 0..10 for the given device.
@@ -434,8 +459,9 @@ where
     let designation = device_designation(kind, alias, Some(format!("#{fingerprint}")));
     let row = row![icon, designation, Space::fill_width(), picker]
         .align_y(Vertical::Center)
-        .spacing(H_SPACING);
-    button::device(row, on_press)
+        .spacing(H_SPACING)
+        .width(Length::Fill);
+    button::list_entry(row, None, button::EntryWidth::Fill, on_press)
 }
 
 /// Row entry for an expected key in a registration-style flow.
@@ -490,7 +516,7 @@ where
     let col = column![row, error].width(Length::Fill);
 
     let msg = on_press.map(|f| f());
-    button::device(col, msg)
+    button::list_entry(col, None, button::EntryWidth::Fill, msg)
 }
 
 pub fn modal_no_devices_placeholder<'a, M: 'a>() -> Element<'a, M> {

--- a/liana-ui/src/component/modal/mod.rs
+++ b/liana-ui/src/component/modal/mod.rs
@@ -155,10 +155,7 @@ where
         .align_y(Vertical::Center)
         .spacing(H_SPACING);
 
-    Button::new(row)
-        .style(theme::button::tertiary)
-        .on_press(msg)
-        .into()
+    button::btn_optional_section(row, msg).into()
 }
 
 /// Outer shell for a collapsible key/signer entry, routed through selectable

--- a/liana-ui/src/component/panels/spend/mod.rs
+++ b/liana-ui/src/component/panels/spend/mod.rs
@@ -257,7 +257,7 @@ pub fn fee_rate_row<'a, M: Clone + 'static, F: Fn(Amount) -> FiatAmount>(
     let label = new::b3("Feerate:");
 
     let input: Element<'a, M> = Container::new(
-        form::Form::new_trimmed("e.g. 5 (in sats/vbyte)", feerate, on_edit)
+        form::Form::new_trimmed("e.g. 5 (in sats/vb)", feerate, on_edit)
             .compact()
             .fee(),
     )

--- a/liana-ui/src/component/panels/spend/mod.rs
+++ b/liana-ui/src/component/panels/spend/mod.rs
@@ -395,7 +395,7 @@ pub fn coin_row<'a, M: Clone + 'static>(
         new::b3_medium(txt)
     }
     fn label_style(theme: &Theme) -> Style {
-        theme::amount::zeroes(theme, false)
+        theme::amount::sats(theme, false)
     }
     let max_len = label_len(available_width);
     let short = |s: String| -> String {
@@ -408,7 +408,7 @@ pub fn coin_row<'a, M: Clone + 'static>(
     let coin_label: Element<M> = match label {
         CoinLabel::Outpoint(label) => font(short(label)).style(label_style).into(),
         CoinLabel::Transaction(label) => {
-            let from = font("From").style(theme::text::secondary);
+            let from = font("From").style(|t| theme::amount::zeroes(t, false));
             row![from, font(short(label)).style(label_style)]
                 .spacing(5)
                 .into()

--- a/liana-ui/src/component/scrollable.rs
+++ b/liana-ui/src/component/scrollable.rs
@@ -24,6 +24,10 @@ pub fn vertical<'a, M: 'a>(content: impl Into<Element<'a, M>>) -> Scrollable<'a,
         .spacing(SPACING)
 }
 
+pub fn vertical_floating<'a, M: 'a>(content: impl Into<Element<'a, M>>) -> Scrollable<'a, M> {
+    Scrollable::new(content).direction(Direction::Vertical(Scrollbar::default()))
+}
+
 pub fn horizontal_thin<'a, M: 'a>(content: impl Into<Element<'a, M>>) -> Scrollable<'a, M> {
     Scrollable::new(content)
         .direction(Direction::Horizontal(thin_scrollbar()))

--- a/liana-ui/src/component/text/new.rs
+++ b/liana-ui/src/component/text/new.rs
@@ -13,6 +13,7 @@ use crate::font;
 //     }
 #[rustfmt::skip]
 text_roles! {
+    d0,                     D0_SPEC,                    font::MANROPE_BOLD,     50;
     d2,                     D2_SPEC,                    font::MANROPE_BOLD,     32;
     d3,                     D3_SPEC,                    font::MANROPE_BOLD,     26;
     d4,                     D4_SPEC,                    font::MANROPE_BOLD,     22;

--- a/liana-ui/src/icon.rs
+++ b/liana-ui/src/icon.rs
@@ -141,10 +141,6 @@ pub fn trash_icon() -> Text<'static> {
     bootstrap_icon('\u{F5DE}')
 }
 
-pub fn pencil_icon() -> Text<'static> {
-    bootstrap_icon('\u{F4CB}')
-}
-
 pub fn collapse_icon() -> Text<'static> {
     bootstrap_icon('\u{F285}')
 }

--- a/liana-ui/src/icon.rs
+++ b/liana-ui/src/icon.rs
@@ -133,7 +133,7 @@ pub fn warning_fill_icon() -> Text<'static> {
     bootstrap_icon('\u{F33A}')
 }
 
-pub fn chip_icon() -> Text<'static> {
+pub fn chip_icon<'a>() -> Text<'a> {
     bootstrap_icon('\u{F2D6}')
 }
 
@@ -181,11 +181,11 @@ pub fn round_key_icon<'a>() -> Text<'a> {
     bootstrap_icon('\u{F44E}')
 }
 
-pub fn backup_icon() -> Text<'static> {
+pub fn backup_icon<'a>() -> Text<'a> {
     bootstrap_icon('\u{F356}')
 }
 
-pub fn restore_icon() -> Text<'static> {
+pub fn restore_icon<'a>() -> Text<'a> {
     bootstrap_icon('\u{F358}')
 }
 

--- a/liana-ui/src/icon.rs
+++ b/liana-ui/src/icon.rs
@@ -53,10 +53,6 @@ pub fn arrow_down() -> Text<'static> {
     bootstrap_icon('\u{F128}')
 }
 
-pub fn arrow_back<'a>() -> Text<'a> {
-    bootstrap_icon('\u{F12E}')
-}
-
 pub fn arrow_right() -> Text<'static> {
     bootstrap_icon('\u{F138}')
 }

--- a/liana-ui/src/icon.rs
+++ b/liana-ui/src/icon.rs
@@ -241,6 +241,10 @@ pub fn clock_fill_icon() -> Text<'static> {
     bootstrap_icon('\u{F291}')
 }
 
+pub fn edit_icon_padding<'a>() -> Text<'a> {
+    bootstrap_icon('\u{F4CA}')
+}
+
 pub fn edit_icon<'a>() -> Text<'a> {
     bootstrap_icon_no_padding('\u{F4CA}')
 }

--- a/liana-ui/src/theme/button.rs
+++ b/liana-ui/src/theme/button.rs
@@ -47,6 +47,7 @@ button_styles!(
     link,
     link_subtle,
     signing_devices,
+    optional_section,
 );
 
 pub fn auxiliary(theme: &Theme, status: Status) -> Style {

--- a/liana-ui/src/theme/container.rs
+++ b/liana-ui/src/theme/container.rs
@@ -72,9 +72,9 @@ pub fn border(theme: &Theme) -> Style {
     }
 }
 
-pub fn step_dot_filled(_theme: &Theme) -> Style {
+pub fn step_dot_filled(theme: &Theme) -> Style {
     Style {
-        background: Some(Background::Color(color::BUSINESS_BLUE)),
+        background: Some(Background::Color(theme.colors.general.accent)),
         border: Border {
             radius: 4.0.into(),
             ..Default::default()

--- a/liana-ui/src/theme/palette/liana.rs
+++ b/liana-ui/src/theme/palette/liana.rs
@@ -524,6 +524,27 @@ impl Palette {
                     }),
                     disabled: btn_disabled(),
                 },
+                optional_section: Button {
+                    active: ButtonPalette {
+                        background: color::TRANSPARENT,
+                        text: color::GREY_2,
+                        border: color::TRANSPARENT.into(),
+                        shadow: Default::default(),
+                    },
+                    hovered: ButtonPalette {
+                        background: color::TRANSPARENT,
+                        text: color::GREY_2,
+                        border: color::GREEN.into(),
+                        shadow: Default::default(),
+                    },
+                    pressed: Some(ButtonPalette {
+                        background: color::TRANSPARENT,
+                        text: color::GREY_2,
+                        border: color::GREEN.into(),
+                        shadow: Default::default(),
+                    }),
+                    disabled: btn_disabled(),
+                },
             },
             cards: Cards {
                 simple: ContainerPalette {

--- a/liana-ui/src/theme/palette/liana.rs
+++ b/liana-ui/src/theme/palette/liana.rs
@@ -284,18 +284,18 @@ impl Palette {
                     active: ButtonPalette {
                         background: color::GREY_6,
                         text: color::GREY_2,
-                        border: color::TRANSPARENT.into(),
+                        border: color::GREY_7.into(),
                         shadow: Default::default(),
                     },
                     hovered: ButtonPalette {
                         background: color::GREY_6,
-                        text: color::GREY_2,
+                        text: color::GREEN,
                         border: color::GREEN.into(),
                         shadow: Default::default(),
                     },
                     pressed: Some(ButtonPalette {
-                        background: color::GREY_6,
-                        text: color::GREY_2,
+                        background: BTN_SECONDARY_HOVER_BGD,
+                        text: color::GREEN,
                         border: color::GREEN.into(),
                         shadow: Default::default(),
                     }),

--- a/liana-ui/src/theme/palette/liana.rs
+++ b/liana-ui/src/theme/palette/liana.rs
@@ -56,7 +56,7 @@ impl Palette {
                 warning: color::ORANGE,
                 success: color::GREEN,
                 error: color::RED,
-                accent: color::BLUE,
+                accent: color::GREEN,
                 card_secondary: color::CARD_TEXT_SECONDARY,
                 address: color::GREY_2,
                 address_dimmed: color::GREEN,

--- a/liana-ui/src/theme/palette/liana_business.rs
+++ b/liana-ui/src/theme/palette/liana_business.rs
@@ -503,6 +503,27 @@ impl Palette {
                     pressed: None,
                     disabled: None,
                 },
+                optional_section: Button {
+                    active: ButtonPalette {
+                        background: BTN_TERTIARY_BG,
+                        text: BTN_TERTIARY_FG,
+                        border: BTN_TERTIARY_BG.into(),
+                        shadow: Default::default(),
+                    },
+                    hovered: ButtonPalette {
+                        background: BTN_TERTIARY_BG,
+                        text: BTN_TERTIARY_FG,
+                        border: BTN_TERTIARY_BG.into(),
+                        shadow: BTN_SHADOW,
+                    },
+                    pressed: Some(ButtonPalette {
+                        background: BTN_TERTIARY_PRESSED,
+                        text: color::WHITE,
+                        border: BTN_TERTIARY_PRESSED.into(),
+                        shadow: BTN_SHADOW,
+                    }),
+                    disabled: btn_disabled(),
+                },
             },
             cards: Cards {
                 simple: ContainerPalette {

--- a/liana-ui/src/theme/palette/mod.rs
+++ b/liana-ui/src/theme/palette/mod.rs
@@ -95,6 +95,7 @@ pub struct Buttons {
     pub link_subtle: Button,
     pub pick_list: Button,
     pub signing_devices: Button,
+    pub optional_section: Button,
     pub border_width: f32,
 }
 

--- a/liana-ui/src/theme/progress_bar.rs
+++ b/liana-ui/src/theme/progress_bar.rs
@@ -5,6 +5,8 @@ use iced::{
 
 use super::Theme;
 
+const PROGRESS_BAR_RADIUS: f32 = 25.0;
+
 impl Catalog for Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
@@ -23,7 +25,7 @@ pub fn primary(theme: &Theme) -> Style {
         bar: theme.colors.progress_bars.bar.into(),
         border: if let Some(color) = theme.colors.cards.simple.border {
             Border {
-                radius: 25.0.into(),
+                radius: PROGRESS_BAR_RADIUS.into(),
                 width: 1.0,
                 color,
                 ..Default::default()
@@ -32,6 +34,17 @@ pub fn primary(theme: &Theme) -> Style {
             Border {
                 ..Default::default()
             }
+        },
+    }
+}
+
+pub fn error(theme: &Theme) -> Style {
+    Style {
+        background: crate::color::TRANSPARENT.into(),
+        bar: theme.colors.text.error.into(),
+        border: Border {
+            radius: PROGRESS_BAR_RADIUS.into(),
+            ..Default::default()
         },
     }
 }

--- a/liana-ui/src/theme/radio.rs
+++ b/liana-ui/src/theme/radio.rs
@@ -15,6 +15,16 @@ impl Catalog for Theme {
 }
 
 pub fn primary(theme: &Theme, status: Status) -> Style {
+    if !theme.is_business() {
+        return Style {
+            dot_color: theme.colors.radio_buttons.dot,
+            text_color: theme.colors.radio_buttons.text.into(),
+            background: theme.colors.cards.simple.background.into(),
+            border_width: 1.0,
+            border_color: theme.colors.radio_buttons.border,
+        };
+    }
+
     let is_selected = match status {
         Status::Active { is_selected } | Status::Hovered { is_selected } => is_selected,
     };

--- a/liana-ui/src/theme/rule.rs
+++ b/liana-ui/src/theme/rule.rs
@@ -1,5 +1,7 @@
 use iced::widget::rule::{Catalog, FillMode, Style, StyleFn};
 
+use crate::color;
+
 use super::Theme;
 
 impl Catalog for Theme {
@@ -37,6 +39,15 @@ pub fn accent(theme: &Theme) -> Style {
 pub fn separator(theme: &Theme) -> Style {
     Style {
         color: theme.colors.cards.section.background,
+        radius: 2.0.into(),
+        fill_mode: FillMode::Full,
+        snap: true,
+    }
+}
+
+pub fn transparent(_theme: &Theme) -> Style {
+    Style {
+        color: color::TRANSPARENT,
         radius: 2.0.into(),
         fill_mode: FillMode::Full,
         snap: true,

--- a/liana-ui/src/theme/text.rs
+++ b/liana-ui/src/theme/text.rs
@@ -78,6 +78,12 @@ pub fn accent(theme: &Theme) -> Style {
     }
 }
 
+pub fn network_banner(theme: &Theme) -> Style {
+    Style {
+        color: theme.colors.banners.network.text,
+    }
+}
+
 pub fn card_secondary(theme: &Theme) -> Style {
     Style {
         color: Some(theme.colors.text.card_secondary),


### PR DESCRIPTION
## Button roles:

### liana gui installer: 

- [x] “Share Xpubs” tertiary througout the whole installer
- [x] new Trash icon 
- [x] “+ Add wallet” auxiliary in the launcher
- [x] “< Back to wallet list” replaced by [< Previous]
- [x] Template options (”Simple Inheritance” …) as list entry
- [x] detected hardware use device list entry
- [x] “Clear all” and “Customize” buttons in the “Set Keys” step → tertiary
- [x] “+Add recovery option” and “+ Add Safety Net” in the “Set Keys” step of the “Build your own” template → tertiary
- [x] buttons in the “Other options” section in the “Select key source” modal → device list entry
- [x] “Next” button in “Back up your mnemonic” step → primary
- [x] “Next” button in “Register descriptor” step → primary
- [x] “Send token” in the “Liana Connect” authentication step → disabled when email text field is empty, primary when active
- [x] “< Change Email” and “Resend token” in Liana Connect authentication step → tertiary
- [x] “Next” button in “Start Bitcoin full node” step → primary
- [x] “Next” button in “give your wallet an alias” step → primary
- [x] The two "Select" buttons in the "Welcome back" and the two in the "Choose backend" screens -> ~~tertiary~~ secondary
- [x] The trash icons for keys in the "Set keys" page  -> std cross button
- [x] "Edit" button for already set keys in the "Set keys" page -> tertiary
- [x] “Send token” in the “Liana Connect” authentication step should be disabled when no text is presend in the email text box (as it is when there is a wrongly formatted email)

### liana business installer:
- [x] “< Change Email” and “Resend token” in Liana Business authentication step → tertiary
liana gui / liana business wallet:
- [x] “See transaction details” in both Outgoing payment and Incoming payment pages → tertiary
- [x] “Clear” in Send panel → destructive
- [x] “< Previous” in signing step of Send process → tertiary
- [x] “Save” in signing step of Send process → secondary
- [x] “Export” and “Import” in signing step of Send process → tertiary
- [x] device selection buttons in “Select signing device to sign with:” modal → list entry
- [x] “Delete” in PSBT screen → destructive
- [x] “Verify on hardware device” and “Show QR Code” in Receive panel (newly generated address modal and already generated address list) → tertiary
- [x] Copy icon -> brand accent color on hover
- [x] “Back up encrypted descriptor” and “Register on hardware device” in “Settings>Wallet” page → tertiary

### liana gui / liana business wallet
- [x] "+ Add payment" in the Send screen -> tertiary
- [x] "Update" in “Settings>Wallet” page → tertiary
- [x] device selection buttons in “Select signing device to sign with:” modal → instead of tertiary they should be selectable buttons (as the wallet list in the launcher)

