### PR TITLE
I18n prepa

### DIFF
--- a/liana-business/business-installer/src/views/keys/modal.rs
+++ b/liana-business/business-installer/src/views/keys/modal.rs
@@ -238,7 +238,7 @@ fn signer_entries<'a>(
             };
             MenuEntry::Option {
                 value,
-                body: combobox::email_entry(&initials(primary), primary, secondary, tag),
+                body: combobox::email_entry(initials(primary), primary, secondary, tag),
                 selected,
             }
         }));

--- a/liana-business/business-installer/src/views/login/account_select.rs
+++ b/liana-business/business-installer/src/views/login/account_select.rs
@@ -19,7 +19,10 @@ pub fn account_select_view(state: &State) -> Element<'_, Msg> {
 
     let header_content = screen_intro(
         "Liana Business",
-        Some(intro_prompt("Select an account to continue", None)),
+        Some(intro_prompt(
+            "Select an account to continue",
+            None::<String>,
+        )),
         false,
     );
 

--- a/liana-business/business-installer/src/views/login/email.rs
+++ b/liana-business/business-installer/src/views/login/email.rs
@@ -36,7 +36,7 @@ pub fn login_email_view(state: &State) -> Element<'_, Msg> {
                 "Liana Business",
                 Some(intro_prompt(
                     "Enter the email associated with your account",
-                    None,
+                    None::<String>,
                 )),
                 true,
             ),

