### PR TITLE
business-installer: Add key binding to select signet network 

### DIFF
--- a/liana-business/FLOW.md
+++ b/liana-business/FLOW.md
@@ -222,7 +222,7 @@ State::update() (state/update.rs)
 |                     | LoginResendToken, LoginSendAuthCode, Logout              |
 +---------------------+----------------------------------------------------------+
 | Account Select      | AccountSelectConnect, AccountSelectDelete,               |
-|                     | AccountSelectNewEmail                                    |
+|                     | AccountSelectNewEmail, AccountSelectSwitchSignet        |
 +---------------------+----------------------------------------------------------+
 | Org Management      | OrgSelected, OrgWalletSelected, OrgCreateNewWallet,      |
 |                     | OrgSelectUpdateSearchFilter                              |

--- a/liana-business/business-installer/src/installer.rs
+++ b/liana-business/business-installer/src/installer.rs
@@ -3,7 +3,11 @@ use crate::state::{
     Msg as Message, SharedWaker, State,
 };
 use crossbeam::channel::{self};
-use iced::Task;
+use iced::{
+    event,
+    keyboard::{self, key::Named},
+    Subscription, Task,
+};
 use liana::miniscript::bitcoin::{self};
 use liana_gui::{
     dir::LianaDirectory,
@@ -99,6 +103,19 @@ impl Installer<'_, Message> for BusinessInstaller {
             tracing::trace!("BusinessInstaller::update received {:?}", message);
         }
         self.state.update(message)
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        iced::event::listen_with(|event, status, _| match (event, status) {
+            (
+                iced::Event::Keyboard(keyboard::Event::KeyPressed {
+                    key: keyboard::Key::Named(Named::Escape),
+                    ..
+                }),
+                event::Status::Ignored,
+            ) => Some(Message::EscapePressed),
+            _ => None,
+        })
     }
 
     fn view(&self) -> Element<'_, Message> {

--- a/liana-business/business-installer/src/state/app.rs
+++ b/liana-business/business-installer/src/state/app.rs
@@ -28,6 +28,7 @@ pub struct AppState {
     pub exit: bool,
     /// Server time offset in seconds (server_time - client_time)
     pub server_time_offset: i64,
+    pub escape_pressed_count: u8,
 }
 
 impl AppState {
@@ -168,6 +169,7 @@ impl AppState {
             reconnecting: false,
             exit: false,
             server_time_offset: 0,
+            escape_pressed_count: 0,
         }
     }
 }
@@ -213,6 +215,7 @@ impl From<PolicyTemplate> for AppState {
             reconnecting: false,
             exit: false,
             server_time_offset: 0,
+            escape_pressed_count: 0,
         }
     }
 }

--- a/liana-business/business-installer/src/state/message.rs
+++ b/liana-business/business-installer/src/state/message.rs
@@ -21,6 +21,7 @@ pub enum Msg {
     AccountSelectConnect(String), // Connect with cached account by email
     AccountSelectDelete(String),  // Delete cached account by email
     AccountSelectNewEmail,        // Start fresh login with new email
+    EscapePressed,    // Switch account selection to Signet network
 
     // Org management
     OrgSelected(Uuid),          // Select an organization

--- a/liana-business/business-installer/src/state/mod.rs
+++ b/liana-business/business-installer/src/state/mod.rs
@@ -60,6 +60,8 @@ pub struct State {
     hw_running: bool,
     /// Bitcoin network (mainnet, testnet, signet, regtest)
     pub network: Network,
+    /// Datadir used to reload network-specific cache state.
+    pub datadir: LianaDirectory,
     /// Dedicated sender for HwiService - messages are bridged to notif_sender with waking
     hw_sender: channel::Sender<Message>,
     /// Handle to the bridge thread (kept alive until State is dropped)
@@ -118,6 +120,7 @@ impl State {
             hw,
             hw_running: false,
             network,
+            datadir,
             hw_sender,
             _hw_bridge_handle: Some(hw_bridge_handle),
             bitbox_config,

--- a/liana-business/business-installer/src/state/update.rs
+++ b/liana-business/business-installer/src/state/update.rs
@@ -54,6 +54,7 @@ impl State {
             Msg::AccountSelectConnect(email) => return self.on_account_select_connect(email),
             Msg::AccountSelectDelete(email) => self.on_account_select_delete(email),
             Msg::AccountSelectNewEmail => return self.on_account_select_new_email(),
+            Msg::EscapePressed => self.on_escape_pressed(),
 
             // Org management
             Msg::OrgSelected(id) => self.on_org_selected(id),
@@ -293,6 +294,27 @@ impl State {
         if self.views.login.account_select.accounts.is_empty() {
             self.views.login.current = views::LoginState::EmailEntry;
         }
+    }
+
+    fn on_escape_pressed(&mut self) {
+        if self.network != miniscript::bitcoin::Network::Bitcoin {
+            return;
+        }
+        if self.current_view != View::Login {
+            return;
+        }
+
+        self.app.escape_pressed_count = self.app.escape_pressed_count.saturating_add(1);
+        if self.app.escape_pressed_count < 3 {
+            return;
+        }
+
+        self.network = miniscript::bitcoin::Network::Signet;
+        self.backend.set_network(self.network, self.datadir.clone());
+
+        let (valid_accounts, to_remove) = self.backend.validate_all_cached_tokens();
+        self.backend.clear_invalid_tokens(&to_remove);
+        self.views.login = views::login::Login::with_cached_accounts(valid_accounts);
     }
 }
 


### PR DESCRIPTION
This PR:
- disable auto-switching to email login step when no accounts
- in the login account select step, if user hit `escape` key 3 times we change to signet