### PR TITLE
docs(installer): clarify dummy user initialization

### DIFF
--- a/liana-business/business-installer/src/client.rs
+++ b/liana-business/business-installer/src/client.rs
@@ -131,7 +131,7 @@ pub struct Client {
 
 impl Client {
     pub fn new(notif_sender: channel::Sender<Message>, notif_waker: SharedWaker) -> Self {
-        // We prefil users with a dummy user, to avoid trying to fetch non exixting users.
+        // We prefill users with a dummy user to avoid trying to fetch nonexistent users.
         let dummy_user = User {
             name: "None".into(),
             uuid: Uuid::nil(),


### PR DESCRIPTION
Clarifies why the business installer pre-populates the user collection with a dummy entry, while correcting the spelling of “prefill” and “nonexistent”.