### PR TITLE
gui: limit label inputs to 80 bytes

### DIFF
--- a/liana-gui/src/app/state/label.rs
+++ b/liana-gui/src/app/state/label.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::result_large_err)]
 
 use liana::miniscript::bitcoin;
+use liana_ui::component::label::LABEL_MAX_LENGTH;
 use std::str::FromStr;
 use std::{collections::HashMap, iter::IntoIterator, sync::Arc};
 
@@ -13,6 +14,10 @@ use crate::{
 };
 use iced::Task;
 use liana_ui::component::form;
+
+pub fn is_valid_label_value(value: &str) -> bool {
+    value.len() <= LABEL_MAX_LENGTH
+}
 
 #[derive(Default)]
 pub struct LabelsEdited(HashMap<String, form::Value<String>>);
@@ -42,7 +47,7 @@ impl LabelsEdited {
             // Edit (open the label editor) is handled by each panel before it reaches the
             // shared cache; it falls through to the catch-all below.
             Message::View(view::Message::Label(items, view::LabelMessage::Edited(value))) => {
-                let valid = value.len() <= 100;
+                let valid = is_valid_label_value(&value);
                 for item in items {
                     if let Some(label) = self.0.get_mut(&item) {
                         label.valid = valid;

--- a/liana-gui/src/app/state/receive.rs
+++ b/liana-gui/src/app/state/receive.rs
@@ -629,7 +629,7 @@ impl NewAddressModal {
         if let Step::Label { label, .. } = &mut self.step {
             // Empty is valid (no warning); the Generate button is gated on non-empty
             // by the modal itself.
-            label.valid = value.len() <= 100;
+            label.valid = super::label::is_valid_label_value(&value);
             label.value = value;
         }
     }

--- a/liana-gui/src/app/state/spend/step.rs
+++ b/liana-gui/src/app/state/spend/step.rs
@@ -620,7 +620,7 @@ impl Step for DefineSpend {
             Message::View(view::Message::CreateSpend(msg)) => {
                 match msg {
                     view::CreateSpendMessage::BatchLabelEdited(label) => {
-                        self.batch_label.valid = label.len() <= 100;
+                        self.batch_label.valid = super::super::label::is_valid_label_value(&label);
                         self.batch_label.value = label;
                     }
                     view::CreateSpendMessage::Clear => {
@@ -1081,7 +1081,7 @@ impl Recipient {
                 }
             }
             view::CreateSpendMessage::RecipientEdited(_, "label", label) => {
-                self.label.valid = label.len() <= 100;
+                self.label.valid = super::super::label::is_valid_label_value(&label);
                 self.label.value = label;
             }
             _ => {}

--- a/liana-gui/src/app/view/label.rs
+++ b/liana-gui/src/app/view/label.rs
@@ -2,7 +2,7 @@ use iced::{advanced::text::Shaping, widget::row, Alignment};
 
 use liana_ui::{
     color,
-    component::{button, form},
+    component::{button, form, label::LABEL_LENGTH_WARNING},
     icon,
     widget::*,
 };
@@ -51,7 +51,7 @@ pub fn label_editing(
     let e: Element<view::LabelMessage> = Container::new(
         row!(
             form::Form::new("Label", label, view::LabelMessage::Edited)
-                .warning("Invalid label length, cannot be superior to 100")
+                .warning(LABEL_LENGTH_WARNING)
                 .size(size)
                 .padding(10),
             if label.valid {

--- a/liana-gui/src/app/view/spend/mod.rs
+++ b/liana-gui/src/app/view/spend/mod.rs
@@ -11,7 +11,7 @@ use liana::{
 };
 
 use liana_ui::{
-    component::{amount::*, button, form, panels::spend, text::new},
+    component::{amount::*, button, form, label::LABEL_LENGTH_WARNING, panels::spend, text::new},
     icon, theme,
     widget::*,
 };
@@ -155,7 +155,7 @@ pub fn create_spend_tx<'a>(
         form::Form::new("Batch label", batch_label, |s| {
             Message::CreateSpend(CreateSpendMessage::BatchLabelEdited(s))
         })
-        .warning("Invalid label length, cannot be superior to 100")
+        .warning(LABEL_LENGTH_WARNING)
         .size(30)
         .padding(10),
     );

--- a/liana-ui/src/component/label.rs
+++ b/liana-ui/src/component/label.rs
@@ -29,6 +29,9 @@ pub fn editable_label<'a, M: 'a + Clone>(label: impl Display, msg: M) -> Element
         .into()
 }
 
+pub const LABEL_MAX_LENGTH: usize = 80;
+pub const LABEL_LENGTH_WARNING: &str = "Invalid label length, must be 80 bytes or less";
+
 pub fn edit_label_modal<'a, M: 'a + Clone, C>(
     title: impl Display,
     descr: impl Display,
@@ -44,7 +47,7 @@ where
     // An empty label is not an error (no warning shown), but it cannot be saved,
     // so the confirm button stays disabled until a label is entered.
     let confirm = (value.valid && !value.value.is_empty()).then_some(confirm);
-    let input = Form::new(descr, value, on_change);
+    let input = Form::new(descr, value, on_change).warning(LABEL_LENGTH_WARNING);
     let input = match &confirm {
         Some(c) => input.on_submit(c.clone()),
         None => input,

--- a/liana-ui/src/component/panels/spend/mod.rs
+++ b/liana-ui/src/component/panels/spend/mod.rs
@@ -13,7 +13,9 @@ use crate::{
         amount::{self, amount_with_fiat, AmountSize, Currency, DisplayAmount, FiatAmount},
         button, card,
         checkbox::{labelled_checkbox, labelled_radio},
-        form, pill, scrollable, section,
+        form,
+        label::LABEL_LENGTH_WARNING,
+        pill, scrollable, section,
         text::{caption, new, P1_SIZE},
         tooltip,
     },
@@ -80,7 +82,7 @@ pub fn recipient_card<'a, M: Clone + 'static>(
 
     let description_form: Element<'a, M> = form::Form::new("Payment label", label, on_label_edit)
         .label("Description")
-        .warning("Label length is too long (> 100 char)")
+        .warning(LABEL_LENGTH_WARNING)
         .size(P1_SIZE)
         .padding(10)
         .into();


### PR DESCRIPTION
Change the label length limit from 100 to 80 to match liana backend & enforce it in the gui from a single source of truth