### PR TITLE
dep: use vendored bip329

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,9 +553,8 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bip329"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8351c1cf438ae5814ad2a696f06fd07d7be4a1a133d889b1785260fa8797798c"
+version = "0.6.0"
+source = "git+https://github.com/wizardsardine/bip329?rev=77c9d91#77c9d9156e1c5029d5df251b04a8f458a66475db"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ getrandom = "0.3.1"
 bip39 = "2.0"
 rdrand = "0.8"
 fern = "0.6"
-bip329 = { version = "0.3.0", default-features = false }
+bip329 = { git = "https://github.com/wizardsardine/bip329", rev = "77c9d91" }
 async-trait = "0.1"
 async-hwi = "0.0.32"
 hex = "0.4.3"

--- a/contrib/reproducible/guix/build.sh
+++ b/contrib/reproducible/guix/build.sh
@@ -30,6 +30,11 @@ replace-with = "vendored_sources"
 git = "https://github.com/wizardsardine/bdk"
 branch = "release/1.0.0-alpha.13"
 replace-with = "vendored_sources"
+
+[source."git+https://github.com/wizardsardine/bip329?rev=77c9d91"]
+git = "https://github.com/wizardsardine/bip329"
+rev = "77c9d91"
+replace-with = "vendored_sources"
 EOF
 
 # We need to set RUSTC_BOOTSTRAP=1 as a workaround to be able to use unstable

--- a/liana-connect/Cargo.toml
+++ b/liana-connect/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 [dependencies]
 liana = { path = "../liana" }
 async-trait = { workspace = true }
-bip329 = { workspace = true, default-features = false }
+bip329 = { workspace = true }
 bip39 = { workspace = true }
 getrandom = { workspace = true }
 miniscript = { workspace = true, features = ["serde"]}

--- a/lianad/Cargo.toml
+++ b/lianad/Cargo.toml
@@ -51,4 +51,4 @@ rusqlite = { workspace = true, features = ["bundled", "unlock_notify"] }
 jsonrpc = { workspace = true, features = ["minreq_http"], default-features = false }
 
 # import/export labels
-bip329 = { workspace = true, default-features = false }
+bip329 = { workspace = true }

--- a/lianad/src/database/sqlite/schema.rs
+++ b/lianad/src/database/sqlite/schema.rs
@@ -395,7 +395,7 @@ impl From<DbLabel> for Label {
             DbLabelledKind::OutPoint => Label::Output(bip329::OutputRecord {
                 ref_: OutPoint::from_str(&ref_).expect(" db contains valid outpoints"),
                 label,
-                spendable: true,
+                spendable: None,
             }),
             DbLabelledKind::Txid => Label::Transaction(bip329::TransactionRecord {
                 ref_: bitcoin::consensus::encode::deserialize_hex(&ref_)


### PR DESCRIPTION
This PR replace the crates.io `bip329` crate by a vendored fork we maintain for 2 reasons:
- the author of the crate has bad security practices (https://x.com/PraveenPerera/status/2090978986629214562)
- features we dont use has been dropped

Note: the previous version of bip329 had `OutpoutRecord.spendable` as a `bool` but it is now a `Option<bool>`, as we dont have any notion of spendable/unspendable in Liana, the default export value is None