### PR TITLE
liana-ui: use badge tiles for modal entry icons

### DIFF
--- a/liana-gui/src/installer/decrypt.rs
+++ b/liana-gui/src/installer/decrypt.rs
@@ -26,7 +26,6 @@ use liana::{
     },
 };
 use liana_ui::{
-    color,
     component::{
         card,
         form::Value,
@@ -44,7 +43,7 @@ use crate::{
     export::ImportExportType,
     hw::{HardwareWallet, HardwareWallets},
     installer,
-    utils::{default_derivation_path, example_xpub},
+    utils::default_derivation_path,
 };
 
 #[allow(unused, clippy::enum_variant_names)]
@@ -624,29 +623,28 @@ fn optional_content(state: &DecryptModal) -> Container<'static, installer::Messa
         ))
         .spacing(5);
 
-    let import = modal::button_entry(
-        Some(icon::import_icon()),
-        "Upload extended public key file",
-        None,
+    let import = modal::import_xpub_entry(
         state.import_xpub_error.clone(),
         Some(|| Decrypt::SelectImportXpub.into()),
     );
 
-    let xpub = modal::collapsible_input_button(
+    let xpub = modal::paste_xpub_entry(
         state.focus == Focus::Xpub,
-        Some(icon::paste_icon()),
-        "Paste an extended public key".to_string(),
-        example_xpub(state.network),
+        state.network,
         &state.xpub,
         Some(|s| Decrypt::Xpub(s).into()),
         Some(|| Decrypt::PasteXpub.into()),
         || Decrypt::SelectXpub.into(),
     );
 
-    let mnemonic = mnemonic_input_button(
+    let mnemonic = modal::enter_mnemonic_entry(
         state.focus == Focus::Mnemonic,
         state.mnemonic_ack,
         &state.mnemonic,
+        |ack| Decrypt::MnemonicAck(ack).into(),
+        |s| Decrypt::Mnemonic(s).into(),
+        || Decrypt::PasteMnemonic.into(),
+        || Decrypt::SelectMnemonic.into(),
     );
 
     let col = column![
@@ -661,26 +659,6 @@ fn optional_content(state: &DecryptModal) -> Container<'static, installer::Messa
     ];
 
     Container::new(col)
-}
-
-pub fn mnemonic_input_button<'a>(
-    collapsed: bool,
-    ack: bool,
-    input_value: &Value<String>,
-) -> Element<'a, installer::Message> {
-    modal::acked_input_button(
-        collapsed,
-        ack,
-        || icon::edit_icon().color(color::WHITE),
-        "UNSAFE: Enter mnemonic of one of the keys",
-        " This option is not secure. I understand that entering a mnemonic on a computer may result in theft of my funds.",
-        "code code code code code code code code code code code brave",
-        input_value,
-        |ack| Decrypt::MnemonicAck(ack).into(),
-        |s| Decrypt::Mnemonic(s).into(),
-        || Decrypt::PasteMnemonic.into(),
-        || Decrypt::SelectMnemonic.into(),
-    )
 }
 
 /// Return the modal view for an export task

