### PR TITLE
docs: add Coldcard Mk3 seed-entropy security warning to SIGNING_DEVICES

### DIFF
--- a/doc/SIGNING_DEVICES.md
+++ b/doc/SIGNING_DEVICES.md
@@ -29,7 +29,7 @@ writing. It is only supported by the [Edge
 firmware](https://github.com/Coldcard/firmware?tab=readme-ov-file#long-lived-branches).
 For use in Taproot descriptors you should use version 6.3.3 or higher.
 
-WARNING: Coinkite disclosed (July 2026) a firmware flaw that reduced generated-seed entropy on Coldcard Mk2/Mk3 (firmware 4.0.1-4.1.9) and Mk4/Mk5/Q before their fixed firmware. If your seed was generated on-device with fewer than 50 independent dice rolls, update to fixed firmware, generate a new seed and move your funds. See the advisory: https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/
+WARNING: Coinkite disclosed (July 2026) a firmware flaw that reduced generated-seed entropy on Coldcard Mk2/Mk3 (firmware 4.0.1-4.1.9) and Mk4/Mk5/Q before their fixed firmware. If your seed was generated on-device with fewer than 50 independent dice rolls, update to fixed firmware, generate a new seed and move your funds. See the advisory: https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/ and Wizardsardine's Liana-specific write-up: https://wizardsardine.com/blog/coldcard-rng-vulnerability/
 
 
 ## [Jade and Jade Plus](https://github.com/Blockstream/Jade)

--- a/doc/SIGNING_DEVICES.md
+++ b/doc/SIGNING_DEVICES.md
@@ -29,6 +29,8 @@ writing. It is only supported by the [Edge
 firmware](https://github.com/Coldcard/firmware?tab=readme-ov-file#long-lived-branches).
 For use in Taproot descriptors you should use version 6.3.3 or higher.
 
+WARNING: Coinkite disclosed (July 2026) a firmware flaw that reduced generated-seed entropy on Coldcard Mk3 (firmware 4.0.1-5.0.3) and pre-fix Mk4/Q. If your seed was generated on-device without extra dice rolls, update to fixed firmware, generate a new seed and move your funds. See the advisory: https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/
+
 
 ## [Jade and Jade Plus](https://github.com/Blockstream/Jade)
 

--- a/doc/SIGNING_DEVICES.md
+++ b/doc/SIGNING_DEVICES.md
@@ -29,7 +29,7 @@ writing. It is only supported by the [Edge
 firmware](https://github.com/Coldcard/firmware?tab=readme-ov-file#long-lived-branches).
 For use in Taproot descriptors you should use version 6.3.3 or higher.
 
-WARNING: Coinkite disclosed (July 2026) a firmware flaw that reduced generated-seed entropy on Coldcard Mk3 (firmware 4.0.1-5.0.3) and pre-fix Mk4/Q. If your seed was generated on-device without extra dice rolls, update to fixed firmware, generate a new seed and move your funds. See the advisory: https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/
+WARNING: Coinkite disclosed (July 2026) a firmware flaw that reduced generated-seed entropy on Coldcard Mk2/Mk3 (firmware 4.0.1-4.1.9) and Mk4/Mk5/Q before their fixed firmware. If your seed was generated on-device with fewer than 50 independent dice rolls, update to fixed firmware, generate a new seed and move your funds. See the advisory: https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/
 
 
 ## [Jade and Jade Plus](https://github.com/Blockstream/Jade)


### PR DESCRIPTION
## Summary

Adds a security warning to the Coldcard section of `doc/SIGNING_DEVICES.md`.

In July 2026 Coinkite [disclosed](https://blog.coinkite.com/coldcard-mk3-seed-generation-warning/) a firmware build error that reduced generated-seed entropy on **Coldcard Mk3** (firmware 4.0.1–5.0.3) and pre-fix **Mk4/Q**. Users who set up a Coldcard for a Liana wallet may hold funds on an affected seed. This adds a one-line `WARNING:` (matching the existing style used for the Jade section) linking the advisory.

Docs-only change. Refs #2241.
