### PR TITLE
lianad: warn `createrecovery` to an address of the same wallet.

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -471,9 +471,13 @@ cover the requested feerate.
 
 #### Response
 
-| Field          | Type      | Description                                          |
-| -------------- | --------- | ---------------------------------------------------- |
-| `psbt`         | string    | PSBT of the recovery transaction, encoded as base64. |
+| Field          | Type           | Description                                           |
+| -------------- | -------------- | ----------------------------------------------------- |
+| `psbt`         | string         | PSBT of the recovery transaction, encoded as base64.  |
+| `warnings`     | list of string | Warnings, if any, generated during recovery creation. |
+
+A warning will be included in the `warnings` response field (`to_own_address`) if the sweep address
+is known to belong to this wallet, since recovered funds would be locked under the same descriptor again.
 
 ### `updatelabels`
 

--- a/liana-gui/src/app/state/spend/step.rs
+++ b/liana-gui/src/app/state/spend/step.rs
@@ -437,9 +437,9 @@ impl DefineSpend {
                     .create_recovery(max_address.clone(), &outpoints, feerate_vb, Some(reco_tl))
                     .await
                     // Map the PSBT to `CreateSpendResult` result. We only need the PSBT below.
-                    .map(|psbt| CreateSpendResult::Success {
+                    .map(|(psbt, warnings)| CreateSpendResult::Success {
                         psbt,
-                        warnings: vec![],
+                        warnings: warnings.iter().map(|w| w.to_string()).collect(),
                     })
             } else {
                 daemon
@@ -738,7 +738,9 @@ impl Step for DefineSpend {
                                         )
                                         .await
                                         .map_err(|e| e.into())
-                                        .map(|psbt| (psbt, vec![]))
+                                        .map(|(psbt, warnings)| {
+                                            (psbt, warnings.iter().map(|w| w.to_string()).collect())
+                                        })
                                 },
                                 Message::Psbt,
                             );

--- a/liana-gui/src/daemon/client/mod.rs
+++ b/liana-gui/src/daemon/client/mod.rs
@@ -3,8 +3,10 @@ use std::fmt::Debug;
 use std::iter::FromIterator;
 
 use async_trait::async_trait;
-use lianad::bip329::Labels;
-use lianad::commands::{GetLabelsBip329Result, UpdateDerivIndexesResult};
+use lianad::{
+    bip329::Labels,
+    commands::{CreateRecoveryWarning, GetLabelsBip329Result, UpdateDerivIndexesResult},
+};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -209,7 +211,7 @@ impl<C: Client + Send + Sync + Debug> Daemon for Lianad<C> {
         coins_outpoints: &[OutPoint],
         feerate_vb: u64,
         sequence: Option<u16>,
-    ) -> Result<Psbt, DaemonError> {
+    ) -> Result<(Psbt, Vec<CreateRecoveryWarning>), DaemonError> {
         let mut params = serde_json::Map::new();
         params.insert("address".to_string(), json!(address));
         params.insert("outpoints".to_string(), json!(coins_outpoints));
@@ -218,7 +220,7 @@ impl<C: Client + Send + Sync + Debug> Daemon for Lianad<C> {
             params.insert("timelock".to_string(), json!(sequence));
         }
         let res: CreateRecoveryResult = self.call("createrecovery", Some(params))?;
-        Ok(res.psbt)
+        Ok((res.psbt, res.warnings))
     }
 
     async fn get_labels(

--- a/liana-gui/src/daemon/embedded.rs
+++ b/liana-gui/src/daemon/embedded.rs
@@ -1,5 +1,9 @@
-use lianad::bip329::Labels;
-use lianad::commands::UpdateDerivIndexesResult;
+use lianad::{
+    bip329::Labels,
+    commands::{CoinStatus, CreateRecoveryWarning, LabelItem, UpdateDerivIndexesResult},
+    config::Config,
+    DaemonControl, DaemonHandle,
+};
 use std::collections::{HashMap, HashSet};
 use tokio::sync::Mutex;
 
@@ -8,11 +12,6 @@ use crate::dir::LianaDirectory;
 use async_trait::async_trait;
 use liana::miniscript::bitcoin::{
     address, bip32::ChildNumber, psbt::Psbt, Address, Network, OutPoint, Txid,
-};
-use lianad::{
-    commands::{CoinStatus, LabelItem},
-    config::Config,
-    DaemonControl, DaemonHandle,
 };
 
 pub struct EmbeddedDaemon {
@@ -236,11 +235,11 @@ impl Daemon for EmbeddedDaemon {
         coins_outpoints: &[OutPoint],
         feerate_vb: u64,
         sequence: Option<u16>,
-    ) -> Result<Psbt, DaemonError> {
+    ) -> Result<(Psbt, Vec<CreateRecoveryWarning>), DaemonError> {
         self.command(|daemon| {
             daemon
                 .create_recovery(address, coins_outpoints, feerate_vb, sequence)
-                .map(|res| res.psbt)
+                .map(|res| (res.psbt, res.warnings))
                 .map_err(|e| DaemonError::Unexpected(e.to_string()))
         })
         .await

--- a/liana-gui/src/daemon/mod.rs
+++ b/liana-gui/src/daemon/mod.rs
@@ -16,10 +16,11 @@ use liana::miniscript::bitcoin::{
     psbt::Psbt,
     secp256k1, Address, Network, OutPoint, Txid,
 };
-use lianad::bip329::Labels;
-use lianad::commands::UpdateDerivIndexesResult;
 use lianad::{
-    commands::{CoinStatus, LabelItem, TransactionInfo},
+    bip329::Labels,
+    commands::{
+        CoinStatus, CreateRecoveryWarning, LabelItem, TransactionInfo, UpdateDerivIndexesResult,
+    },
     config::Config,
     StartupError,
 };
@@ -182,7 +183,7 @@ pub trait Daemon: Debug {
         coins_outpoints: &[OutPoint],
         feerate_vb: u64,
         sequence: Option<u16>,
-    ) -> Result<Psbt, DaemonError>;
+    ) -> Result<(Psbt, Vec<CreateRecoveryWarning>), DaemonError>;
     async fn list_txs(&self, txid: &[Txid]) -> Result<model::ListTransactionsResult, DaemonError>;
     async fn get_labels(
         &self,

--- a/liana-gui/src/services/connect/client/backend/mod.rs
+++ b/liana-gui/src/services/connect/client/backend/mod.rs
@@ -16,7 +16,10 @@ use liana::{
 };
 use lianad::{
     bip329::Labels,
-    commands::{CoinStatus, GetInfoDescriptors, LCSpendInfo, LabelItem, UpdateDerivIndexesResult},
+    commands::{
+        CoinStatus, CreateRecoveryWarning, GetInfoDescriptors, LCSpendInfo, LabelItem,
+        UpdateDerivIndexesResult,
+    },
     config::Config,
 };
 use reqwest::{Error, IntoUrl, Method, RequestBuilder};
@@ -936,7 +939,7 @@ impl Daemon for BackendWalletClient {
         coins_outpoints: &[OutPoint],
         feerate_vb: u64,
         sequence: Option<u16>,
-    ) -> Result<Psbt, DaemonError> {
+    ) -> Result<(Psbt, Vec<CreateRecoveryWarning>), DaemonError> {
         let timelock = sequence.ok_or(DaemonError::Unexpected("Missing sequence".to_string()))?;
         let res: api::DraftPsbt = self
             .inner
@@ -955,7 +958,13 @@ impl Daemon for BackendWalletClient {
             )
             .await?;
 
-        Ok(res.raw)
+        let warnings = res
+            .warnings
+            .into_iter()
+            .map(CreateRecoveryWarning::String)
+            .collect();
+
+        Ok((res.raw, warnings))
     }
 
     async fn get_labels(

--- a/lianad/src/commands/mod.rs
+++ b/lianad/src/commands/mod.rs
@@ -1251,6 +1251,10 @@ impl DaemonControl {
     /// otherwise not currently recoverable using the given recovery path.
     ///
     /// Note that not all coins may be spendable through a single recovery path at the same time.
+    ///
+    /// A warning will be included in the result's `warnings` field if the sweep address is
+    /// known to belong to this same wallet, since recovered funds would be locked under the
+    /// same descriptor again.
     pub fn create_recovery(
         &self,
         address: bitcoin::Address<address::NetworkUnchecked>,
@@ -1311,7 +1315,14 @@ impl DaemonControl {
             return Err(CommandError::RecoveryNotAvailable);
         }
 
+        // If DB knows (as derived address) about the provided address, it means
+        // the sweep address belongs to this wallet.
         let sweep_addr_info = sweep_addr.info;
+        let mut warnings = Vec::new();
+        if sweep_addr_info.is_some() {
+            warnings.push(CreateRecoveryWarning::ToOwnAddress);
+        }
+
         let locktime = self.anti_fee_sniping_locktime();
         let CreateSpendRes {
             psbt, has_change, ..
@@ -1329,7 +1340,7 @@ impl DaemonControl {
             self.maybe_increase_last_deriv_index(&mut db_conn, &sweep_addr_info);
         }
 
-        Ok(CreateRecoveryResult { psbt })
+        Ok(CreateRecoveryResult { psbt, warnings })
     }
 }
 
@@ -1523,6 +1534,34 @@ pub struct TransactionInfo {
 pub struct CreateRecoveryResult {
     #[serde(serialize_with = "ser_to_string", deserialize_with = "deser_fromstr")]
     pub psbt: Psbt,
+    #[serde(default)]
+    pub warnings: Vec<CreateRecoveryWarning>,
+}
+
+/// Warnings to be included in the `warnings` response field.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CreateRecoveryWarning {
+    /// A warning if the sweep address is known to belong to user's wallet.
+    #[serde(rename = "to_own_address")]
+    ToOwnAddress,
+
+    /// Warning returned by connect api.
+    #[serde(untagged)]
+    String(String),
+}
+
+impl fmt::Display for CreateRecoveryWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CreateRecoveryWarning::ToOwnAddress => write!(
+                f,
+                "Recovery address belongs to the same wallet. If you can no \
+                longer spend with the primary path, use an address from a \
+                different wallet instead."
+            ),
+            CreateRecoveryWarning::String(str) => write!(f, "{str}"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1544,7 +1583,7 @@ mod tests {
 
     #[test]
     fn getinfo() {
-        let ms = DummyLiana::new(DummyBitcoind::new(), DummyDatabase::new());
+        let ms = DummyLiana::new_timelock(DummyBitcoind::new(), DEFAULT_TIMELOCK);
         // We can query getinfo
         ms.control().get_info();
         ms.shutdown();
@@ -1552,8 +1591,7 @@ mod tests {
 
     #[test]
     fn getnewaddress() {
-        let ms = DummyLiana::new(DummyBitcoind::new(), DummyDatabase::new());
-
+        let ms = DummyLiana::new_timelock(DummyBitcoind::new(), DEFAULT_TIMELOCK);
         let control = &ms.control();
         // We can get an address (it will have index 1)
         let addr = control.get_new_address().address;
@@ -1579,7 +1617,7 @@ mod tests {
 
     #[test]
     fn listaddresses() {
-        let ms = DummyLiana::new(DummyBitcoind::new(), DummyDatabase::new());
+        let ms = DummyLiana::new_timelock(DummyBitcoind::new(), DEFAULT_TIMELOCK);
 
         let control = &ms.control();
 
@@ -1693,7 +1731,7 @@ mod tests {
 
     #[test]
     fn list_revealed_addresses() {
-        let ms = DummyLiana::new(DummyBitcoind::new(), DummyDatabase::new());
+        let ms = DummyLiana::new_timelock(DummyBitcoind::new(), DEFAULT_TIMELOCK);
 
         let control = &ms.control();
         let mut db_conn = control.db().lock().unwrap().connection();
@@ -2010,7 +2048,7 @@ mod tests {
             output: vec![],
         };
         let dummy_op = bitcoin::OutPoint::new(dummy_tx.compute_txid(), 0);
-        let ms = DummyLiana::new(DummyBitcoind::new(), DummyDatabase::new());
+        let ms = DummyLiana::new_timelock(DummyBitcoind::new(), DEFAULT_TIMELOCK);
         let control = &ms.control();
         let mut db_conn = control.db().lock().unwrap().connection();
         db_conn.new_txs(&[dummy_tx]);
@@ -2549,7 +2587,11 @@ mod tests {
             .txs
             .insert(dummy_op_a.txid, (dummy_tx.clone(), None));
         dummy_bitcoind.txs.insert(dummy_op_b.txid, (dummy_tx, None));
-        let ms = DummyLiana::new(dummy_bitcoind, DummyDatabase::new());
+        let ms = DummyLiana::new(
+            dummy_bitcoind,
+            DummyDatabase::new(dummy_descriptor(DEFAULT_TIMELOCK)),
+            false,
+        );
         let control = &ms.control();
         let mut db_conn = control.db().lock().unwrap().connection();
 
@@ -2697,7 +2739,7 @@ mod tests {
         };
         let dummy_txid_a = dummy_psbt_a.unsigned_tx.compute_txid();
         dummy_bitcoind.txs.insert(dummy_txid_a, (dummy_tx_a, None));
-        let ms = DummyLiana::new(dummy_bitcoind, DummyDatabase::new());
+        let ms = DummyLiana::new_timelock(dummy_bitcoind, DEFAULT_TIMELOCK);
         let control = &ms.control();
         let mut db_conn = control.db().lock().unwrap().connection();
         // The spend needs to be in DB before using RBF.
@@ -2820,7 +2862,7 @@ mod tests {
             ],
         };
 
-        let mut db = DummyDatabase::new();
+        let mut db = DummyDatabase::new(dummy_descriptor(DEFAULT_TIMELOCK));
         db.insert_coins(vec![
             // Deposit 1
             Coin {
@@ -2939,7 +2981,7 @@ mod tests {
             ),
         );
 
-        let ms = DummyLiana::new(DummyBitcoind::new(), db);
+        let ms = DummyLiana::new(DummyBitcoind::new(), db, false);
 
         let control = &ms.control();
         let mut db_conn = control.db.connection();
@@ -3076,7 +3118,7 @@ mod tests {
             ),
         );
 
-        let ms = DummyLiana::new(DummyBitcoind::new(), DummyDatabase::new());
+        let ms = DummyLiana::new_timelock(DummyBitcoind::new(), DEFAULT_TIMELOCK);
         let control = &ms.control();
         let mut db_conn = control.db.connection();
         let txs: Vec<_> = txs_map.values().map(|(tx, _)| tx.clone()).collect();
@@ -3136,7 +3178,7 @@ mod tests {
         };
         let dummy_txid = dummy_tx.compute_txid();
         let dummy_op = bitcoin::OutPoint::new(dummy_txid, 0);
-        let ms = DummyLiana::new_timelock(DummyBitcoind::new(), DummyDatabase::new(), 10);
+        let ms = DummyLiana::new_timelock(DummyBitcoind::new(), 10);
         let control = &ms.control();
         let mut db_conn = control.db().lock().unwrap().connection();
         db_conn.new_txs(&[dummy_tx]);
@@ -3241,6 +3283,14 @@ mod tests {
             control.create_recovery(dummy_addr.clone(), &[dummy_op], 1, Some(11)),
             Err(CommandError::OutpointNotRecoverable(dummy_op, 11)),
         );
+
+        // allow to recover with own address with a warning attached.
+        let own_addr = control.get_new_address();
+        let own_unchecked_addr = own_addr.address.as_unchecked().clone();
+        let res = control
+            .create_recovery(own_unchecked_addr, &[], 1, None)
+            .unwrap();
+        assert_eq!(res.warnings, vec![CreateRecoveryWarning::ToOwnAddress]);
 
         // If the coin is spending, it is no longer recoverable.
         db_conn.spend_coins(&[(

--- a/lianad/src/jsonrpc/server/unix.rs
+++ b/lianad/src/jsonrpc/server/unix.rs
@@ -402,7 +402,7 @@ mod tests {
     #[cfg(not(target_os = "macos"))]
     #[test]
     fn server_sanity_check() {
-        let ms = DummyLiana::new_server(DummyBitcoind::new(), DummyDatabase::new());
+        let ms = DummyLiana::new_server(DummyBitcoind::new(), DEFAULT_TIMELOCK);
         let socket_path: path::PathBuf = [
             ms.tmp_dir.as_path(),
             path::Path::new("d"),

--- a/lianad/src/testutils.rs
+++ b/lianad/src/testutils.rs
@@ -23,6 +23,10 @@ use miniscript::{
     descriptor,
 };
 
+const TEST_OWNER_KEY_SINGLE: &str = "[aabbccdd]xpub68JJTXc1MWK8KLW4HGLXZBJknja7kDUJuFHnM424LbziEXsfkh1WQCiEjjHw4zLqSUm4rvhgyGkkuRowE9tCJSgt3TQB5J3SKAbZ2SdcKST/<0;1>/*";
+const TEST_HEIR_KEY_SINGLE: &str = "[aabbccdd]xpub68JJTXc1MWK8PEQozKsRatrUHXKFNkD1Cb1BuQU9Xr5moCv87anqGyXLyUd4KpnDyZgo3gz4aN1r3NiaoweFW8UutBsBbgKHzaD5HkTkifK/<0;1>/*";
+pub const DEFAULT_TIMELOCK: u16 = 10_000;
+
 pub struct DummyBitcoind {
     pub txs: HashMap<Txid, (Transaction, Option<Block>)>,
 }
@@ -156,6 +160,7 @@ struct DummyDbState {
     timestamp: u32,
     rescan_timestamp: Option<u32>,
     last_poll_timestamp: Option<u32>,
+    main_descriptor: descriptors::LianaDescriptor,
 }
 
 pub struct DummyDatabase {
@@ -171,7 +176,7 @@ impl DatabaseInterface for DummyDatabase {
 }
 
 impl DummyDatabase {
-    pub fn new() -> DummyDatabase {
+    pub fn new(main_descriptor: descriptors::LianaDescriptor) -> DummyDatabase {
         let now: u32 = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -191,6 +196,7 @@ impl DummyDatabase {
                 timestamp: now,
                 rescan_timestamp: None,
                 last_poll_timestamp: None,
+                main_descriptor,
             })),
         }
     }
@@ -363,8 +369,29 @@ impl DatabaseConnection for DummyDatabase {
 
     fn derivation_index_by_address(
         &mut self,
-        _: &bitcoin::Address,
+        addr: &bitcoin::Address,
     ) -> Option<(bip32::ChildNumber, bool)> {
+        let net = self.network();
+        let db = self.db.read().unwrap();
+        let desc = &db.main_descriptor;
+        let context = secp256k1::Secp256k1::verification_only();
+
+        // Check in list of ([recv | change] desc path, child idx, is change or not)
+        let data = vec![
+            (desc.receive_descriptor(), db.deposit_index, false),
+            (desc.change_descriptor(), db.change_index, true),
+        ];
+
+        // From first to last index used, if gets we found
+        for (wall_desc, idx, is_change) in data {
+            for i in 0..=u32::from(idx) {
+                let index = bip32::ChildNumber::from(i);
+                let look = wall_desc.derive(index, &context).address(net);
+                if &look == addr {
+                    return Some((index, is_change));
+                }
+            }
+        }
         None
     }
 
@@ -576,13 +603,27 @@ pub fn tmp_dir() -> path::PathBuf {
     ))
 }
 
+pub fn dummy_descriptor(timelock: u16) -> descriptors::LianaDescriptor {
+    let owner_key = descriptors::PathInfo::Single(
+        descriptor::DescriptorPublicKey::from_str(TEST_OWNER_KEY_SINGLE).unwrap(),
+    );
+    let heir_key = descriptors::PathInfo::Single(
+        descriptor::DescriptorPublicKey::from_str(TEST_HEIR_KEY_SINGLE).unwrap(),
+    );
+    let policy = descriptors::LianaPolicy::new_legacy(
+        owner_key,
+        [(timelock, heir_key)].iter().cloned().collect(),
+    )
+    .unwrap();
+    descriptors::LianaDescriptor::new(policy)
+}
+
 impl DummyLiana {
     /// Creates a new DummyLiana interface
     pub fn _new(
         bitcoin_interface: impl BitcoinInterface + 'static,
-        database: impl DatabaseInterface + 'static,
+        database: DummyDatabase,
         rpc_server: bool,
-        timelock: u16,
     ) -> DummyLiana {
         let tmp_dir = tmp_dir();
         fs::create_dir_all(&tmp_dir).unwrap();
@@ -599,19 +640,11 @@ impl DummyLiana {
             poll_interval_secs: time::Duration::from_secs(2),
         };
 
-        let owner_key = descriptors::PathInfo::Single(descriptor::DescriptorPublicKey::from_str("[aabbccdd]xpub68JJTXc1MWK8KLW4HGLXZBJknja7kDUJuFHnM424LbziEXsfkh1WQCiEjjHw4zLqSUm4rvhgyGkkuRowE9tCJSgt3TQB5J3SKAbZ2SdcKST/<0;1>/*").unwrap());
-        let heir_key = descriptors::PathInfo::Single(descriptor::DescriptorPublicKey::from_str("[aabbccdd]xpub68JJTXc1MWK8PEQozKsRatrUHXKFNkD1Cb1BuQU9Xr5moCv87anqGyXLyUd4KpnDyZgo3gz4aN1r3NiaoweFW8UutBsBbgKHzaD5HkTkifK/<0;1>/*").unwrap());
-        let policy = descriptors::LianaPolicy::new_legacy(
-            owner_key,
-            [(timelock, heir_key)].iter().cloned().collect(),
-        )
-        .unwrap();
-        let desc = descriptors::LianaDescriptor::new(policy);
         let config = Config::new(
             bitcoin_config,
             None,
             log::LevelFilter::Debug,
-            desc,
+            database.db.read().unwrap().main_descriptor.clone(),
             DataDirectory::new(data_directory),
         );
 
@@ -624,26 +657,30 @@ impl DummyLiana {
     /// Creates a new DummyLiana interface
     pub fn new(
         bitcoin_interface: impl BitcoinInterface + 'static,
-        database: impl DatabaseInterface + 'static,
+        database: DummyDatabase,
+        rpc_server: bool,
     ) -> DummyLiana {
-        Self::_new(bitcoin_interface, database, false, 10_000)
+        Self::_new(bitcoin_interface, database, rpc_server)
     }
 
     /// Creates a new DummyLiana interface with the specified recovery path timelock.
     pub fn new_timelock(
         bitcoin_interface: impl BitcoinInterface + 'static,
-        database: impl DatabaseInterface + 'static,
         timelock: u16,
     ) -> DummyLiana {
-        Self::_new(bitcoin_interface, database, false, timelock)
+        let descriptor = dummy_descriptor(timelock);
+        let database = DummyDatabase::new(descriptor);
+        Self::new(bitcoin_interface, database, false)
     }
 
     /// Creates a new DummyLiana interface which also spins up an RPC server.
     pub fn new_server(
         bitcoin_interface: impl BitcoinInterface + 'static,
-        database: impl DatabaseInterface + 'static,
+        timelock: u16,
     ) -> DummyLiana {
-        Self::_new(bitcoin_interface, database, true, 10_000)
+        let descriptor = dummy_descriptor(timelock);
+        let database = DummyDatabase::new(descriptor);
+        Self::new(bitcoin_interface, database, true)
     }
 
     pub fn control(&self) -> &DaemonControl {

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1298,7 +1298,15 @@ def test_create_recovery(lianad, bitcoind):
     ][0]
     reco_address = bitcoind.rpc.getnewaddress()
     res = lianad.rpc.createrecovery(reco_address, 18)
+
+    # No warnings because it swept to an external address
+    assert len(res["warnings"]) == 0
     reco_psbt = PSBT.from_base64(res["psbt"])
+
+    # Recover to own address but warn user about re-lock behaviour
+    own_address = lianad.rpc.getnewaddress()["address"]
+    res_own = lianad.rpc.createrecovery(own_address, 18)
+    assert res_own["warnings"] == ["to_own_address"]
 
     # Do the same passing all three coins explicitly:
     res_op = lianad.rpc.createrecovery(reco_address, 18, 10, first_outpoints)


### PR DESCRIPTION
~~This commit adds a new error (code 1001, just after the existing 1000) bound to `createrecovery` -- as warning response when a user wants to re-lock funds from/to addresses derived from the wallet descriptor.~~

~~As stated by jp1ac4 the starting point is to check this on the backend since it have easier access to known wallet addresses (needs a check on how to deal with derivation indices beyond what the DB knows).~~

~~The proposed flow check if the provided address belongs to the user if the DB have `Some` or `None`. If `None`, just continue the flow; if `Some`, a `RecoveryToOwnAddress` error will be added to a `warnings` field as a string.~~

EDIT: As stated by jp1ac4 the starting point is to check this on the backend since the backend has easier access to known wallet addresses (needs a check on how to deal with derivation indices beyond what the DB knows -- worth of a follow-up).

If the DB knows the sweep address as a derived one, it belongs to the wallet's descriptor and recovered funds would be locked under the same descriptor again.

In that case a `CreateRecoveryWarning::ToOwnAddress` enum is used as a warning with the address to be added to a new `warnings` field of the `createrecovery` response so the rpc command could respond with `{"psbt": ..., "warnings": [{ "to_own_address": "<addr>"}] }`.

Close #1654.

## Details

~~A follow-up commit (the GUI confirmation flow) is being drafted while discussing.~~

EDIT: the `gui` commit handles the previous commit `createrecovery` rpc update to `Daemon` trait, so when user request do a self-transfer when using recovery options on GUI, it will be warned about the re-lock.

EDIT 2: Maybe it needs some GUI tests? maybe now or follow up?