--- a/liana-gui/src/installer/step/descriptor/editor/key.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/key.rs
@@ -1,4 +1,3 @@
-use crate::utils::example_xpub;
 use std::{
     collections::HashMap,
     str::FromStr,
@@ -24,12 +23,12 @@ use liana_ui::{
     color,
     component::{
         button, card, form,
-        modal::{self, collapsible_input_button, modal_no_devices_placeholder},
+        modal::{self, modal_no_devices_placeholder, KeySourceKind},
         pick_list,
         text::{p1_bold, p1_regular},
         tooltip,
     },
-    icon, theme,
+    theme,
     widget::{ColumnExt, Container, Element, RowExt, SpaceExt},
 };
 
@@ -1029,17 +1028,36 @@ impl SelectKeySource {
         self.actual_path.token_kind.contains(&KeyKind::Cosigner)
     }
     fn view_other_options(&self) -> Element<'_, Message> {
-        let safety_net_token = self
-            .safety_net_enabled()
-            .then_some(self.widget_paste_safety_net_token());
+        let safety_net_token = self.safety_net_enabled().then(|| {
+            modal::safety_net_token_entry(
+                self.focus == Focus::EnterSafetyNetToken,
+                &self.form_safety_net_token,
+                Some(|token| Self::route(SelectKeySourceMessage::Token(token))),
+                Some(|| Self::route(SelectKeySourceMessage::PasteToken)),
+                || Self::route(SelectKeySourceMessage::SelectEnterSafetyNetToken),
+            )
+        });
 
-        let cosigner_token = self
-            .cosigner_enabled()
-            .then_some(self.widget_paste_cosigner_token());
+        let cosigner_token = self.cosigner_enabled().then(|| {
+            modal::cosigner_token_entry(
+                self.focus == Focus::EnterCosignerToken,
+                &self.form_cosigner_token,
+                Some(|token| Self::route(SelectKeySourceMessage::Token(token))),
+                Some(|| Self::route(SelectKeySourceMessage::PasteToken)),
+                || Self::route(SelectKeySourceMessage::SelectEnterCosignerToken),
+            )
+        });
 
-        let paste_xpub = safety_net_token
-            .is_none()
-            .then_some(self.widget_paste_xpub());
+        let paste_xpub = safety_net_token.is_none().then(|| {
+            modal::paste_xpub_entry(
+                self.focus == Focus::EnterXpub,
+                self.network,
+                &self.form_xpub,
+                Some(|xpub| Self::route(SelectKeySourceMessage::Xpub(xpub))),
+                Some(|| Self::route(SelectKeySourceMessage::PasteXpub)),
+                || Self::route(SelectKeySourceMessage::SelectEnterXpub),
+            )
+        });
 
         let collapsed = self.options_collapsed || safety_net_token.is_some();
 
@@ -1052,9 +1070,18 @@ impl SelectKeySource {
 
         let hot_signer_fg = self.hot_signer.lock().expect("poisoned").fingerprint();
         let hot_signer = (!self.keys.contains_key(&hot_signer_fg) && safety_net_token.is_none())
-            .then_some(self.widget_generate_hot_key());
+            .then(|| {
+                modal::generate_hot_key_entry(Some(|| {
+                    Self::route(SelectKeySourceMessage::SelectGenerateHotKey)
+                }))
+            });
 
-        let load_key = safety_net_token.is_none().then_some(self.widget_load_key());
+        let load_key = safety_net_token.is_none().then(|| {
+            modal::import_xpub_entry(
+                self.import_xpub_error.clone(),
+                Some(|| Self::route(SelectKeySourceMessage::SelectLoadXpub)),
+            )
+        });
 
         let mut col = Column::new()
             .push(option_section)
@@ -1123,7 +1150,7 @@ impl SelectKeySource {
         }
         let fingerprint = fg.map(|fg| format!("#{fg}"));
         modal::key_entry(
-            Some(icon::usb_drive_icon()),
+            KeySourceKind::Device,
             alias,
             fingerprint,
             None,
@@ -1142,11 +1169,11 @@ impl SelectKeySource {
         ),
     ) -> Element<'_, Message> {
         let (source, alias, fg, available) = key;
-        let icon = match source {
-            KeySource::Device(..) => icon::usb_drive_icon(),
-            KeySource::HotSigner => icon::round_key_icon().color(color::RED),
-            KeySource::Manual => icon::round_key_icon(),
-            KeySource::Token(..) => icon::hdd_icon(),
+        let kind = match source {
+            KeySource::Device(..) => KeySourceKind::Device,
+            KeySource::HotSigner => KeySourceKind::HotKey,
+            KeySource::Manual => KeySourceKind::Xpub,
+            KeySource::Token(..) => KeySourceKind::Token,
         };
         let message = if let KeySource::Token(kind, _) = source {
             if !self.actual_path.token_kind.contains(&kind) {
@@ -1161,69 +1188,7 @@ impl SelectKeySource {
         let on_press = message
             .is_none()
             .then_some(Self::route(SelectKeySourceMessage::SelectKey(fg)));
-        modal::key_entry(
-            Some(icon),
-            alias,
-            Some(fg_str),
-            None,
-            None,
-            message,
-            on_press,
-        )
-    }
-    fn widget_load_key(&self) -> Element<'_, Message> {
-        modal::button_entry(
-            Some(icon::import_icon()),
-            "Import extended public key file",
-            None,
-            self.import_xpub_error.clone(),
-            Some(|| Self::route(SelectKeySourceMessage::SelectLoadXpub)),
-        )
-    }
-    fn widget_generate_hot_key(&self) -> Element<'_, Message> {
-        modal::button_entry(
-            Some(icon::round_key_icon().color(color::RED)),
-            "Generate hot key stored on this computer",
-            Some("We recommend to use this option only for test purposes"),
-            None,
-            Some(|| Self::route(SelectKeySourceMessage::SelectGenerateHotKey)),
-        )
-    }
-    fn widget_paste_xpub(&self) -> Element<'_, Message> {
-        collapsible_input_button(
-            self.focus == Focus::EnterXpub,
-            Some(icon::paste_icon()),
-            "Paste an extended public key".to_string(),
-            example_xpub(self.network),
-            &self.form_xpub,
-            Some(|xpub| Self::route(SelectKeySourceMessage::Xpub(xpub))),
-            Some(|| Self::route(SelectKeySourceMessage::PasteXpub)),
-            || Self::route(SelectKeySourceMessage::SelectEnterXpub),
-        )
-    }
-    fn widget_paste_safety_net_token(&self) -> Element<'_, Message> {
-        collapsible_input_button(
-            self.focus == Focus::EnterSafetyNetToken,
-            Some(icon::enter_box_icon()),
-            "Enter a Safety Net token".to_string(),
-            "aaaa-bbbb-cccc".to_string(),
-            &self.form_safety_net_token,
-            Some(|token| Self::route(SelectKeySourceMessage::Token(token))),
-            Some(|| Self::route(SelectKeySourceMessage::PasteToken)),
-            || Self::route(SelectKeySourceMessage::SelectEnterSafetyNetToken),
-        )
-    }
-    fn widget_paste_cosigner_token(&self) -> Element<'_, Message> {
-        collapsible_input_button(
-            self.focus == Focus::EnterCosignerToken,
-            Some(icon::enter_box_icon()),
-            "Enter a Cosigner token".to_string(),
-            "aaaa-bbbb-cccc".to_string(),
-            &self.form_cosigner_token,
-            Some(|token| Self::route(SelectKeySourceMessage::Token(token))),
-            Some(|| Self::route(SelectKeySourceMessage::PasteToken)),
-            || Self::route(SelectKeySourceMessage::SelectEnterCosignerToken),
-        )
+        modal::key_entry(kind, alias, Some(fg_str), None, None, message, on_press)
     }
 }
 

