### PR TITLE
installer: make node configuration non-editable during ping wait

### DIFF
--- a/liana-gui/src/installer/step/node/bitcoind.rs
+++ b/liana-gui/src/installer/step/node/bitcoind.rs
@@ -339,7 +339,7 @@ impl Step for SelectBitcoindTypeStep {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DefineBitcoind {
     rpc_auth_vals: RpcAuthValues,
     selected_auth_type: RpcAuthType,
@@ -482,8 +482,13 @@ impl DefineBitcoind {
         }
     }
 
-    pub fn view(&self) -> Element<'_, Message> {
-        view::define_bitcoind(&self.address, &self.rpc_auth_vals, &self.selected_auth_type)
+    pub fn view(&self, waiting_for_ping_result: bool) -> Element<'_, Message> {
+        view::define_bitcoind(
+            &self.address,
+            &self.rpc_auth_vals,
+            &self.selected_auth_type,
+            waiting_for_ping_result,
+        )
     }
 }
 

--- a/liana-gui/src/installer/step/node/electrum.rs
+++ b/liana-gui/src/installer/step/node/electrum.rs
@@ -14,7 +14,7 @@ use crate::{
     node::electrum::ConfigField,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DefineElectrum {
     address: form::Value<String>,
     validate_domain: bool,
@@ -65,8 +65,8 @@ impl DefineElectrum {
         false
     }
 
-    pub fn view(&self) -> Element<'_, Message> {
-        view::define_electrum(&self.address, self.validate_domain)
+    pub fn view(&self, waiting_for_ping_result: bool) -> Element<'_, Message> {
+        view::define_electrum(&self.address, self.validate_domain, waiting_for_ping_result)
     }
 
     pub fn ping(&self) -> Result<(), Error> {

--- a/liana-gui/src/installer/step/node/mod.rs
+++ b/liana-gui/src/installer/step/node/mod.rs
@@ -19,7 +19,7 @@ use iced::Task;
 use liana::miniscript::bitcoin::Network;
 use liana_ui::widget::Element;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum NodeDefinition {
     Bitcoind(DefineBitcoind),
     Electrum(DefineElectrum),
@@ -70,10 +70,10 @@ impl NodeDefinition {
         }
     }
 
-    fn view(&self) -> Element<'_, Message> {
+    fn view(&self, waiting_for_ping_result: bool) -> Element<'_, Message> {
         match self {
-            NodeDefinition::Bitcoind(def) => def.view(),
-            NodeDefinition::Electrum(def) => def.view(),
+            NodeDefinition::Bitcoind(def) => def.view(waiting_for_ping_result),
+            NodeDefinition::Electrum(def) => def.view(waiting_for_ping_result),
         }
     }
 
@@ -85,6 +85,7 @@ impl NodeDefinition {
     }
 }
 
+#[derive(Debug)]
 pub struct Node {
     definition: NodeDefinition,
     is_running: Option<Result<(), Error>>,
@@ -233,13 +234,14 @@ impl Step for DefineNode {
         network: Network,
         _email: Option<&str>,
     ) -> Element<'_, Message> {
-        // TODO: Make input fields read-only while waiting for a ping result.
         view::define_bitcoin_node(
             progress,
             network,
             self.nodes.iter().map(|node| node.definition.node_type()),
             self.selected_node_type,
-            self.selected().definition.view(),
+            self.selected()
+                .definition
+                .view(self.selected().waiting_for_ping_result),
             self.selected().is_running.as_ref(),
             self.selected().definition.can_try_ping(),
             self.selected().waiting_for_ping_result,

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -984,6 +984,7 @@ pub fn define_bitcoind<'a>(
     address: &form::Value<String>,
     rpc_auth_vals: &RpcAuthValues,
     selected_auth_type: &RpcAuthType,
+    waiting_for_ping_result: bool,
 ) -> Element<'a, Message> {
     let is_loopback = if let Some((ip, _port)) = address.value.clone().rsplit_once(':') {
         let (ipv4, ipv6) = (Ipv4Addr::from_str(ip), Ipv6Addr::from_str(ip));
@@ -996,10 +997,14 @@ pub fn define_bitcoind<'a>(
         false
     };
 
-    let address_msg = |msg| {
-        Message::DefineNode(DefineNode::DefineBitcoind(
-            DefineBitcoind::ConfigFieldEdited(ConfigField::Address, msg),
-        ))
+    let address_msg = move |msg| {
+        if !waiting_for_ping_result {
+            Message::DefineNode(DefineNode::DefineBitcoind(
+                DefineBitcoind::ConfigFieldEdited(ConfigField::Address, msg),
+            ))
+        } else {
+            Message::None
+        }
     };
     let address_input = form::Form::new_trimmed("Address", address, address_msg)
         .warning("Please enter correct address")
@@ -1023,9 +1028,13 @@ pub fn define_bitcoind<'a>(
                     *auth_type,
                     Some(*selected_auth_type),
                     |new_selection| {
-                        Message::DefineNode(DefineNode::DefineBitcoind(
-                            DefineBitcoind::RpcAuthTypeSelected(new_selection),
-                        ))
+                        if !waiting_for_ping_result {
+                            Message::DefineNode(DefineNode::DefineBitcoind(
+                                DefineBitcoind::RpcAuthTypeSelected(new_selection),
+                            ))
+                        } else {
+                            Message::None
+                        }
                     },
                 ))
                 .spacing(30)
