### PR TITLE
liana-ui: fix color of imported key badge

### DIFF
--- a/liana-ui/src/component/badge.rs
+++ b/liana-ui/src/component/badge.rs
@@ -192,7 +192,7 @@ tile_specs! {
     (KeyInternal, round_key_icon, Neutral, DEFAULT),
     (KeyExternal, scale_icon, Neutral, DEFAULT),
     (KeyService, shield_icon, Neutral, DEFAULT),
-    (KeyImported, file_icon, Danger, DEFAULT),
+    (KeyImported, file_icon, Neutral, DEFAULT),
     (KeyHot, round_key_icon, Danger, DEFAULT),
     (Device, usb_icon, Neutral, DEFAULT),
     (Account, person_icon, Neutral, DEFAULT),


### PR DESCRIPTION
This PR fixes the color of the imported key icon in the installer:

<img width="814" height="501" alt="image" src="https://github.com/user-attachments/assets/592b29c4-8af5-48f6-87f3-2746f9c261fe" />
