### PR TITLE
gui: show rescan warning when a pasted descriptor is imported

### DIFF
--- a/liana-business/src/settings/mod.rs
+++ b/liana-business/src/settings/mod.rs
@@ -223,7 +223,7 @@ impl SettingsTrait for BusinessSettings {
                 Arc::new(remote_backend),
                 liana_dir,
                 None,
-                false,
+                None,
             ))
         })())
     }

--- a/liana-gui/src/app/mod.rs
+++ b/liana-gui/src/app/mod.rs
@@ -22,7 +22,7 @@ use tracing::{error, info, warn};
 
 pub use liana::miniscript::bitcoin;
 use liana_ui::{
-    component::network_banner,
+    component::{network_banner, panels::home::WalletOrigin},
     widget::{Column, Element},
 };
 pub use lianad::{commands::CoinStatus, config::Config as DaemonConfig};
@@ -71,15 +71,16 @@ impl<S: SettingsTrait> Panels<S> {
         daemon_backend: DaemonBackend,
         internal_bitcoind: Option<&Bitcoind>,
         config: Arc<Config>,
-        restored_from_backup: bool,
+        wallet_origin: Option<WalletOrigin>,
     ) -> (Panels<S>, Task<S::Message>) {
-        let show_rescan_warning = restored_from_backup
-            && daemon_backend.is_lianad()
-            && daemon_backend
-                .node_type()
-                .map(|nt| nt == NodeType::Bitcoind)
-                // We don't know the node type for external lianad so assume it's bitcoind.
-                .unwrap_or(true);
+        let rescan_warning = wallet_origin.filter(|_| {
+            daemon_backend.is_lianad()
+                && daemon_backend
+                    .node_type()
+                    .map(|nt| nt == NodeType::Bitcoind)
+                    // We don't know the node type for external lianad so assume it's bitcoind.
+                    .unwrap_or(true)
+        });
 
         let (settings_ui, settings_task) = S::UI::new(
             data_dir.clone(),
@@ -103,7 +104,7 @@ impl<S: SettingsTrait> Panels<S> {
                     cache.last_poll_at_startup,
                 ),
                 cache.blockheight(),
-                show_rescan_warning,
+                rescan_warning,
             ),
             coins: CoinsPanel::new(cache.coins(), wallet.main_descriptor.first_timelock_value()),
             transactions: TransactionsPanel::new(wallet.clone()),
@@ -179,7 +180,7 @@ impl<S: SettingsTrait> App<S> {
         daemon: Arc<dyn Daemon + Sync + Send>,
         data_dir: LianaDirectory,
         internal_bitcoind: Option<Bitcoind>,
-        restored_from_backup: bool,
+        wallet_origin: Option<WalletOrigin>,
     ) -> (App<S>, Task<Message>) {
         let config = Arc::new(config);
 
@@ -206,7 +207,7 @@ impl<S: SettingsTrait> App<S> {
             daemon.backend(),
             internal_bitcoind.as_ref(),
             config.clone(),
-            restored_from_backup,
+            wallet_origin,
         );
         let cmd = panels.home.reload(daemon.clone(), wallet.clone());
         (

--- a/liana-gui/src/app/state/mod.rs
+++ b/liana-gui/src/app/state/mod.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 
 use iced::{Subscription, Task};
 use liana::miniscript::bitcoin::{Amount, OutPoint};
-use liana_ui::widget::*;
+use liana_ui::{component::panels::home::WalletOrigin, widget::*};
 use lianad::commands::CoinStatus;
 
 use super::{
@@ -157,7 +157,7 @@ pub struct Home {
     labels_edited: LabelsEdited,
 
     warning: Option<Error>,
-    show_rescan_warning: bool,
+    rescan_warning: Option<WalletOrigin>,
 }
 
 impl Home {
@@ -166,7 +166,7 @@ impl Home {
         coins: &[Coin],
         sync_status: SyncStatus,
         tip_height: i32,
-        show_rescan_warning: bool,
+        rescan_warning: Option<WalletOrigin>,
     ) -> Self {
         let (balance, unconfirmed_balance, expiring_coins, remaining_seq) = coins_summary(
             coins,
@@ -186,7 +186,7 @@ impl Home {
             labels_edited: LabelsEdited::default(),
             warning: None,
             processing: false,
-            show_rescan_warning,
+            rescan_warning,
             last_reload: Instant::now(),
         }
     }
@@ -218,7 +218,7 @@ impl State for Home {
                     self.payments.is_last_page,
                     self.processing,
                     &self.sync_status,
-                    self.show_rescan_warning,
+                    self.rescan_warning,
                 ),
             )
         }
@@ -320,7 +320,7 @@ impl State for Home {
                 }
             },
             Message::View(view::Message::HideRescanWarning) => {
-                self.show_rescan_warning = false;
+                self.rescan_warning = None;
             }
             Message::View(view::Message::SelectPayment(outpoint)) => {
                 return Task::perform(

--- a/liana-gui/src/app/view/home/mod.rs
+++ b/liana-gui/src/app/view/home/mod.rs
@@ -10,7 +10,7 @@ use liana_ui::{
         panels::home::{
             self,
             payment::{payment_card, PaymentKind, UIPayment},
-            rescan_warning, SyncProgress,
+            SyncProgress, WalletOrigin,
         },
         text::new,
     },
@@ -37,7 +37,7 @@ pub fn home_view<'a>(
     is_last_page: bool,
     processing: bool,
     sync_status: &SyncStatus,
-    show_rescan_warning: bool,
+    rescan_warning: Option<WalletOrigin>,
 ) -> Element<'a, Message> {
     let fiat_unconfirmed = fiat_converter.map(|c| c.convert(*unconfirmed_balance));
     let sync = (!sync_status.is_synced()).then_some(match sync_status {
@@ -75,8 +75,9 @@ pub fn home_view<'a>(
         Some(recovery_warning(expiring_coins))
     };
 
-    let rescan_warn = show_rescan_warning.then_some({
-        rescan_warning(
+    let rescan_warn = rescan_warning.map(|origin| {
+        home::rescan_warning(
+            origin,
             Message::Menu(Menu::SettingsPreSelected(menu::SettingsOption::Node)),
             Message::HideRescanWarning,
         )

--- a/liana-gui/src/backup.rs
+++ b/liana-gui/src/backup.rs
@@ -59,6 +59,9 @@ pub struct Backup {
     pub proprietary: serde_json::Map<String, serde_json::Value>,
     #[serde(default = "default_version")]
     pub version: u32,
+    /// True when synthesized from a bare descriptor rather than read from a backup file.
+    #[serde(skip)]
+    pub descriptor_only: bool,
 }
 
 fn default_version() -> u32 {
@@ -124,6 +127,7 @@ impl Backup {
             date: None,
             proprietary: Default::default(),
             version: default_version(),
+            descriptor_only: true,
         }
     }
 
@@ -240,6 +244,7 @@ impl Backup {
             proprietary: serde_json::Map::new(),
             date: Some(now().as_secs()),
             version: 0,
+            descriptor_only: false,
         })
     }
 
@@ -473,6 +478,7 @@ mod test {
             date: Some(0),
             proprietary: serde_json::Map::new(),
             version: 0,
+            descriptor_only: false,
         };
         let serialized = serde_json::to_string(&backup).unwrap();
         let expected = r#"{"accounts":[],"network":"signet","date":0,"version":0}"#;

--- a/liana-gui/src/gui/tab.rs
+++ b/liana-gui/src/gui/tab.rs
@@ -6,7 +6,7 @@ extern crate serde;
 extern crate serde_json;
 
 use liana::miniscript::bitcoin;
-use liana_ui::widget::Element;
+use liana_ui::{component::panels::home::WalletOrigin, widget::Element};
 use lianad::commands::ListCoinsResult;
 
 use crate::{
@@ -377,6 +377,11 @@ where
                     if let Some(backup) = backup {
                         let config = loader.gui_config.clone();
                         let datadir = loader.datadir_path.clone();
+                        let origin = if backup.descriptor_only {
+                            WalletOrigin::Descriptor
+                        } else {
+                            WalletOrigin::Backup
+                        };
                         Task::perform(
                             async move {
                                 import_backup_at_launch(
@@ -384,11 +389,9 @@ where
                                 )
                                 .await
                             },
-                            |r| {
+                            move |r| {
                                 let r = r.map_err(loader::Error::RestoreBackup);
-                                Message::Load(Box::new(loader::Message::App(
-                                    r, /* restored_from_backup */ true,
-                                )))
+                                Message::Load(Box::new(loader::Message::App(r, Some(origin))))
                             },
                         )
                     } else {
@@ -399,7 +402,7 @@ where
                             daemon,
                             loader.datadir_path.clone(),
                             bitcoind,
-                            false,
+                            None,
                         );
                         self.state = State::App(app);
                         command.map(|msg| Message::Run(Box::new(msg)))
@@ -407,7 +410,7 @@ where
                 }
                 loader::Message::App(
                     Ok((cache, wallet, config, daemon, datadir, bitcoind)),
-                    restored_from_backup,
+                    wallet_origin,
                 ) => {
                     let (app, command) = app::App::<S>::new(
                         cache,
@@ -416,7 +419,7 @@ where
                         daemon,
                         datadir,
                         bitcoind,
-                        restored_from_backup,
+                        wallet_origin,
                     );
                     self.state = State::App(app);
                     command.map(|msg| Message::Run(Box::new(msg)))
@@ -684,7 +687,7 @@ pub fn create_app_with_remote_backend(
         Arc::new(remote_backend),
         liana_dir,
         None,
-        false,
+        None,
     ))
 }
 

--- a/liana-gui/src/installer/step/descriptor/mod.rs
+++ b/liana-gui/src/installer/step/descriptor/mod.rs
@@ -204,13 +204,13 @@ impl Step for ImportDescriptor {
         ctx.hw_is_used = true;
         // descriptor forms for import or creation cannot be both empty or filled.
         if let Some(desc) = self.check_descriptor(self.network) {
-            ctx.descriptor = Some(desc);
+            ctx.descriptor = Some(desc.clone());
+            ctx.backup = Some(match &self.imported_backup {
+                Some(backup) => backup.clone(),
+                None => Backup::from_descriptor(desc, self.network),
+            });
         } else {
             return false;
-        }
-
-        if let Some(backup) = &self.imported_backup {
-            ctx.backup = Some(backup.clone());
         }
 
         if let Some(aliases) = &self.imported_aliases {

--- a/liana-gui/src/loader.rs
+++ b/liana-gui/src/loader.rs
@@ -13,7 +13,7 @@ use tracing::{debug, info, warn};
 
 use liana::miniscript::bitcoin;
 use liana_ui::{
-    component::{button, notification, text::*},
+    component::{button, notification, panels::home::WalletOrigin, text::*},
     icon, theme,
     widget::*,
 };
@@ -109,7 +109,7 @@ pub enum Message {
             ),
             Error,
         >,
-        /* restored_from_backup */ bool,
+        Option<WalletOrigin>,
     ),
     Started(StartedResult),
     Loaded(Result<(Arc<dyn Daemon + Sync + Send>, GetInfoResult), Error>),

--- a/liana-ui/src/component/panels/home/mod.rs
+++ b/liana-ui/src/component/panels/home/mod.rs
@@ -25,16 +25,31 @@ use crate::{
     widget::{Container, Element, SpaceExt},
 };
 
-const RESCAN_WARNING: &str = "As this wallet was restored from a backup, you may need to rescan the blockchain to see past transactions.";
+/// Which import brought an existing wallet in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WalletOrigin {
+    Backup,
+    Descriptor,
+}
 
-/// Card prompting a rescan after restoring a wallet from backup.
-pub fn rescan_warning<'a, M: Clone + 'static>(go_to_rescan: M, dismiss: M) -> Element<'a, M> {
+/// Card prompting a rescan after importing an existing wallet.
+pub fn rescan_warning<'a, M: Clone + 'static>(
+    origin: WalletOrigin,
+    go_to_rescan: M,
+    dismiss: M,
+) -> Element<'a, M> {
+    let source = match origin {
+        WalletOrigin::Backup => "restored from a backup",
+        WalletOrigin::Descriptor => "imported from a descriptor",
+    };
     let icon = icon::warning_fill_icon().size(icon::ICON_SIZE_M as u32);
     let msg = row![
         Space::with_width(10),
         icon,
         Space::with_width(15),
-        new::h3(RESCAN_WARNING),
+        new::h3(format!(
+            "As this wallet was {source}, you may need to rescan the blockchain to see past transactions."
+        )),
     ]
     .align_y(Alignment::Center);
 


### PR DESCRIPTION
This PR make the rescan banner displayed when a wallet is imported by pasting a descriptor for bitcoind:

<img width="1313" height="299" alt="image" src="https://github.com/user-attachments/assets/f632f620-f1d1-470d-a089-48784d920aa9" />


closes #1778
