### PR TITLE
bump versions to v15 and v1 for business

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,43 @@
 
 # Liana daemon and GUI release notes
 
+## 15.0
+
+This release delivers a major UI rework of liana-gui and the installer, a bump to iced 0.14, and
+several fixes.
+
+### Features
+
+#### Liana GUI
+
+- UI rework: reworked home, receive, and spend panels, the installer flow, the tab menu, and the
+  sidebar responsive mechanism, with new signing-device modals, chunked address display, badges,
+  cards, and amount components.
+- Rework the receive flow with label-first address generation.
+- Add a loading spinner.
+- Add copy-button feedback across the app.
+- Enable the cosigner token in the installer.
+- Limit label inputs to 80 bytes.
+- Link Liana Connect credentials by JWT user_id.
+
+#### Dependencies
+
+- Bump iced to 0.14.
+- Bump Rust to 1.88.
+
+### Fixes
+
+#### Liana GUI
+
+- Fix signing device entry.
+- Fix Ledger devices always being reported as locked.
+- Hide Liana Business wallets in the liana-gui installer.
+- Leave the new business path timelock empty.
+- Fix business key type tooltip.
+- Reword the spend warning shown when a label is missing.
+- Make launcher wallet entries consistent in height.
+- Fix reproducible Windows build by stripping the COFF symbol table.
+
 ## 14.0
 
 This release includes a UI rework for liana-gui, several UX improvements, and bug fixes across liana,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "business-installer"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "async-hwi",
  "chrono",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "liana"
-version = "14.0.0"
+version = "15.0.0"
 dependencies = [
  "bdk_coin_select",
  "bip39",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "liana-business"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "async-hwi",
  "backtrace",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "liana-connect"
-version = "0.1.0"
+version = "15.0.0"
 dependencies = [
  "async-trait",
  "bip329",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "liana-gui"
-version = "14.0.0"
+version = "15.0.0"
 dependencies = [
  "async-fd-lock",
  "async-hwi",
@@ -3265,7 +3265,7 @@ dependencies = [
 
 [[package]]
 name = "liana-ui"
-version = "0.4.0"
+version = "15.0.0"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "lianad"
-version = "14.0.0"
+version = "15.0.0"
 dependencies = [
  "backtrace",
  "bdk_electrum",

--- a/liana-business/CHANGELOG.md
+++ b/liana-business/CHANGELOG.md
@@ -1,0 +1,22 @@
+
+# Liana Business release notes
+
+## 1.0
+
+First release of Liana Business and its installer.
+
+### Features
+
+- Installer: organizations and wallets management.
+- Spending-policy template builder.
+- Key and signer management with cosigner token support.
+- Business settings integration.
+- Last-edit tracking on templates.
+- Wizardsardine fiat price source.
+- Add the liana-business version to the User-Agent header.
+
+### Fixes
+
+- Fix missing "Approve template" action.
+- Fix button size in the business installer.
+- Reword "Signer" to "Signer email" in the add key modal.

--- a/liana-business/Cargo.toml
+++ b/liana-business/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liana-business"
-version = "0.2.0"
+version = "1.0.0"
 edition = "2021"
 
 [package.metadata.winresource]

--- a/liana-business/business-installer/Cargo.toml
+++ b/liana-business/business-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "business-installer"
-version = "0.2.0"
+version = "1.0.0"
 edition = "2021"
 
 [lib]

--- a/liana-connect/Cargo.toml
+++ b/liana-connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liana-connect"
-version = "0.1.0"
+version = "15.0.0"
 authors = ["Pyth <pythcoiner@proton.me>"]
 edition = "2021"
 repository = "https://github.com/wizardsardine/liana"

--- a/liana-gui/Cargo.toml
+++ b/liana-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liana-gui"
-version = "14.0.0"
+version = "15.0.0"
 readme = "README.md"
 description = "Liana GUI"
 repository = "https://github.com/wizardsardine/liana"

--- a/liana-ui/Cargo.toml
+++ b/liana-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liana-ui"
-version = "0.4.0"
+version = "15.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/liana/Cargo.toml
+++ b/liana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liana"
-version = "14.0.0"
+version = "15.0.0"
 authors = ["Antoine Poinsot <darosior@protonmail.com>"]
 edition = "2018"
 repository = "https://github.com/wizardsardine/liana"

--- a/lianad/Cargo.toml
+++ b/lianad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lianad"
-version = "14.0.0"
+version = "15.0.0"
 authors = ["Antoine Poinsot <darosior@protonmail.com>"]
 edition = "2018"
 repository = "https://github.com/wizardsardine/liana"

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -26,7 +26,7 @@ MAX_DERIV = 2**31 - 1
 def test_getinfo(lianad):
     res = lianad.rpc.getinfo()
     assert "timestamp" in res.keys()
-    assert res["version"] == "14.0-dev"
+    assert res["version"] == "15.0-dev"
     assert res["network"] == "regtest"
     wait_for(lambda: lianad.rpc.getinfo()["block_height"] == 101)
     res = lianad.rpc.getinfo()


### PR DESCRIPTION
Bumping all major versions to match their product version. Easier for us to remember.