@@ -1035,25 +1044,37 @@ pub fn define_bitcoind<'a>(
     let auth_fields = match selected_auth_type {
         RpcAuthType::CookieFile => {
             row![
-                form::Form::new_trimmed("Cookie path", &rpc_auth_vals.cookie_path, |msg| {
-                    Message::DefineNode(DefineNode::DefineBitcoind(
-                        DefineBitcoind::ConfigFieldEdited(ConfigField::CookieFilePath, msg),
-                    ))
+                form::Form::new_trimmed("Cookie path", &rpc_auth_vals.cookie_path, move |msg| {
+                    if !waiting_for_ping_result {
+                        Message::DefineNode(DefineNode::DefineBitcoind(
+                            DefineBitcoind::ConfigFieldEdited(ConfigField::CookieFilePath, msg),
+                        ))
+                    } else {
+                        Message::None
+                    }
                 })
                 .warning("Please enter correct path")
             ]
         }
         RpcAuthType::UserPass => row![
-            form::Form::new_trimmed("User", &rpc_auth_vals.user, |msg| {
-                Message::DefineNode(DefineNode::DefineBitcoind(
-                    DefineBitcoind::ConfigFieldEdited(ConfigField::User, msg),
-                ))
+            form::Form::new_trimmed("User", &rpc_auth_vals.user, move |msg| {
+                if !waiting_for_ping_result {
+                    Message::DefineNode(DefineNode::DefineBitcoind(
+                        DefineBitcoind::ConfigFieldEdited(ConfigField::User, msg),
+                    ))
+                } else {
+                    Message::None
+                }
             })
             .warning("Please enter correct user"),
-            form::Form::new_trimmed("Password", &rpc_auth_vals.password, |msg| {
-                Message::DefineNode(DefineNode::DefineBitcoind(
-                    DefineBitcoind::ConfigFieldEdited(ConfigField::Password, msg),
-                ))
+            form::Form::new_trimmed("Password", &rpc_auth_vals.password, move |msg| {
+                if !waiting_for_ping_result {
+                    Message::DefineNode(DefineNode::DefineBitcoind(
+                        DefineBitcoind::ConfigFieldEdited(ConfigField::Password, msg),
+                    ))
+                } else {
+                    Message::None
+                }
             })
             .warning("Please enter correct password")
         ]
@@ -1067,18 +1088,27 @@ pub fn define_bitcoind<'a>(
 pub fn define_electrum<'a>(
     address: &form::Value<String>,
     validate_domain: bool,
+    waiting_for_ping_result: bool,
 ) -> Element<'a, Message> {
-    let validate_certificate_msg = |b| {
-        Message::DefineNode(DefineNode::DefineElectrum(
-            message::DefineElectrum::ValidDomainChanged(b),
-        ))
+    let validate_certificate_msg = move |b| {
+        if !waiting_for_ping_result {
+            Message::DefineNode(DefineNode::DefineElectrum(
+                message::DefineElectrum::ValidDomainChanged(b),
+            ))
+        } else {
+            Message::None
+        }
     };
     let checkbox = validate_domain_checkbox(address, validate_domain, validate_certificate_msg);
 
-    let address_msg = |msg| {
-        Message::DefineNode(DefineNode::DefineElectrum(
-            message::DefineElectrum::ConfigFieldEdited(electrum::ConfigField::Address, msg),
-        ))
+    let address_msg = move |msg| {
+        if !waiting_for_ping_result {
+            Message::DefineNode(DefineNode::DefineElectrum(
+                message::DefineElectrum::ConfigFieldEdited(electrum::ConfigField::Address, msg),
+            ))
+        } else {
+            Message::None
+        }
     };
     let address_input = form::Form::new_trimmed("127.0.0.1:50001", address, address_msg)
         .warning(


### PR DESCRIPTION
This PR disable editing of the node config while the ping request is in-flight.

closes #2212