--- a/liana-business/business-installer/src/views/mod.rs
+++ b/liana-business/business-installer/src/views/mod.rs
@@ -129,7 +129,7 @@ fn layout_inner<'a>(
         installer_layout::LayoutConfig {
             variant: Variant::LianaBusiness,
             network,
-            email,
+            email: email.map(String::from),
             is_ws_admin,
             nav_bar: installer_layout::NavBar::Steps {
                 progress,

--- a/liana-business/business-installer/src/views/paths/mod.rs
+++ b/liana-business/business-installer/src/views/paths/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::{
     backend::Backend,
     state::{message::Msg, State},
@@ -30,10 +32,11 @@ pub use entry_path_list::path_list;
 fn banner_card(
     variant: fn(Element<'static, Msg>) -> Container<'static, Msg>,
     icon_style: fn(&theme::Theme) -> iced::widget::text::Style,
-    body: &'static str,
+    body: impl Display,
 ) -> Element<'static, Msg> {
+    let body = body.to_string();
     let content = row![
-        tooltip::tooltip_with_style(body, icon_style),
+        tooltip::tooltip_with_style(body.clone(), icon_style),
         text::new::caption(body).style(icon_style),
     ]
     .spacing(HSpacing::M)

--- a/liana-business/business-installer/src/views/template_builder/mod.rs
+++ b/liana-business/business-installer/src/views/template_builder/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::{
     backend::Backend,
     state::{message::Msg, State},
@@ -26,10 +28,11 @@ pub use entry_path_list::entry_path_list;
 fn banner_card(
     variant: fn(Element<'static, Msg>) -> Container<'static, Msg>,
     icon_style: fn(&theme::Theme) -> iced::widget::text::Style,
-    body: &'static str,
+    body: impl Display,
 ) -> Element<'static, Msg> {
+    let body = body.to_string();
     let content = row![
-        tooltip::tooltip_with_style(body, icon_style),
+        tooltip::tooltip_with_style(body.clone(), icon_style),
         text::new::caption(body).style(icon_style),
     ]
     .spacing(HSpacing::M)

--- a/liana-gui/src/app/view/home/mod.rs
+++ b/liana-gui/src/app/view/home/mod.rs
@@ -87,8 +87,8 @@ pub fn home_view<'a>(
         if event.kind != PaymentKind::SendToSelf {
             col.push(payment_card(
                 UIPayment {
-                    label: event.label.as_deref(),
-                    address_label: event.address_label.as_deref(),
+                    label: event.label.clone(),
+                    address_label: event.address_label.clone(),
                     kind: event.kind,
                     time: event.time,
                     amount: event.amount,

--- a/liana-gui/src/debug/pills.rs
+++ b/liana-gui/src/debug/pills.rs
@@ -27,7 +27,7 @@ fn pill_components_b() -> Sample<14> {
         (pill::rescan(1.0_f64, false),                        "liana_ui::component::pill::rescan(1.0, false)"),
         (pill::rescan(1.0_f64, true),                        "liana_ui::component::pill::rescan(1.0, true)"),
         (pill::fingerprint("deadbeef", Some("alice")), "liana_ui::component::pill::fingerprint(_, Some(_))"),
-        (pill::fingerprint("abcd1234", None),          "liana_ui::component::pill::fingerprint(_, None)"),
+        (pill::fingerprint("abcd1234", None::<String>),          "liana_ui::component::pill::fingerprint(_, None)"),
         (pill::coin_sequence(0),                       "liana_ui::component::pill::coin_sequence(0)"),
         (pill::coin_sequence(50),                      "liana_ui::component::pill::coin_sequence(50)"),
         (pill::coin_sequence(200),                      "liana_ui::component::pill::coin_sequence(200)"),

--- a/liana-gui/src/installer/step/descriptor/editor/key.rs
+++ b/liana-gui/src/installer/step/descriptor/editor/key.rs
@@ -1164,7 +1164,7 @@ impl SelectKeySource {
             KeySourceKind::Device,
             alias,
             fingerprint,
-            None,
+            None::<String>,
             None,
             message,
             msg,
@@ -1199,7 +1199,15 @@ impl SelectKeySource {
         let on_press = message
             .is_none()
             .then_some(Self::route(SelectKeySourceMessage::SelectKey(fg)));
-        modal::key_entry(kind, alias, Some(fg_str), None, None, message, on_press)
+        modal::key_entry(
+            kind,
+            alias,
+            Some(fg_str),
+            None::<String>,
+            None,
+            message,
+            on_press,
+        )
     }
 }
 

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -1713,7 +1713,7 @@ pub fn connection_step_select_account<'a>(
         "Liana Connect",
         Some(installer_layout::intro_prompt(
             "Select an account to continue",
-            None,
+            None::<String>,
         )),
         false,
     );
@@ -1756,7 +1756,7 @@ pub fn connection_step_select_account<'a>(
             is_ws_admin: false,
             nav_bar: installer_layout::NavBar::StepTitle {
                 progress,
-                title: "Login",
+                title: "Login".to_string(),
                 previous_message: (!processing).then_some(Message::Previous),
             },
             content_width: button::STANDARD_ENTRY_WIDTH,
@@ -1978,11 +1978,11 @@ fn layout<'a>(
         installer_layout::LayoutConfig {
             variant: Variant::Liana,
             network,
-            email,
+            email: email.map(String::from),
             is_ws_admin: false,
             nav_bar: installer_layout::NavBar::StepTitle {
                 progress,
-                title,
+                title: title.to_string(),
                 previous_message,
             },
             content_width: 800.0,

--- a/liana-gui/src/installer/view/mod.rs
+++ b/liana-gui/src/installer/view/mod.rs
@@ -148,9 +148,11 @@ pub fn import_wallet_or_descriptor<'a>(
     let invitation = list::entry_collapsible(list::CollapsibleEntry {
         accent: wallet_accent,
         tile: Tile::Import,
-        title: "Load a shared wallet",
-        collapsed_subtitle: Some("If you received an invitation to join a shared wallet"),
-        expanded_subtitle: Some("Type the invitation token you received by email"),
+        title: "Load a shared wallet".to_string(),
+        collapsed_subtitle: Some(
+            "If you received an invitation to join a shared wallet".to_string(),
+        ),
+        expanded_subtitle: Some("Type the invitation token you received by email".to_string()),
         content: invitation_content,
         expanded: active_option == Some(message::ImportWalletOption::Invitation),
         on_toggle: Message::ImportRemoteWallet(message::ImportRemoteWallet::ToggleOption(
@@ -189,9 +191,9 @@ pub fn import_wallet_or_descriptor<'a>(
     let paste_descriptor = list::entry_collapsible(list::CollapsibleEntry {
         accent: wallet_accent,
         tile: Tile::Paste,
-        title: "Paste a descriptor",
-        collapsed_subtitle: Some("Creates a new wallet from the pasted descriptor"),
-        expanded_subtitle: Some("Creates a new wallet from the pasted descriptor"),
+        title: "Paste a descriptor".to_string(),
+        collapsed_subtitle: Some("Creates a new wallet from the pasted descriptor".to_string()),
+        expanded_subtitle: Some("Creates a new wallet from the pasted descriptor".to_string()),
         content: descriptor_content.into(),
         expanded: active_option == Some(message::ImportWalletOption::PasteDescriptor),
         on_toggle: Message::ImportRemoteWallet(message::ImportRemoteWallet::ToggleOption(
@@ -279,9 +281,9 @@ pub fn import_descriptor<'a>(
     let paste_descriptor = list::entry_collapsible(list::CollapsibleEntry {
         accent,
         tile: Tile::Paste,
-        title: "Paste a descriptor",
-        collapsed_subtitle: Some("Creates a new wallet from the pasted descriptor"),
-        expanded_subtitle: Some("Creates a new wallet from the pasted descriptor"),
+        title: "Paste a descriptor".to_string(),
+        collapsed_subtitle: Some("Creates a new wallet from the pasted descriptor".to_string()),
+        expanded_subtitle: Some("Creates a new wallet from the pasted descriptor".to_string()),
         content: descriptor_form.into(),
         expanded: paste_descriptor_expanded,
         on_toggle: Message::DefineDescriptor(message::DefineDescriptor::ShowImportDescriptor(
@@ -1563,7 +1565,7 @@ fn import_mnemonic_entry<'a>(
     list::entry_collapsible(list::CollapsibleEntry {
         accent,
         tile: Tile::Import,
-        title: "Import mnemonic",
+        title: "Import mnemonic".to_string(),
         collapsed_subtitle: None,
         expanded_subtitle: None,
         content: content.into(),

--- a/liana-ui/src/component/button.rs
+++ b/liana-ui/src/component/button.rs
@@ -41,7 +41,7 @@ const BTN_PADDING_COMPACT: [u16; 2] = [7 /* Top/Bottom */, 12 /* Left/Right */];
 pub type ListEntryAccent = fn(&Theme) -> Color;
 pub type ButtonStyle = fn(&theme::Theme, Status) -> Style;
 
-pub fn menu<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str, compact: bool) -> Button<'a, T> {
+pub fn menu<'a, T: 'a>(icon: Option<Text<'a>>, t: impl Display, compact: bool) -> Button<'a, T> {
     Button::new(
         content_menu(
             icon.map(|i| i.style(theme::text::secondary)),
@@ -57,7 +57,7 @@ pub fn menu<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str, compact: bool) -
 
 pub fn menu_active<'a, T: 'a>(
     icon: Option<Text<'a>>,
-    t: &'static str,
+    t: impl Display,
     compact: bool,
 ) -> Button<'a, T> {
     Button::new(content_menu(icon, t, true, compact).padding(MENU_BTN_PADDING))
@@ -87,7 +87,7 @@ pub fn menu_active_small<'a, T: 'a>(icon: Text<'a>) -> Button<'a, T> {
 
 fn content_menu<'a, T: 'a>(
     icon: Option<Text<'a>>,
-    t: &'static str,
+    t: impl Display,
     active: bool,
     compact: bool,
 ) -> Container<'a, T> {
@@ -178,7 +178,7 @@ pub fn auxiliary<'a, T: 'a + Clone>(
         .padding(0)
 }
 
-pub fn breadcrumb<'a, T: 'a>(icon: Option<Text<'a>>, t: &'static str) -> Button<'a, T> {
+pub fn breadcrumb<'a, T: 'a>(icon: Option<Text<'a>>, t: impl Display) -> Button<'a, T> {
     Button::new(content(icon, panel_title(t), false))
         .style(theme::button::breadcrumb)
         .padding(0)
@@ -328,7 +328,7 @@ fn auxiliary_content<'a, T: 'a>(icon: Option<Text<'a>>, t: impl Display) -> Cont
 fn content_with_tooltip<'a, T: 'a>(
     icon: Option<Text<'a>>,
     text: Text<'a>,
-    tooltip: Option<&'a str>,
+    tooltip: Option<String>,
     compact: bool,
 ) -> Container<'a, T> {
     let content = row![icon, text, tooltip.map(tooltip::tooltip)]
@@ -458,7 +458,7 @@ pub fn clickable_icon_with_size<'a, T: 'a + Clone>(
 /// Primary button with preset width.
 pub fn btn_primary<'a, T: Clone + 'a>(
     icon: Option<Text<'a>>,
-    label: &'static str,
+    label: impl Display,
     width: BtnWidth,
     msg: Option<T>,
 ) -> Button<'a, T> {
@@ -472,7 +472,7 @@ pub fn btn_primary<'a, T: Clone + 'a>(
 /// Secondary button with preset width.
 pub fn btn_secondary<'a, T: Clone + 'a>(
     icon: Option<Text<'a>>,
-    label: &'a str,
+    label: impl Display,
     width: BtnWidth,
     msg: Option<T>,
 ) -> Button<'a, T> {
@@ -510,8 +510,8 @@ pub fn btn_high<'a, T: Clone + 'a>(selected: bool, msg: Option<T>) -> Button<'a,
 
 fn btn_with_tooltip<'a, T: Clone + 'a>(
     icon: Option<Text<'a>>,
-    label: &'a str,
-    tooltip: Option<&'a str>,
+    label: impl Display,
+    tooltip: Option<impl Into<String>>,
     width: BtnWidth,
     msg: Option<T>,
     style: ButtonStyle,
@@ -519,7 +519,7 @@ fn btn_with_tooltip<'a, T: Clone + 'a>(
     Button::new(content_with_tooltip(
         icon,
         button_text(label),
-        tooltip,
+        tooltip.map(Into::into),
         false,
     ))
     .width(width)
@@ -531,7 +531,7 @@ fn btn_with_tooltip<'a, T: Clone + 'a>(
 /// Tertiary button with preset width.
 pub fn btn_tertiary<'a, T: Clone + 'a>(
     icon: Option<Text<'a>>,
-    label: &'static str,
+    label: impl Display,
     width: BtnWidth,
     msg: Option<T>,
 ) -> Button<'a, T> {
@@ -545,7 +545,7 @@ pub fn btn_tertiary<'a, T: Clone + 'a>(
 /// Destructive button with preset width.
 pub fn btn_destructive<'a, T: Clone + 'a>(
     icon: Option<Text<'a>>,
-    label: &'static str,
+    label: impl Display,
     width: BtnWidth,
     msg: Option<T>,
 ) -> Button<'a, T> {
@@ -559,7 +559,7 @@ pub fn btn_destructive<'a, T: Clone + 'a>(
 /// Flat button with preset width.
 pub fn btn_flat<'a, T: Clone + 'a>(
     icon: Option<Text<'a>>,
-    label: &'static str,
+    label: impl Display,
     width: BtnWidth,
     msg: Option<T>,
 ) -> Button<'a, T> {
@@ -902,7 +902,7 @@ pub fn btn_add_wallet<'a, T: Clone + 'a>(msg: Option<T>) -> Button<'a, T> {
 /// Full-width "Show QR Code" button for an optional modal section, with an
 /// optional tooltip.
 pub fn btn_show_qr_section<'a, M: 'a + 'static>(
-    tt: Option<&'static str>,
+    tt: Option<impl Into<String>>,
     msg: Option<M>,
 ) -> Button<'a, M> {
     let mut btn = Button::new(
@@ -1028,6 +1028,6 @@ pub fn btn_modal_previous<'a, T: Clone + 'a>(msg: T) -> Button<'a, T> {
     transparent(Some(icon::previous_icon().size(25)), "").on_press(msg)
 }
 
-pub fn btn_mnemonic_word<'a, T: Clone + 'a>(word: &str, msg: T) -> Button<'a, T> {
+pub fn btn_mnemonic_word<'a, T: Clone + 'a>(word: impl Display, msg: T) -> Button<'a, T> {
     button_compact(word, theme::button::tertiary, Some(msg)).width(BtnWidth::S)
 }

--- a/liana-ui/src/component/combobox.rs
+++ b/liana-ui/src/component/combobox.rs
@@ -114,11 +114,17 @@ pub enum Tag {
 
 /// A member row: an initials avatar, the name over the email, and a trailing [`Tag`]. When
 /// `email` is empty the row is a single line (used for emails with no member name).
-pub fn email_entry<'a, M: 'a>(avatar: &str, name: &str, email: &str, tag: Tag) -> Element<'a, M> {
+pub fn email_entry<'a, M: 'a>(
+    avatar: impl Display,
+    name: impl Display,
+    email: impl Display,
+    tag: Tag,
+) -> Element<'a, M> {
+    let email = email.to_string();
     let details = column![
         text::new::b5_medium(name.to_string()),
         (!email.is_empty())
-            .then_some(text::new::small_caption(email.to_string()).style(theme::text::secondary))
+            .then_some(text::new::small_caption(email).style(theme::text::secondary))
     ]
     .spacing(2)
     .width(Length::Fill);
@@ -144,7 +150,7 @@ fn trailing<'a, M: 'a>(tag: Tag) -> Element<'a, M> {
 
 pub fn combobox<'a, T, Message>(
     state: &'a State<T>,
-    placeholder: &'a str,
+    placeholder: impl Display,
     selected: Option<T>,
     on_selected: impl Fn(T) -> Message + 'static,
 ) -> Combobox<'a, Message>
@@ -157,7 +163,7 @@ where
 
 pub fn editable_combobox<'a, T, Message>(
     state: &'a State<T>,
-    placeholder: &'a str,
+    placeholder: impl Display,
     selected: Option<T>,
     on_selected: impl Fn(T) -> Message + 'static,
     on_input: impl Fn(String) -> Message + 'static,
@@ -176,7 +182,7 @@ where
 
 fn styled_combobox<'a, T, Message>(
     state: &'a State<T>,
-    placeholder: &'a str,
+    placeholder: impl Display,
     selected: Option<T>,
     on_selected: impl Fn(T) -> Message + 'static,
 ) -> IcedComboBox<'a, T, Message, theme::Theme, Renderer>
@@ -186,7 +192,7 @@ where
 {
     IcedComboBox::new(
         state.combo_box(),
-        placeholder,
+        &placeholder.to_string(),
         selected.as_ref(),
         on_selected,
     )
@@ -200,7 +206,7 @@ where
 }
 
 pub fn editable_menu_combobox<'a, T, Message, F>(
-    placeholder: &'a str,
+    placeholder: impl Display,
     value: String,
     on_selected: impl Fn(T) -> Message + 'static,
     entries: Vec<MenuEntry<'a, T, Message>>,
@@ -221,7 +227,7 @@ where
 }
 
 fn input<'a, Message, F>(
-    placeholder: &'a str,
+    placeholder: impl Display,
     value: String,
     on_input: Option<F>,
 ) -> Element<'a, Message>

--- a/liana-ui/src/component/form.rs
+++ b/liana-ui/src/component/form.rs
@@ -64,7 +64,7 @@ fn default_styled<'a, M: 'a + Clone>(input: TextInput<'a, M>) -> TextInput<'a, M
 
 pub struct Form<'a, Message> {
     input: TextInput<'a, Message>,
-    warning: Option<&'a str>,
+    warning: Option<String>,
     valid: bool,
     label: Option<Element<'a, Message>>,
     fee: bool,
@@ -88,7 +88,7 @@ where
             input: default_styled(
                 text_input::TextInput::new(placeholder, &value.value).on_input(on_change),
             ),
-            warning: value.warning,
+            warning: value.warning.map(String::from),
             valid: value.valid,
             label: None,
             fee: false,
@@ -100,7 +100,7 @@ where
     /// It expects:
     /// - a placeholder
     /// - the current value
-    pub fn new_disabled(placeholder: &str, value: &Value<String>) -> Self {
+    pub fn new_disabled(placeholder: impl Display, value: &Value<String>) -> Self {
         Self {
             input: default_styled(text_input::TextInput::new(placeholder, &value.value)),
             warning: None, // no warning for disabled form
@@ -116,7 +116,7 @@ where
     /// - a placeholder
     /// - the current value
     /// - a function that produces a message when the [`Form`] changes
-    pub fn new_trimmed<F>(placeholder: &str, value: &Value<String>, on_change: F) -> Self
+    pub fn new_trimmed<F>(placeholder: impl Display, value: &Value<String>, on_change: F) -> Self
     where
         F: 'static + Fn(String) -> Message,
     {
@@ -125,7 +125,7 @@ where
                 text_input::TextInput::new(placeholder, &value.value)
                     .on_input(move |s| on_change(s.trim().to_string())),
             ),
-            warning: value.warning,
+            warning: value.warning.map(String::from),
             valid: value.valid,
             label: None,
             fee: false,
@@ -138,7 +138,11 @@ where
     /// - a placeholder
     /// - the current value
     /// - a function that produces a message when the [`Form`] changes
-    pub fn new_amount_btc<F>(placeholder: &str, value: &'a Value<String>, on_change: F) -> Self
+    pub fn new_amount_btc<F>(
+        placeholder: impl Display,
+        value: &'a Value<String>,
+        on_change: F,
+    ) -> Self
     where
         F: 'static + Fn(String) -> Message + Clone,
     {
@@ -166,7 +170,7 @@ where
                         on_change_clone(pasted)
                     }),
             ),
-            warning: value.warning,
+            warning: value.warning.map(String::from),
             valid: value.valid,
             label: None,
             fee: false,
@@ -184,14 +188,14 @@ where
     }
 
     /// Sets the [`Form`] with a warning message
-    pub fn warning(mut self, warning: &'a str) -> Self {
-        self.warning = Some(warning);
+    pub fn warning(mut self, warning: impl Into<String>) -> Self {
+        self.warning = Some(warning.into());
         self
     }
 
     /// Sets the [`Form`] with a warning message
-    pub fn maybe_warning(mut self, warning: Option<&'a str>) -> Self {
-        self.warning = warning;
+    pub fn maybe_warning(mut self, warning: Option<impl Into<String>>) -> Self {
+        self.warning = warning.map(Into::into);
         self
     }
 

--- a/liana-ui/src/component/installer.rs
+++ b/liana-ui/src/component/installer.rs
@@ -39,7 +39,7 @@ pub enum LayoutContent<'a, M> {
 pub struct LayoutConfig<'a, M> {
     pub variant: Variant,
     pub network: Network,
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     pub is_ws_admin: bool,
     pub nav_bar: NavBar<'a, M>,
     pub content_width: f32,
@@ -53,7 +53,7 @@ pub enum NavBar<'a, M> {
     },
     StepTitle {
         progress: (usize, usize),
-        title: &'a str,
+        title: String,
         previous_message: Option<M>,
     },
     Launcher {
@@ -77,7 +77,7 @@ pub fn screen_intro<'a, M: 'a>(
         .into()
 }
 
-pub fn intro_description<'a, M: 'a>(value: &'a str) -> Element<'a, M> {
+pub fn intro_description<'a, M: 'a>(value: impl Display) -> Element<'a, M> {
     Container::new(text::new::caption(value).style(theme::text::secondary))
         .width(Length::Shrink)
         .max_width(SCREEN_INTRO_SUB_WIDTH)
@@ -85,8 +85,11 @@ pub fn intro_description<'a, M: 'a>(value: &'a str) -> Element<'a, M> {
         .into()
 }
 
-pub fn intro_prompt<'a, M: 'a>(prompt: &'a str, accent: Option<&'a str>) -> Element<'a, M> {
-    let accent = accent.map(|accent| text::new::h3_semi(accent).style(theme::text::accent));
+pub fn intro_prompt<'a, M: 'a>(
+    prompt: impl Display,
+    accent: Option<impl Into<String>>,
+) -> Element<'a, M> {
+    let accent = accent.map(|accent| text::new::h3_semi(accent.into()).style(theme::text::accent));
     Container::new(row![text::new::h3_semi(prompt), accent].wrap())
         .center_x(Length::Fill)
         .into()
@@ -123,7 +126,7 @@ fn identity_bar<'a, M: 'static + 'a + Clone>(
     variant: Variant,
     network: Network,
     is_ws_admin: bool,
-    email: Option<&'a str>,
+    email: Option<String>,
 ) -> Element<'a, M> {
     const IDENTITY_BAR_HEIGHT: u32 = 28;
 
@@ -161,7 +164,7 @@ fn identity_bar<'a, M: 'static + 'a + Clone>(
     let ws_admin_pill = is_ws_admin.then_some(pill::ws_admin());
     let user = email.map(|e| {
         let mut icon = icon::person_icon().size(16).style(theme::text::tertiary);
-        let e = component::text::short_email(e, 35);
+        let e = component::text::short_email(&e, 35);
         let mut mail = text::new::caption(e).style(theme::text::accent);
         if network != Network::Bitcoin {
             icon = icon.style(theme::text::network_banner);

--- a/liana-ui/src/component/list.rs
+++ b/liana-ui/src/component/list.rs
@@ -92,7 +92,7 @@ pub enum DeviceStatus {
     Warning(&'static str),
 }
 
-fn device_success_mark<'a, M: 'static>(label: Option<&'static str>) -> Element<'a, M> {
+fn device_success_mark<'a, M: 'static>(label: Option<String>) -> Element<'a, M> {
     row![label.map(text::new::b5_medium), badge::success()]
         .align_y(Alignment::Center)
         .spacing(5)
@@ -141,8 +141,8 @@ impl<'a, M: 'static> From<DeviceStatus> for Option<Element<'a, M>> {
                 text::new::b5_medium(format!("Install firmware version {version} \nor later"))
                     .into(),
             ),
-            DeviceStatus::Signed => Some(device_success_mark(Some("Signed"))),
-            DeviceStatus::Registered => Some(device_success_mark(Some("Registered"))),
+            DeviceStatus::Signed => Some(device_success_mark(Some("Signed".to_string()))),
+            DeviceStatus::Registered => Some(device_success_mark(Some("Registered".to_string()))),
             DeviceStatus::Selected => Some(device_success_mark(None)),
             DeviceStatus::Warning(w) => Some(
                 tooltip::tooltip_custom(
@@ -210,7 +210,7 @@ pub fn list_entry_row_static<'a, M: Clone + 'a>(
 /// Expanded "paste an extended public key" entry: a paste tile, an xpub text input and a paste button,
 /// laid out as a static (non-clickable) entry row.
 pub fn entry_paste_xpub<'a, M: Clone + 'a>(
-    value: &str,
+    value: impl Display,
     on_input: impl Fn(String) -> M + 'static,
     on_paste: M,
 ) -> Element<'a, M> {
@@ -230,9 +230,9 @@ pub fn entry_paste_xpub<'a, M: Clone + 'a>(
 pub struct CollapsibleEntry<'a, M> {
     pub accent: Option<EntryAccent>,
     pub tile: Tile,
-    pub title: &'static str,
-    pub collapsed_subtitle: Option<&'static str>,
-    pub expanded_subtitle: Option<&'static str>,
+    pub title: String,
+    pub collapsed_subtitle: Option<String>,
+    pub expanded_subtitle: Option<String>,
     pub content: Element<'a, M>,
     pub expanded: bool,
     pub on_toggle: M,
@@ -241,16 +241,8 @@ pub struct CollapsibleEntry<'a, M> {
 pub fn entry_collapsible<'a, M: Clone + 'static>(cfg: CollapsibleEntry<'a, M>) -> Element<'a, M> {
     let accent = cfg.accent.map(entry_accent);
     let entry = collapse::Collapse::new(
-        collapsible_entry_header(
-            cfg.tile,
-            cfg.title.to_string(),
-            cfg.collapsed_subtitle.map(str::to_string),
-        ),
-        collapsible_entry_header(
-            cfg.tile,
-            cfg.title.to_string(),
-            cfg.expanded_subtitle.map(str::to_string),
-        ),
+        collapsible_entry_header(cfg.tile, cfg.title.to_string(), cfg.collapsed_subtitle),
+        collapsible_entry_header(cfg.tile, cfg.title.to_string(), cfg.expanded_subtitle),
         Container::new(cfg.content).padding(iced::Padding {
             left: button::LIST_ENTRY_PADDING[1].into(),
             right: button::LIST_ENTRY_PADDING[1].into(),

--- a/liana-ui/src/component/modal/mod.rs
+++ b/liana-ui/src/component/modal/mod.rs
@@ -253,9 +253,9 @@ fn acked_input_button<'a, Message, Ack, Input, Paste, Collapse>(
     collapsed: bool,
     ack: bool,
     tile: Tile,
-    label: &'a str,
-    disclaimer: &'a str,
-    input_placeholder: &'a str,
+    label: impl Into<String>,
+    disclaimer: impl Into<String>,
+    input_placeholder: impl Into<String>,
     input_value: &Value<String>,
     ack_message: Ack,
     input_message: Input,
@@ -269,10 +269,13 @@ where
     Collapse: 'static + Fn() -> Message,
     Message: Clone + 'static,
 {
+    let label = label.into();
+    let disclaimer = disclaimer.into();
+    let input_placeholder = input_placeholder.into();
     let form = if ack {
-        form::Form::new(input_placeholder, input_value, input_message)
+        form::Form::new(&input_placeholder, input_value, input_message)
     } else {
-        form::Form::new_disabled(input_placeholder, input_value)
+        form::Form::new_disabled(&input_placeholder, input_value)
     }
     .padding(10);
     let paste = Button::new(icon::paste_icon().color(color::BLACK)).on_press(paste_message());
@@ -280,7 +283,10 @@ where
     let expanded = {
         let line = row![form, paste].spacing(H_SPACING);
         let check_box = CheckBox::new(ack).label(disclaimer).on_toggle(ack_message);
-        let label = row![caption(label).color(color::WHITE), Space::fill_width()];
+        let label = row![
+            caption(label.clone()).color(color::WHITE),
+            Space::fill_width()
+        ];
         let content = if ack {
             Container::new(column![label, line])
         } else {
@@ -320,7 +326,7 @@ pub fn key_entry<'a, M: 'a + Clone>(
     kind: KeySourceKind,
     name: String,
     fingerprint: Option<String>,
-    tooltip_str: Option<&'a str>,
+    tooltip_str: Option<impl Into<String>>,
     error: Option<String>,
     mut message: Option<String>,
     on_press: Option<M>,
@@ -330,7 +336,7 @@ pub fn key_entry<'a, M: 'a + Clone>(
     }
     let message = message.map(caption);
     let error = error.map(|e| caption(e).color(color::ORANGE));
-    let tt = tooltip_str.map(|s| tooltip(s));
+    let tt = tooltip_str.map(|s| tooltip(s.into()));
 
     let designation = column![
         b5_bold(name),
@@ -507,8 +513,8 @@ where
 
 fn button_entry<'a, Message, M>(
     tile: Tile,
-    label: &'a str,
-    tooltip_str: Option<&'static str>,
+    label: impl Into<String>,
+    tooltip_str: Option<impl Into<String>>,
     error: Option<String>,
     on_press: Option<M>,
 ) -> Element<'a, Message>
@@ -518,11 +524,16 @@ where
 {
     let error = error.map(|e| row![caption(e).color(color::ORANGE), Space::fill_width()]);
 
-    let tt = tooltip_str.map(|s| tooltip(s));
+    let tt = tooltip_str.map(|s| tooltip(s.into()));
 
-    let row = row![badge::tile(tile), caption(label), Space::fill_width(), tt]
-        .spacing(list::ENTRY_H_SPACING)
-        .align_y(Vertical::Center);
+    let row = row![
+        badge::tile(tile),
+        caption(label.into()),
+        Space::fill_width(),
+        tt
+    ]
+    .spacing(list::ENTRY_H_SPACING)
+    .align_y(Vertical::Center);
 
     let col = column![row, error].width(Length::Fill);
 
@@ -542,7 +553,7 @@ where
     button_entry(
         Tile::Import,
         "Import extended public key file",
-        None,
+        None::<String>,
         error,
         on_press,
     )
@@ -557,7 +568,7 @@ where
     button_entry(
         Tile::KeyHot,
         "Generate hot key stored on this computer",
-        Some("We recommend to use this option only for test purposes"),
+        Some("We recommend to use this option only for test purposes".to_string()),
         None,
         on_press,
     )
@@ -639,7 +650,7 @@ where
 }
 
 fn token_entry<'a, Message, Paste, Collapse, Input>(
-    label: &'static str,
+    label: impl Into<String>,
     collapsed: bool,
     input_value: &Value<String>,
     input_message: Option<Input>,
@@ -655,7 +666,7 @@ where
     collapsible_input_button(
         collapsed,
         Tile::EnterToken,
-        label.to_string(),
+        label.into(),
         TOKEN_PLACEHOLDER.to_string(),
         input_value,
         input_message,

--- a/liana-ui/src/component/notification.rs
+++ b/liana-ui/src/component/notification.rs
@@ -54,14 +54,14 @@ pub fn processing_hardware_wallet<'a, T: 'a, K: Display, V: Display, F: Display>
     kind: K,
     version: Option<V>,
     fingerprint: F,
-    alias: Option<&'a str>,
+    alias: Option<impl Into<String>>,
 ) -> Container<'a, T> {
     container(
         row(vec![
             column(vec![
                 Row::new()
                     .spacing(5)
-                    .push_maybe(alias.map(text::p1_bold))
+                    .push_maybe(alias.map(|a| text::p1_bold(a.into())))
                     .push(text::p1_regular(format!("#{fingerprint}")))
                     .into(),
                 Row::new()

--- a/liana-ui/src/component/panels/home/payment.rs
+++ b/liana-ui/src/component/panels/home/payment.rs
@@ -91,9 +91,9 @@ pub struct FiatPrice {
 }
 
 #[derive(Debug, Clone)]
-pub struct UIPayment<'a> {
-    pub label: Option<&'a str>,
-    pub address_label: Option<&'a str>,
+pub struct UIPayment {
+    pub label: Option<String>,
+    pub address_label: Option<String>,
     pub kind: PaymentKind,
     pub time: Option<chrono::DateTime<chrono::Utc>>,
     pub amount: bitcoin::Amount,
@@ -105,7 +105,7 @@ pub fn format_date(time: chrono::DateTime<chrono::Utc>) -> String {
     time.format("%b %-d, %Y").to_string()
 }
 
-pub fn payment_card<'a, M: 'a + Clone>(payment: UIPayment<'a>, msg: Option<M>) -> Element<'a, M> {
+pub fn payment_card<'a, M: 'a + Clone>(payment: UIPayment, msg: Option<M>) -> Element<'a, M> {
     let UIPayment {
         label,
         address_label,
@@ -118,9 +118,9 @@ pub fn payment_card<'a, M: 'a + Clone>(payment: UIPayment<'a>, msg: Option<M>) -
         (None, None) => h2("(No label)").style(theme::text::primary).into(),
         (Some(label), _) => {
             if label.chars().count() > MAX_LABEL_LENGTH {
-                let short = truncate(label, MAX_LABEL_LENGTH);
+                let short = truncate(&label, MAX_LABEL_LENGTH);
                 let short = h2(short).style(theme::text::primary);
-                tooltip_custom(label, short, Position::Top).into()
+                tooltip_custom(h2(label), short, Position::Top).into()
             } else {
                 h2(label).style(theme::text::primary).into()
             }
@@ -128,9 +128,9 @@ pub fn payment_card<'a, M: 'a + Clone>(payment: UIPayment<'a>, msg: Option<M>) -
         (None, Some(label)) => {
             let prefix = "address label: ";
             if label.chars().count() > (MAX_LABEL_LENGTH - prefix.len()) {
-                let short = truncate(label, MAX_LABEL_LENGTH - prefix.len());
+                let short = truncate(&label, MAX_LABEL_LENGTH - prefix.len());
                 let short = h2(format!("{prefix}{short}")).style(theme::text::primary);
-                tooltip_custom(label, short, Position::Top).into()
+                tooltip_custom(h2(label), short, Position::Top).into()
             } else {
                 h2(format!("{prefix}{label}"))
                     .style(theme::text::primary)

--- a/liana-ui/src/component/panels/receive/modal.rs
+++ b/liana-ui/src/component/panels/receive/modal.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use iced::{
     widget::{
         column,
@@ -44,11 +46,11 @@ pub fn verify_address_modal<'a, M: Clone + 'static>(
 }
 
 /// QR code for an address, with the address shown below it.
-pub fn qr_display<'a, M: 'a>(qr: &'a qr_code::Data, address: &'a str) -> Element<'a, M> {
+pub fn qr_display<'a, M: 'a>(qr: &'a qr_code::Data, address: impl Display) -> Element<'a, M> {
     column![
         Container::new(QRCode::<theme::Theme>::new(qr).cell_size(8)).padding(10),
         Space::with_height(Length::Fixed(15.0)),
-        Container::new(address_view(address)).center_x(Length::Fill),
+        Container::new(address_view(address.to_string())).center_x(Length::Fill),
     ]
     .align_x(Alignment::Center)
     .width(Length::Fill)

--- a/liana-ui/src/component/panels/setting/mod.rs
+++ b/liana-ui/src/component/panels/setting/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use iced::{
     widget::{column, row},
     Alignment, Length,
@@ -15,17 +17,17 @@ use crate::{
 const PADDING: u16 = 10;
 const SPACING: u32 = 20;
 
-fn breadcrumb_btn<M: Clone + 'static>(label: &'static str, msg: Option<M>) -> Button<'static, M> {
+fn breadcrumb_btn<M: Clone + 'static>(label: impl Display, msg: Option<M>) -> Button<'static, M> {
     button::breadcrumb(None, label).on_press_maybe(msg)
 }
 
 pub fn header<M: Clone + 'static>(
     setting_msg: Option<M>,
-    section_title: Option<&'static str>,
+    section_title: Option<impl Into<String>>,
     msg: Option<M>,
 ) -> Element<'static, M> {
     let setting_btn = breadcrumb_btn("Settings", setting_msg);
-    let section_btn = section_title.map(|t| breadcrumb_btn(t, msg));
+    let section_btn = section_title.map(|t| breadcrumb_btn(t.into(), msg));
 
     if let Some(s_btn) = section_btn {
         row![setting_btn, icon::chevron_right().size(30), s_btn]
@@ -136,7 +138,7 @@ pub fn export_section<M: Clone + 'static>(kind: ImportExportKind, msg: M) -> Ele
 }
 
 pub fn section_list<M: 'static + Clone>(children: Vec<Element<'static, M>>) -> Element<'static, M> {
-    let header = header(None, None, None);
+    let header = header(None, None::<String>, None);
     let mut header = vec![header];
     header.extend(children);
 

--- a/liana-ui/src/component/panels/spend/mod.rs
+++ b/liana-ui/src/component/panels/spend/mod.rs
@@ -59,7 +59,7 @@ pub fn recipient_card<'a, M: Clone + 'static>(
     amount: &'a form::Value<String>,
     fiat: Option<RecipientFiat<'a, M>>,
     is_max_selected: bool,
-    dust_warning: Option<&'a str>,
+    dust_warning: Option<impl Into<String>>,
     max_estimated_amount: Option<Amount>,
     on_address_edit: impl Fn(String) -> M + 'static,
     on_label_edit: impl Fn(String) -> M + 'static,
@@ -197,7 +197,7 @@ pub fn recipient_card<'a, M: Clone + 'static>(
         .width(Length::Fill);
     // Show dust warning, if any, or otherwise any amount warning.
     let warning = dust_warning
-        .map(|w| new::caption(w).color(color::RED))
+        .map(|w| new::caption(w.into()).color(color::RED))
         .or_else(|| {
             amount
                 .warning

--- a/liana-ui/src/component/pill.rs
+++ b/liana-ui/src/component/pill.rs
@@ -51,11 +51,12 @@ impl From<PillWidth> for Length {
 }
 
 pub fn pill<'a, T: 'a>(
-    label: &'static str,
-    tooltip: &'static str,
+    label: impl Display,
+    tooltip: impl Display,
     width: PillWidth,
     style: fn(&Theme) -> Style,
 ) -> Container<'a, T> {
+    let tooltip = tooltip.to_string();
     let pill = pill_body_with_font(label, width, style, PILL_FONT);
     if !tooltip.is_empty() {
         pill_with_tooltip(pill, Some(tooltip))
@@ -335,7 +336,7 @@ pub fn compact_metric<'a, T: 'a, L: Display>(
 }
 
 pub fn compact_pill<'a, T: 'a>(
-    text: &'a str,
+    text: impl Display,
     width: PillWidth,
     style: fn(&Theme) -> Style,
 ) -> Container<'a, T> {
@@ -423,12 +424,15 @@ pub fn rescan<'a, T: 'a>(progress: f64, compact: bool) -> Container<'a, T> {
     }
 }
 
-pub fn fingerprint<'a, T: 'a>(fg: impl Into<String>, alias: Option<&str>) -> Container<'a, T> {
+pub fn fingerprint<'a, T: 'a>(
+    fg: impl Into<String>,
+    alias: Option<impl Into<String>>,
+) -> Container<'a, T> {
     let fg = fg.into();
     match alias {
         Some(alias) => {
             let body = compact_pill_body_with_font(
-                alias.to_string(),
+                alias.into(),
                 PillWidth::Shrink,
                 theme::pill::fingerprint,
                 PILL_FONT_COMPACT,

--- a/liana-ui/src/component/tab.rs
+++ b/liana-ui/src/component/tab.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use iced::{
     alignment::Vertical,
     border::Radius,
@@ -20,10 +22,10 @@ pub enum Dot {
     Pending,
 }
 
-pub fn tab_header<'a, K: PartialEq + 'a, M: Clone + 'a>(
-    items: &[(K, &'a str, Option<Dot>)],
+pub fn tab_header<'a, K: PartialEq, L: Display, M: Clone + 'a>(
+    items: &[(K, L, Option<Dot>)],
     active: &K,
-    on_select: impl Fn(&K) -> M + 'a,
+    on_select: impl Fn(&K) -> M,
 ) -> Element<'a, M> {
     let tabs = items.iter().fold(
         row![]
@@ -40,7 +42,7 @@ pub fn tab_header<'a, K: PartialEq + 'a, M: Clone + 'a>(
 }
 
 fn tab_item<'a, M: Clone + 'a>(
-    label: &'a str,
+    label: impl Display,
     dot: Option<Dot>,
     active: bool,
     on_press: M,
@@ -57,7 +59,7 @@ fn tab_item<'a, M: Clone + 'a>(
     } else {
         font::MANROPE_MEDIUM
     };
-    let label = Text::new(label)
+    let label = Text::new(label.to_string())
         .size(TAB_LABEL_SIZE)
         .font(font)
         .style(move |theme| iced::widget::text::Style {

--- a/liana-ui/src/component/tooltip.rs
+++ b/liana-ui/src/component/tooltip.rs
@@ -7,14 +7,22 @@ use crate::{
 use iced::widget::{text::Style, tooltip::Position};
 
 pub fn tooltip_with_style<'a, T: 'a>(
-    help: &'a str,
+    help: impl Into<String>,
     icon_style: fn(&Theme) -> Style,
 ) -> Container<'a, T> {
-    tooltip_custom(help, icon::tooltip_icon().style(icon_style), Position::Top)
+    tooltip_custom(
+        iced::widget::text(help.into()),
+        icon::tooltip_icon().style(icon_style),
+        Position::Top,
+    )
 }
 
-pub fn tooltip<'a, T: 'a>(help: &'a str) -> Container<'a, T> {
-    tooltip_custom(help, icon::tooltip_icon(), Position::Right)
+pub fn tooltip<'a, T: 'a>(help: impl Into<String>) -> Container<'a, T> {
+    tooltip_custom(
+        iced::widget::text(help.into()),
+        icon::tooltip_icon(),
+        Position::Right,
+    )
 }
 
 pub fn tooltip_custom<'a, T: 'a>(


### PR DESCRIPTION
This PR introduce some preparatory changes for #2157: it changes signatures of many ui functions to accept owned string, using `impl Display` as much as possible and fall back to `Into<String>` or `String`