--- a/liana-gui/src/utils/mod.rs
+++ b/liana-gui/src/utils/mod.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH},
 };
 
-use liana::miniscript::bitcoin::{self, bip32::DerivationPath, Network};
+use liana::miniscript::bitcoin::{bip32::DerivationPath, Network};
 
 pub mod serde;
 pub mod subscription;
@@ -22,12 +22,6 @@ pub fn now() -> Duration {
 /// Faliible version of [`now`].
 pub fn now_fallible() -> Result<Duration, SystemTimeError> {
     SystemTime::now().duration_since(UNIX_EPOCH)
-}
-
-pub fn example_xpub(network: Network) -> String {
-    format!("[aabbccdd/42'/0']{}pub6DAkq8LWw91WGgUGnkR5Sbzjev5JCsXaTVZQ9MwsPV4BkNFKygtJ8GHodfDVx1udR723nT7JASqGPpKvz7zQ25pUTW6zVEBdiWoaC4aUqik",
-        if network == bitcoin::Network::Bitcoin { "x" } else { "t" }
-    )
 }
 
 pub fn default_derivation_path(network: Network) -> DerivationPath {

--- a/liana-ui/src/component/badge.rs
+++ b/liana-ui/src/component/badge.rs
@@ -22,6 +22,7 @@ pub enum Tile {
     KeyInternal,
     KeyExternal,
     KeyService,
+    KeyHot,
     Device,
     Account,
     DeviceMuted,
@@ -30,6 +31,8 @@ pub enum Tile {
     Restricted,
     Import,
     Paste,
+    EnterToken,
+    Mnemonic,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -182,6 +185,7 @@ tile_specs! {
     (KeyInternal, round_key_icon, Neutral, DEFAULT),
     (KeyExternal, scale_icon, Neutral, DEFAULT),
     (KeyService, shield_icon, Neutral, DEFAULT),
+    (KeyHot, round_key_icon, Danger, DEFAULT),
     (Device, usb_icon, Neutral, DEFAULT),
     (Account, person_icon, Neutral, DEFAULT),
     (DeviceMuted, usb_icon, Muted, DEFAULT),
@@ -190,6 +194,8 @@ tile_specs! {
     (Restricted, lock_icon, Muted, XL),
     (Import, import_icon, Neutral, DEFAULT),
     (Paste, paste_icon, Neutral, DEFAULT),
+    (EnterToken, enter_box_icon, Neutral, DEFAULT),
+    (Mnemonic, edit_icon, Neutral, DEFAULT),
 }
 
 fn tile_tone(theme: &theme::Theme, tone: TileStyle) -> theme::palette::Tile {

--- a/liana-ui/src/component/list.rs
+++ b/liana-ui/src/component/list.rs
@@ -25,6 +25,8 @@ use crate::{
 use super::text::truncate;
 
 const COLLAPSIBLE_ENTRY_CONTENT_BOTTOM_PADDING: u16 = 10;
+/// Gap between the leading tile and the body of an entry row.
+pub const ENTRY_H_SPACING: HSpacing = HSpacing::L;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum EntryAccent {
@@ -164,7 +166,7 @@ pub fn list_entry_row<'a, M: Clone + 'a>(
     let body = Container::new(body).width(Length::Fill);
     let trailing = trailing.map(|trailing| Container::new(trailing).align_y(Alignment::Center));
     let content = row![tile, body, trailing]
-        .spacing(16)
+        .spacing(ENTRY_H_SPACING)
         .align_y(Alignment::Center)
         .width(Length::Fill);
 
@@ -197,7 +199,7 @@ pub fn list_entry_row_static<'a, M: Clone + 'a>(
     let body = Container::new(body).width(Length::Fill);
     let trailing = trailing.map(|trailing| Container::new(trailing).align_y(Alignment::Center));
     let content = row![tile, body, trailing]
-        .spacing(16)
+        .spacing(ENTRY_H_SPACING)
         .align_y(Alignment::Center)
         .width(Length::Fill);
 
@@ -274,7 +276,7 @@ fn collapsible_entry_header<'a, M: Clone + 'a>(
         badge::tile_accent(tile),
         Container::new(item_body(title, subtitle)).width(Length::Fill),
     ]
-    .spacing(16)
+    .spacing(ENTRY_H_SPACING)
     .align_y(Alignment::Center)
     .width(Length::Fill);
 
@@ -406,7 +408,7 @@ pub fn list_entry_chevron<'a, M: Clone + 'a>(
         .align_y(Alignment::Center);
     let body = Container::new(body).width(Length::Fill);
     let content = row![tile, body, trailing]
-        .spacing(16)
+        .spacing(ENTRY_H_SPACING)
         .align_y(Alignment::Center)
         .width(Length::Fill);
 
@@ -539,7 +541,7 @@ fn list_entry_row_with_enabled<'a, M: Clone + 'a>(
     let body = Container::new(body).width(Length::Fill);
     let trailing = trailing.map(|trailing| Container::new(trailing).align_y(Alignment::Center));
     let content = row![tile, body, trailing]
-        .spacing(16)
+        .spacing(ENTRY_H_SPACING)
         .align_y(Alignment::Center)
         .width(Length::Fill);
 

--- a/liana-ui/src/component/modal/mod.rs
+++ b/liana-ui/src/component/modal/mod.rs
@@ -11,11 +11,15 @@ use iced::{
 
 use iced::widget::Container;
 
-use bitcoin::bip32::{ChildNumber, Fingerprint};
+use bitcoin::{
+    bip32::{ChildNumber, Fingerprint},
+    Network,
+};
 
 use crate::{
     color,
     component::{
+        badge::{self, Tile},
         button,
         form::{self, Value},
         list::{self, DeviceStatus},
@@ -29,7 +33,7 @@ use crate::{
 
 use crate::{
     spacing::{HSpacing, VSpacing},
-    widget::{Button, CheckBox, Column, Element, PickList, SpaceExt, Text},
+    widget::{Button, CheckBox, Column, Element, PickList, SpaceExt},
 };
 
 pub const BTN_W: u32 = 500;
@@ -37,6 +41,8 @@ pub const V_SPACING: VSpacing = VSpacing::S;
 pub const H_SPACING: HSpacing = HSpacing::S;
 const MODAL_PADDING: f32 = 20.0;
 const MODAL_SPACING: VSpacing = VSpacing::M;
+const TOKEN_PLACEHOLDER: &str = "aaaa-bbbb-cccc";
+const MNEMONIC_PLACEHOLDER: &str = "code code code code code code code code code code code brave";
 
 /// Modal width presets.
 #[derive(Debug, Clone, Copy)]
@@ -186,9 +192,9 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn collapsible_input_button<'a, Message, Paste, Collapse, Input>(
+fn collapsible_input_button<'a, Message, Paste, Collapse, Input>(
     collapsed: bool,
-    icon: Option<Text<'static>>,
+    tile: Tile,
     label: String,
     input_placeholder: String,
     input_value: &Value<String>,
@@ -211,24 +217,23 @@ where
     let paste = paste_message.map(|m| button::btn_paste_icon(Some(m())));
 
     if collapsed {
-        let icon = icon.map(|i| i.style(theme::text::primary));
         let line = row![form, paste].spacing(H_SPACING);
         let col = column![
             row![
                 caption(label).style(theme::text::primary),
-                Space::with_width(Length::Fill)
+                Space::fill_width()
             ],
             line
         ]
         .width(Length::Fill);
-        let content = row![icon, col]
+        let content = row![badge::tile(tile), col]
             .align_y(Vertical::Center)
-            .spacing(H_SPACING)
+            .spacing(list::ENTRY_H_SPACING)
             .width(Length::Fill);
         button::list_entry_with_state(content, None, button::EntryWidth::Fill, true, false, None)
     } else {
-        let content = row![icon, caption(label)]
-            .spacing(H_SPACING)
+        let content = row![badge::tile(tile), caption(label)]
+            .spacing(list::ENTRY_H_SPACING)
             .align_y(Vertical::Center)
             .width(Length::Fill);
         button::list_entry(
@@ -244,10 +249,10 @@ where
 /// disclaimer checkbox: the expanded button shows the checkbox first
 /// (`!ack`), then swaps to the form once the user toggles it on (`ack`).
 #[allow(clippy::too_many_arguments)]
-pub fn acked_input_button<'a, Message, Ack, Input, Paste, Collapse, I>(
+fn acked_input_button<'a, Message, Ack, Input, Paste, Collapse>(
     collapsed: bool,
     ack: bool,
-    icon: I,
+    tile: Tile,
     label: &'a str,
     disclaimer: &'a str,
     input_placeholder: &'a str,
@@ -258,7 +263,6 @@ pub fn acked_input_button<'a, Message, Ack, Input, Paste, Collapse, I>(
     collapse_message: Collapse,
 ) -> Element<'a, Message>
 where
-    I: Fn() -> Text<'static>,
     Ack: 'static + Fn(bool) -> Message,
     Input: 'static + Fn(String) -> Message,
     Paste: 'static + Fn() -> Message,
@@ -282,18 +286,38 @@ where
         } else {
             Container::new(check_box)
         };
-        row![icon(), content]
+        row![badge::tile(tile), content]
             .align_y(Vertical::Center)
-            .spacing(H_SPACING)
+            .spacing(list::ENTRY_H_SPACING)
     };
-    let closed = row![icon(), caption(label)]
-        .spacing(H_SPACING)
+    let closed = row![badge::tile(tile), caption(label)]
+        .spacing(list::ENTRY_H_SPACING)
         .align_y(Vertical::Center);
     collapsible_button(collapsed, closed, expanded, collapse_message)
 }
 
+/// Where the key behind a select-key-source row comes from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeySourceKind {
+    Device,
+    HotKey,
+    Xpub,
+    Token,
+}
+
+impl From<KeySourceKind> for Tile {
+    fn from(kind: KeySourceKind) -> Self {
+        match kind {
+            KeySourceKind::Device => Tile::Device,
+            KeySourceKind::HotKey => Tile::KeyHot,
+            KeySourceKind::Xpub => Tile::KeyExternal,
+            KeySourceKind::Token => Tile::KeyService,
+        }
+    }
+}
+
 pub fn key_entry<'a, M: 'a + Clone>(
-    icon: Option<Text<'a>>,
+    kind: KeySourceKind,
     name: String,
     fingerprint: Option<String>,
     tooltip_str: Option<&'a str>,
@@ -315,15 +339,15 @@ pub fn key_entry<'a, M: 'a + Clone>(
     .align_x(Horizontal::Left)
     .width(200);
     let row = row![
-        icon,
+        badge::tile(kind.into()),
         designation,
         message,
         error,
-        Space::with_width(Length::Fill),
+        Space::fill_width(),
         tt
     ]
     .align_y(Vertical::Center)
-    .spacing(H_SPACING)
+    .spacing(list::ENTRY_H_SPACING)
     .width(Length::Fill);
     button::list_entry(
         row,
@@ -352,11 +376,12 @@ impl Display for Account {
     }
 }
 
-fn device_icon(is_device: bool) -> Text<'static> {
+/// Physical device rows get the device tile, the hot signer row gets a key tile.
+fn device_tile(is_device: bool) -> Tile {
     if is_device {
-        icon::usb_drive_icon()
+        Tile::Device
     } else {
-        icon::round_key_icon()
+        Tile::KeyInternal
     }
 }
 
@@ -396,16 +421,16 @@ where
     K: Display + 'a,
     A: Display + 'a,
 {
-    let icon = device_icon(kind.is_some());
+    let tile = device_tile(kind.is_some());
     let designation = device_designation(kind, alias, fingerprint);
     let row = row![
-        icon,
+        badge::tile(tile),
         designation,
         Space::fill_width(),
         Option::<Element<'a, M>>::from(status)
     ]
     .align_y(Vertical::Center)
-    .spacing(H_SPACING)
+    .spacing(list::ENTRY_H_SPACING)
     .width(Length::Fill);
     button::list_entry(row, None, button::EntryWidth::Fill, on_press)
 }
@@ -446,11 +471,11 @@ where
     let picker = account_pick_list(fingerprint, selected, |a: Account| {
         (a.fingerprint, a.index).into()
     });
-    let icon = device_icon(kind.is_some());
+    let tile = device_tile(kind.is_some());
     let designation = device_designation(kind, alias, Some(format!("#{fingerprint}")));
-    let row = row![icon, designation, Space::fill_width(), picker]
+    let row = row![badge::tile(tile), designation, Space::fill_width(), picker]
         .align_y(Vertical::Center)
-        .spacing(H_SPACING)
+        .spacing(list::ENTRY_H_SPACING)
         .width(Length::Fill);
     button::list_entry(row, None, button::EntryWidth::Fill, on_press)
 }
@@ -480,8 +505,8 @@ where
     list::entry_register(entry_status, body, None, msg.is_some(), msg)
 }
 
-pub fn button_entry<'a, Message, M>(
-    icon: Option<Text<'static>>,
+fn button_entry<'a, Message, M>(
+    tile: Tile,
     label: &'a str,
     tooltip_str: Option<&'static str>,
     error: Option<String>,
@@ -491,23 +516,191 @@ where
     M: 'static + Fn() -> Message,
     Message: Clone + 'static,
 {
-    let error = error.map(|e| {
-        row![
-            caption(e).color(color::ORANGE),
-            Space::with_width(Length::Fill)
-        ]
-    });
+    let error = error.map(|e| row![caption(e).color(color::ORANGE), Space::fill_width()]);
 
     let tt = tooltip_str.map(|s| tooltip(s));
 
-    let row = row![icon, caption(label), Space::fill_width(), tt]
-        .spacing(H_SPACING)
+    let row = row![badge::tile(tile), caption(label), Space::fill_width(), tt]
+        .spacing(list::ENTRY_H_SPACING)
         .align_y(Vertical::Center);
 
     let col = column![row, error].width(Length::Fill);
 
     let msg = on_press.map(|f| f());
     button::list_entry(col, None, button::EntryWidth::Fill, msg)
+}
+
+/// Entry loading an extended public key from a file.
+pub fn import_xpub_entry<'a, Message, M>(
+    error: Option<String>,
+    on_press: Option<M>,
+) -> Element<'a, Message>
+where
+    M: 'static + Fn() -> Message,
+    Message: Clone + 'static,
+{
+    button_entry(
+        Tile::Import,
+        "Import extended public key file",
+        None,
+        error,
+        on_press,
+    )
+}
+
+/// Entry generating a key stored on this computer.
+pub fn generate_hot_key_entry<'a, Message, M>(on_press: Option<M>) -> Element<'a, Message>
+where
+    M: 'static + Fn() -> Message,
+    Message: Clone + 'static,
+{
+    button_entry(
+        Tile::KeyHot,
+        "Generate hot key stored on this computer",
+        Some("We recommend to use this option only for test purposes"),
+        None,
+        on_press,
+    )
+}
+
+/// Collapsible entry pasting an extended public key.
+pub fn paste_xpub_entry<'a, Message, Paste, Collapse, Input>(
+    collapsed: bool,
+    network: Network,
+    input_value: &Value<String>,
+    input_message: Option<Input>,
+    paste_message: Option<Paste>,
+    collapse_message: Collapse,
+) -> Element<'a, Message>
+where
+    Input: 'static + Fn(String) -> Message,
+    Paste: 'static + Fn() -> Message,
+    Collapse: 'static + Fn() -> Message,
+    Message: Clone + 'static,
+{
+    collapsible_input_button(
+        collapsed,
+        Tile::Paste,
+        "Paste an extended public key".to_string(),
+        example_xpub(network),
+        input_value,
+        input_message,
+        paste_message,
+        collapse_message,
+    )
+}
+
+/// Collapsible entry entering a Safety Net token.
+pub fn safety_net_token_entry<'a, Message, Paste, Collapse, Input>(
+    collapsed: bool,
+    input_value: &Value<String>,
+    input_message: Option<Input>,
+    paste_message: Option<Paste>,
+    collapse_message: Collapse,
+) -> Element<'a, Message>
+where
+    Input: 'static + Fn(String) -> Message,
+    Paste: 'static + Fn() -> Message,
+    Collapse: 'static + Fn() -> Message,
+    Message: Clone + 'static,
+{
+    token_entry(
+        "Enter a Safety Net token",
+        collapsed,
+        input_value,
+        input_message,
+        paste_message,
+        collapse_message,
+    )
+}
+
+/// Collapsible entry entering a Cosigner token.
+pub fn cosigner_token_entry<'a, Message, Paste, Collapse, Input>(
+    collapsed: bool,
+    input_value: &Value<String>,
+    input_message: Option<Input>,
+    paste_message: Option<Paste>,
+    collapse_message: Collapse,
+) -> Element<'a, Message>
+where
+    Input: 'static + Fn(String) -> Message,
+    Paste: 'static + Fn() -> Message,
+    Collapse: 'static + Fn() -> Message,
+    Message: Clone + 'static,
+{
+    token_entry(
+        "Enter a Cosigner token",
+        collapsed,
+        input_value,
+        input_message,
+        paste_message,
+        collapse_message,
+    )
+}
+
+fn token_entry<'a, Message, Paste, Collapse, Input>(
+    label: &'static str,
+    collapsed: bool,
+    input_value: &Value<String>,
+    input_message: Option<Input>,
+    paste_message: Option<Paste>,
+    collapse_message: Collapse,
+) -> Element<'a, Message>
+where
+    Input: 'static + Fn(String) -> Message,
+    Paste: 'static + Fn() -> Message,
+    Collapse: 'static + Fn() -> Message,
+    Message: Clone + 'static,
+{
+    collapsible_input_button(
+        collapsed,
+        Tile::EnterToken,
+        label.to_string(),
+        TOKEN_PLACEHOLDER.to_string(),
+        input_value,
+        input_message,
+        paste_message,
+        collapse_message,
+    )
+}
+
+/// Collapsible entry typing a mnemonic, gated behind a disclaimer checkbox.
+#[allow(clippy::too_many_arguments)]
+pub fn enter_mnemonic_entry<'a, Message, Ack, Input, Paste, Collapse>(
+    collapsed: bool,
+    ack: bool,
+    input_value: &Value<String>,
+    ack_message: Ack,
+    input_message: Input,
+    paste_message: Paste,
+    collapse_message: Collapse,
+) -> Element<'a, Message>
+where
+    Ack: 'static + Fn(bool) -> Message,
+    Input: 'static + Fn(String) -> Message,
+    Paste: 'static + Fn() -> Message,
+    Collapse: 'static + Fn() -> Message,
+    Message: Clone + 'static,
+{
+    acked_input_button(
+        collapsed,
+        ack,
+        Tile::Mnemonic,
+        "UNSAFE: Enter mnemonic of one of the keys",
+        " This option is not secure. I understand that entering a mnemonic on a computer may result in theft of my funds.",
+        MNEMONIC_PLACEHOLDER,
+        input_value,
+        ack_message,
+        input_message,
+        paste_message,
+        collapse_message,
+    )
+}
+
+fn example_xpub(network: Network) -> String {
+    format!("[aabbccdd/42'/0']{}pub6DAkq8LWw91WGgUGnkR5Sbzjev5JCsXaTVZQ9MwsPV4BkNFKygtJ8GHodfDVx1udR723nT7JASqGPpKvz7zQ25pUTW6zVEBdiWoaC4aUqik",
+        if network == Network::Bitcoin { "x" } else { "t" }
+    )
 }
 
 pub fn modal_no_devices_placeholder<'a, M: 'a>() -> Element<'a, M> {

--- a/liana-ui/src/icon.rs
+++ b/liana-ui/src/icon.rs
@@ -205,7 +205,7 @@ pub fn hdd_icon() -> Text<'static> {
     bootstrap_icon('\u{F412}')
 }
 
-pub fn enter_box_icon() -> Text<'static> {
+pub fn enter_box_icon<'a>() -> Text<'a> {
     bootstrap_icon('\u{F1BE}')
 }
 


### PR DESCRIPTION
This PR fixes disrepencies on how key entries icon where rendered, now all entries are consistants and render the icon in a tile.

<img width="731" height="333" alt="image" src="https://github.com/user-attachments/assets/106499c1-3d8d-4e9c-b2ae-67c05f5f2f56" />
